### PR TITLE
Fix opencode call: use 'run <prompt>' instead of non-existent --resume --message-file

### DIFF
--- a/e2etest/mock-opencode.sh
+++ b/e2etest/mock-opencode.sh
@@ -2,17 +2,23 @@
 set -euo pipefail
 
 MOCK_DIR="$(cd "$(dirname "$0")" && pwd)"
-MODE_FILE=""
 MODE=""
+
+PROMPT=""
+if [[ "${1:-}" == "run" && -n "${2:-}" ]]; then
+  PROMPT="$2"
+  shift 2
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --message-file)
       PROMPT_FILE="$2"
+      PROMPT=$(cat "$PROMPT_FILE")
       shift 2
       ;;
     --mode)
-      MODE_FILE="$2"
+      MODE="$2"
       shift 2
       ;;
     *)
@@ -21,24 +27,12 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "${PROMPT_FILE:-}" ]]; then
-  echo "MOCK: --message-file is required" >&2
+if [[ -z "${PROMPT:-}" ]]; then
+  echo "MOCK: no prompt provided" >&2
   exit 1
 fi
 
-if [[ ! -f "$PROMPT_FILE" ]]; then
-  echo "MOCK: prompt file not found: $PROMPT_FILE" >&2
-  exit 1
-fi
-
-# override from --mode or env
-if [[ -n "$MODE_FILE" ]]; then
-  MODE="$MODE_FILE"
-fi
 MODE="${MODE:-${MOCK_MODE:-normal}}"
-
-# read prompt
-PROMPT=$(cat "$PROMPT_FILE")
 
 # extract agent name (first line: # name)
 AGENT=$(echo "$PROMPT" | head -1 | sed 's/^# //')

--- a/pkg/runtime/agentcli.go
+++ b/pkg/runtime/agentcli.go
@@ -25,23 +25,12 @@ func (r *AgentCLIRuntime) Execute(ctx context.Context, agent *Agent, task *Task,
 		return fmt.Errorf("ошибка сборки промпта: %w", err)
 	}
 
-	tmpDir, err := os.MkdirTemp("", "ai-team-*")
-	if err != nil {
-		return fmt.Errorf("ошибка создания temp dir: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	promptFile := filepath.Join(tmpDir, "prompt.md")
-	if err := os.WriteFile(promptFile, []byte(prompt), 0644); err != nil {
-		return fmt.Errorf("ошибка записи промпта: %w", err)
-	}
-
 	targetDir := task.TargetDir
 	if targetDir == "" {
 		targetDir = "."
 	}
 
-	cmd := exec.CommandContext(ctx, cli, "--resume", "--message-file", promptFile)
+	cmd := exec.CommandContext(ctx, cli, "run", prompt)
 	cmd.Dir = targetDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
- agentcli.go: replace --resume --message-file with opencode run <prompt>
- Remove temp file creation (prompt passed directly as argument)
- mock-opencode.sh: handle 'run' subcommand, fix missing MODE default
