### PR TITLE
feat: tamper-evident run anchor + ai-team verify

### DIFF
--- a/cmd/ai-team/main.go
+++ b/cmd/ai-team/main.go
@@ -73,6 +73,8 @@ func main() {
 		cmdList()
 	case "usage":
 		cmdUsage()
+	case "verify":
+		cmdVerify()
 	case "eval":
 		cmdEval()
 	case "web":
@@ -103,6 +105,7 @@ func printUsage() {
   ai-team scheduler-worker         Claim и выполнить job из persistent queue
   ai-team list                     Список доступных агентов
   ai-team usage <run_id>           Usage-сводка завершённого run (этапы, попытки, время)
+  ai-team verify                   Проверить tamper-evident anchor терминального run
   ai-team eval                     Оценить качество артефакта или агента
   ai-team web                      Запустить web-дашборд
   ai-team gc                       Уборка растущих артефактов .ai-team
@@ -966,6 +969,34 @@ func cmdList() {
 	for _, f := range failures {
 		fmt.Fprintf(os.Stderr, "%s агент %q не загружен: %v\n", ui.Colorize("⚠", ui.ColorYellow), f.Name, f.Err)
 	}
+}
+
+// cmdVerify проверяет tamper-evident anchor терминального run:
+// ai-team verify --target <dir> <run_id>
+func cmdVerify() {
+	verifyFlags := flag.NewFlagSet("verify", flag.ExitOnError)
+	target := verifyFlags.String("target", ".", "Путь к целевому проекту")
+	if err := verifyFlags.Parse(os.Args[2:]); err != nil {
+		fatal("Ошибка аргументов verify: %v", err)
+	}
+	if verifyFlags.NArg() != 1 {
+		fatal("Использование: ai-team verify --target <dir> <run_id>")
+	}
+	runID := verifyFlags.Arg(0)
+	if runID == "" || runID == "." || runID == ".." || filepath.Base(runID) != runID {
+		fatal("недопустимый run_id %q", runID)
+	}
+	absolute, err := absoluteTarget(*target)
+	if err != nil {
+		fatal("Ошибка target: %v", err)
+	}
+	requireControlRoot(absolute)
+	runDir := filepath.Join(absolute, ".ai-team", "runs", runID)
+	if err := evidence.VerifyAnchor(runDir); err != nil {
+		fmt.Fprintf(os.Stderr, "✗ Run %s: %v\n", runID, ui.Colorize(err.Error(), ui.ColorRed))
+		os.Exit(exitFailed)
+	}
+	fmt.Printf("✓ Run %s: anchor OK — event chain и manifests digest совпадают\n", runID)
 }
 
 func cmdWeb() {

--- a/pkg/evidence/anchor.go
+++ b/pkg/evidence/anchor.go
@@ -1,0 +1,183 @@
+package evidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/arturpanteleev/ai-team/pkg/safeio"
+)
+
+// AnchorSchemaVersion is the schema of the terminal anchor.json manifest.
+const AnchorSchemaVersion = 1
+
+const (
+	anchorFileName    = "anchor.json"
+	maxAnchorFileSize = 64 << 10
+)
+
+// Terminal event types that trigger anchor publication.
+func isTerminalEventType(eventType string) bool {
+	return eventType == "run_finished" || eventType == "run_canceled"
+}
+
+// Anchor — tamper-evident терминальный manifest run: фиксирует длину
+// hash-chained event log, корень цепочки и digest всех attempt manifests на
+// момент завершения run.
+type Anchor struct {
+	SchemaVersion   int       `json:"schema_version"`
+	RunID           string    `json:"run_id"`
+	TerminalEvent   string    `json:"terminal_event"`
+	EventCount      uint64    `json:"event_count"`
+	ChainRootSHA256 string    `json:"chain_root_sha256"`
+	ManifestsDigest string    `json:"manifests_digest"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// manifestsDigest вычисляет sha256 отсортированного списка
+// "attemptID:manifestSHA256" из attempt_finished событий.
+func manifestsDigest(events []Event) (string, error) {
+	byAttempt := make(map[string]string)
+	for _, event := range events {
+		if event.Type != "attempt_finished" || !safeEventIdentifier(event.AttemptID) {
+			continue
+		}
+		digest, err := eventString(event.Data, "manifest_sha256", false)
+		if err != nil || digest == "" {
+			continue
+		}
+		if !validSHA256(digest) {
+			return "", fmt.Errorf("attempt_finished %q manifest digest is invalid", event.AttemptID)
+		}
+		byAttempt[event.AttemptID] = digest
+	}
+	lines := make([]string, 0, len(byAttempt))
+	for attemptID, digest := range byAttempt {
+		lines = append(lines, attemptID+":"+digest)
+	}
+	sort.Strings(lines)
+	return sha256Bytes([]byte(strings.Join(lines, "\n"))), nil
+}
+
+// writeAnchor атомарно публикует {RunDir}/anchor.json после terminal события
+// (тот же tmp+rename паттерн, что и остальные evidence-артефакты).
+func (s *Store) writeAnchor(terminalEvent string, events []Event) error {
+	if len(events) == 0 {
+		return fmt.Errorf("anchor требует непустой event log")
+	}
+	digest, err := manifestsDigest(events)
+	if err != nil {
+		return err
+	}
+	anchor := Anchor{
+		SchemaVersion:   AnchorSchemaVersion,
+		RunID:           s.runID,
+		TerminalEvent:   terminalEvent,
+		EventCount:      events[len(events)-1].Sequence,
+		ChainRootSHA256: events[len(events)-1].SHA256,
+		ManifestsDigest: digest,
+		CreatedAt:       time.Now().UTC(),
+	}
+	data, err := json.MarshalIndent(anchor, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmpFile, err := os.CreateTemp(s.RunDir(), ".tmp-anchor-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, filepath.Join(s.RunDir(), anchorFileName))
+}
+
+// VerifyAnchor проверяет терминальный anchor manifest run: replay цепочки,
+// число событий, корень цепочки и digest attempt manifests. Любое расхождение
+// означает tampering или повреждение evidence.
+func VerifyAnchor(runDir string) error {
+	manifestData, err := safeio.ReadRegularFile(filepath.Join(runDir, "run.json"), 1<<20)
+	if err != nil {
+		return fmt.Errorf("anchor verify: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(manifestData))
+	decoder.DisallowUnknownFields()
+	var manifest RunManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return fmt.Errorf("anchor verify: run manifest: %w", err)
+	}
+	if manifest.RunID == "" {
+		return fmt.Errorf("anchor verify: run manifest без run_id")
+	}
+	anchorData, err := safeio.ReadRegularFile(filepath.Join(runDir, anchorFileName), maxAnchorFileSize)
+	if err != nil {
+		return fmt.Errorf("anchor verify: run %s не имеет валидного anchor.json: %w", manifest.RunID, err)
+	}
+	anchorDecoder := json.NewDecoder(bytes.NewReader(anchorData))
+	anchorDecoder.DisallowUnknownFields()
+	var anchor Anchor
+	if err := anchorDecoder.Decode(&anchor); err != nil {
+		return fmt.Errorf("anchor verify: anchor.json повреждён: %w", err)
+	}
+	var trailing any
+	if err := anchorDecoder.Decode(&trailing); err == nil {
+		return fmt.Errorf("anchor verify: anchor.json содержит trailing JSON")
+	} else if !errors.Is(err, io.EOF) {
+		return fmt.Errorf("anchor verify: anchor.json trailing data: %w", err)
+	}
+	if anchor.SchemaVersion != AnchorSchemaVersion {
+		return fmt.Errorf("anchor verify: неожиданная schema_version %d", anchor.SchemaVersion)
+	}
+	if anchor.RunID != manifest.RunID {
+		return fmt.Errorf("anchor verify: anchor run_id %q не совпадает с manifest %q — evidence подменён", anchor.RunID, manifest.RunID)
+	}
+	if !isTerminalEventType(anchor.TerminalEvent) {
+		return fmt.Errorf("anchor verify: недопустимый terminal_event %q", anchor.TerminalEvent)
+	}
+	replayed, err := ReplayEventLog(filepath.Join(runDir, "events.jsonl"), manifest.RunID)
+	if err != nil {
+		return fmt.Errorf("anchor verify: event chain сломан: %w", err)
+	}
+	events, err := VerifyEventLog(filepath.Join(runDir, "events.jsonl"), manifest.RunID)
+	if err != nil {
+		return fmt.Errorf("anchor verify: event chain сломан: %w", err)
+	}
+	if len(events) == 0 {
+		return fmt.Errorf("anchor verify: пустой event log")
+	}
+	if uint64(len(events)) != anchor.EventCount {
+		return fmt.Errorf("anchor verify: tampering обнаружен — anchor event_count=%d, фактически %d событий", anchor.EventCount, len(events))
+	}
+	if replayed.LastEventSHA256 != anchor.ChainRootSHA256 {
+		return fmt.Errorf("anchor verify: tampering обнаружен — chain_root_sha256 не совпадает с последним событием (цепочка пересобрана или усечена)")
+	}
+	digest, err := manifestsDigest(events)
+	if err != nil {
+		return fmt.Errorf("anchor verify: %w", err)
+	}
+	if digest != anchor.ManifestsDigest {
+		return fmt.Errorf("anchor verify: tampering обнаружен — manifests_digest не совпадает")
+	}
+	return nil
+}

--- a/pkg/evidence/anchor_test.go
+++ b/pkg/evidence/anchor_test.go
@@ -1,0 +1,203 @@
+package evidence
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildAnchoredRun создаёт терминальный run с attempt manifest и anchor.json.
+func buildAnchoredRun(t *testing.T, runID string) string {
+	t.Helper()
+	target := t.TempDir()
+	store, err := Start(filepath.Join(target, "runs"), testRunManifest(runID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now().UTC()
+	attemptID := runID + "-001-check"
+	steps := []func() error{
+		func() error { return store.Append(Event{Type: "run_started", Timestamp: started}) },
+		func() error {
+			return store.Append(Event{Type: "attempt_started", Stage: "check", AttemptID: attemptID,
+				Timestamp: started.Add(time.Second), Data: map[string]any{"stage_index": 1}})
+		},
+		func() error {
+			return store.PublishAttempt(AttemptManifest{
+				AttemptID: attemptID, Stage: "check", StageIndex: 1,
+				StartedAt: started.Add(time.Second), FinishedAt: started.Add(2 * time.Second),
+				Status: "passed", Execution: "succeeded", Decision: "approved", Outcome: "passed",
+			}, filepath.Join(target, "artifacts"), nil, nil)
+		},
+	}
+	for _, step := range steps {
+		if err := step(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, _, manifestDigest, err := ArtifactDigest(filepath.Join(store.RunDir(), "attempts", attemptID, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Append(Event{Type: "attempt_finished", Stage: "check", AttemptID: attemptID,
+		Timestamp: started.Add(2 * time.Second), Data: map[string]any{
+			"status": "passed", "execution": "succeeded", "decision": "approved",
+			"outcome": "passed", "manifest_sha256": manifestDigest,
+		}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Append(Event{Type: "run_finished", Timestamp: started.Add(3 * time.Second),
+		Data: map[string]any{"status": "completed", "stage_attempts": 1}}); err != nil {
+		t.Fatal(err)
+	}
+	return store.RunDir()
+}
+
+func readAnchor(t *testing.T, runDir string) Anchor {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(runDir, "anchor.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var anchor Anchor
+	if err := json.Unmarshal(data, &anchor); err != nil {
+		t.Fatal(err)
+	}
+	return anchor
+}
+
+func TestTerminalEventWritesValidAnchor(t *testing.T) {
+	runDir := buildAnchoredRun(t, "run-anchor-ok")
+	anchor := readAnchor(t, runDir)
+	events, err := VerifyEventLog(filepath.Join(runDir, "events.jsonl"), "run-anchor-ok")
+	if err != nil || len(events) == 0 {
+		t.Fatalf("event log must be valid: err=%v len=%d", err, len(events))
+	}
+	if anchor.SchemaVersion != AnchorSchemaVersion || anchor.RunID != "run-anchor-ok" ||
+		anchor.TerminalEvent != "run_finished" || anchor.EventCount != uint64(len(events)) ||
+		anchor.ChainRootSHA256 != events[len(events)-1].SHA256 || anchor.CreatedAt.IsZero() {
+		t.Fatalf("unexpected anchor: %+v", anchor)
+	}
+	if err := VerifyAnchor(runDir); err != nil {
+		t.Fatalf("VerifyAnchor должен проходить на нетронутом run: %v", err)
+	}
+}
+
+func TestVerifyAnchorDetectsTamperedMiddleEvent(t *testing.T) {
+	runDir := buildAnchoredRun(t, "run-anchor-mid")
+	path := filepath.Join(runDir, "events.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered := strings.Replace(string(data), `"type":"attempt_started"`, `"type":"attempt_hacked"`, 1)
+	if tampered == string(data) {
+		t.Fatal("подмена не применилась")
+	}
+	if err := os.WriteFile(path, []byte(tampered), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = VerifyAnchor(runDir)
+	if err == nil {
+		t.Fatal("подмена события в середине должна ломать VerifyAnchor")
+	}
+	if !strings.Contains(err.Error(), "tampering") && !strings.Contains(err.Error(), "сломан") {
+		t.Fatalf("ожидалась причина tampering, получено: %v", err)
+	}
+}
+
+func TestVerifyAnchorDetectsRemovedLastEvent(t *testing.T) {
+	runDir := buildAnchoredRun(t, "run-anchor-trunc")
+	path := filepath.Join(runDir, "events.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("слишком мало событий: %d", len(lines))
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines[:len(lines)-1], "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyAnchor(runDir); err == nil {
+		t.Fatal("удаление последнего события должно ломать VerifyAnchor")
+	}
+}
+
+// Ключевой кейс: злоумышленник пересобирает цепочку целиком (пересчитывает
+// previous_sha256/sha256 после подмены), но anchor.json остался от исходной
+// цепочки — VerifyAnchor обязан это обнаружить по chain_root_sha256.
+func TestVerifyAnchorDetectsRebuiltChainWithoutAnchorUpdate(t *testing.T) {
+	runDir := buildAnchoredRun(t, "run-anchor-rebuild")
+	path := filepath.Join(runDir, "events.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	rebuilt := make([]string, 0, len(lines))
+	previous := genesisEventHash
+	for index, line := range lines {
+		var event Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatal(err)
+		}
+		event.PreviousSHA256 = previous
+		// Подмена содержимого середины цепочки + полный пересчёт хешей.
+		if index == 1 {
+			event.Timestamp = event.Timestamp.Add(500 * time.Millisecond)
+		}
+		digest, err := eventDigest(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		event.SHA256 = digest
+		encoded, err := json.Marshal(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rebuilt = append(rebuilt, string(encoded))
+		previous = digest
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(rebuilt, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReplayEventLog(path, "run-anchor-rebuild"); err != nil {
+		t.Fatalf("пересобранная цепочка должна проходить replay: %v", err)
+	}
+	err = VerifyAnchor(runDir)
+	if err == nil {
+		t.Fatal("пересобранная цепочка без обновления anchor должна ломать VerifyAnchor")
+	}
+	if !strings.Contains(err.Error(), "chain_root_sha256") {
+		t.Fatalf("ожидалась ошибка chain root, получено: %v", err)
+	}
+}
+
+func TestVerifyAnchorRejectsMissingOrCorruptAnchor(t *testing.T) {
+	runDir := buildAnchoredRun(t, "run-anchor-missing")
+	if err := os.Remove(filepath.Join(runDir, "anchor.json")); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyAnchor(runDir); err == nil {
+		t.Fatal("отсутствие anchor.json должно быть ошибкой")
+	}
+
+	runDir = buildAnchoredRun(t, "run-anchor-corrupt")
+	anchorPath := filepath.Join(runDir, "anchor.json")
+	data, err := os.ReadFile(anchorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corrupt := strings.Replace(string(data), `"event_count":`, `"event_count_x":`, 1)
+	if err := os.WriteFile(anchorPath, []byte(corrupt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyAnchor(runDir); err == nil {
+		t.Fatal("повреждённый anchor.json должен быть ошибкой")
+	}
+}

--- a/pkg/evidence/store.go
+++ b/pkg/evidence/store.go
@@ -579,6 +579,12 @@ func (s *Store) Append(event Event) error {
 	}
 	s.nextID = event.Sequence
 	s.lastEventHash = event.SHA256
+	if isTerminalEventType(event.Type) {
+		events = append(events, event)
+		if err := s.writeAnchor(event.Type, events); err != nil {
+			return fmt.Errorf("запись anchor.json: %w", err)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Что делали

У каждого прогона уже был журнал событий, защищённый хеш-цепочкой: каждое событие содержит хеш предыдущего, и любое изменение записи ломает цепочку. Но была дыра: злоумышленник (или забывчивый владелец) мог **переписать весь журнал целиком** и пересчитать все хеши заново — такая подделка ничем не отличалась от оригинала.

Теперь при завершении прогона создаётся **якорь** — маленький файл `anchor.json` с отпечатком всего журнала: количество событий, хеш последнего события, дайджест всех манифестов попыток. И появилась команда проверки:

```
ai-team verify --target . <run_id>
```

Она проигрывает журнал заново, пересчитывает всё и сверяет с якорем. Ключевой сценарий покрыт тестом: если кто-то пересоберёт цепочку с новыми хешами, но не обновит якорь — проверка это ловит.

## Зачем

Вся ценность «неизменяемых доказательств» упирается в вопрос: неизменяемые *относительно кого*? Пока якоря не было, защита работала только против случайной порчи — а осознанная подделка проходила незамеченной. Для инструмента, который обещает строгие гарантии, это была дыра в главном обещании.

## Что получим после мержа

- спор «агент этого не делал» решается командой `ai-team verify`, а не разбором файлов на глаз;
- случайная порча, усечение журнала, подмена события в середине, полная пересборка цепочки — все четыре сценария детектируются;
- foundation для будущих внешних якорей (подписи, git notes) из плана.