### PR TITLE
feat(runtime): Codex adapter over codex exec, launch-carrying Command contract (ADP-1)

### DIFF
--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -132,12 +132,14 @@ func (e *Eval) Run(ctx context.Context) (*Result, error) {
 	cmd.Stdout = &out
 	stderr := cappedBuffer{limit: 256 << 10}
 	cmd.Stderr = &stderr
-	stdin, err := os.Open(promptPath)
-	if err != nil {
-		return nil, err
+	if adapter.Describe().PromptViaStdin {
+		stdin, err := os.Open(promptPath)
+		if err != nil {
+			return nil, err
+		}
+		defer stdin.Close()
+		cmd.Stdin = stdin
 	}
-	defer stdin.Close()
-	cmd.Stdin = stdin
 	environment, cleanupEnvironment, envErr := adapter.Environment(
 		&runtime.Agent{Name: "eval-judge", Mutation: "none"},
 		&runtime.Task{TargetDir: isolatedDir, ArtifactRoot: filepath.Join(isolatedDir, "artifacts"), Feature: "eval"},

--- a/pkg/eval/eval.go
+++ b/pkg/eval/eval.go
@@ -123,7 +123,7 @@ func (e *Eval) Run(ctx context.Context) (*Result, error) {
 	if err := adapter.Validate(launch); err != nil {
 		return nil, fmt.Errorf("eval: %w", err)
 	}
-	args, err := adapter.Command(cli, "", promptPath)
+	args, err := adapter.Command(cli, launch, promptPath)
 	if err != nil {
 		return nil, err
 	}
@@ -132,6 +132,12 @@ func (e *Eval) Run(ctx context.Context) (*Result, error) {
 	cmd.Stdout = &out
 	stderr := cappedBuffer{limit: 256 << 10}
 	cmd.Stderr = &stderr
+	stdin, err := os.Open(promptPath)
+	if err != nil {
+		return nil, err
+	}
+	defer stdin.Close()
+	cmd.Stdin = stdin
 	environment, cleanupEnvironment, envErr := adapter.Environment(
 		&runtime.Agent{Name: "eval-judge", Mutation: "none"},
 		&runtime.Task{TargetDir: isolatedDir, ArtifactRoot: filepath.Join(isolatedDir, "artifacts"), Feature: "eval"},

--- a/pkg/eval/eval_test.go
+++ b/pkg/eval/eval_test.go
@@ -31,7 +31,7 @@ func (a testJudgeAdapter) Validate(launch aiteamruntime.Launch) error {
 	return aiteamruntime.ValidateLaunch(a, launch)
 }
 
-func (testJudgeAdapter) Command(cli, model, promptFile string) ([]string, error) {
+func (testJudgeAdapter) Command(cli string, launch aiteamruntime.Launch, promptFile string) ([]string, error) {
 	return []string{"run", promptFile}, nil
 }
 

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -210,11 +210,16 @@ func (b *limitedBuffer) Write(value []byte) (int, error) {
 func allowedCredentialNames() []string {
 	seen := make(map[string]bool)
 	var names []string
-	for _, raw := range strings.Split(os.Getenv("AI_TEAM_OPENCODE_ENV_ALLOW"), ",") {
-		name := strings.TrimSpace(raw)
-		if name != "" && !seen[name] {
-			seen[name] = true
-			names = append(names, name)
+	for _, raw := range []string{
+		os.Getenv(runtime.HarnessEnvAllowVar),
+		os.Getenv(runtime.HarnessEnvAllowLegacyVar),
+	} {
+		for _, entry := range strings.Split(raw, ",") {
+			name := strings.TrimSpace(entry)
+			if name != "" && !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
 		}
 	}
 	sort.Strings(names)

--- a/pkg/runtime/adapter.go
+++ b/pkg/runtime/adapter.go
@@ -34,10 +34,12 @@ type RuntimeAdapter interface {
 	// декларирует capability, обязательную для запроса.
 	Validate(launch Launch) error
 
-	// Command — argv запуска харнесса. CLI указывает бинарник; model — модель,
-	// если пустая, применяется дефолт; promptFile — временный файл 0600 с
-	// промптом (адаптер решает, использовать ли его через --file и т.п.).
-	Command(cli, model, promptFile string) ([]string, error)
+	// Command — argv запуска харнесса. Launch несёт model/effort политику этапа
+	// (adapter маппит её в харнесс-специфичные флаги); cli — бинарник;
+	// promptFile — временный файл 0600 с промптом. Адаптер, принимающий промпт
+	// через stdin (codex exec -), ожидает, что оркестратор направляет
+	// promptFile в cmd.Stdin.
+	Command(cli string, launch Launch, promptFile string) ([]string, error)
 
 	// Environment — окружение субпроцесса с изоляцией сессии (allow-list env,
 	// запрет эффектных инструментов, суженные edit-scope). Возвращает cleanup,

--- a/pkg/runtime/adapter.go
+++ b/pkg/runtime/adapter.go
@@ -97,7 +97,7 @@ type Launch struct {
 // от адаптера, аттестующего источник данных (see CapUsageReported / P1-7);
 // контроллер никогда не угадывает usage сам.
 type Usage struct {
-	TokensInput int64   `json:"tokens_input,omitempty"`
+	TokensInput int64 `json:"tokens_input,omitempty"`
 	// CachedInputTokens — доля входных токенов, прочитанных из кэша харнесса.
 	// По конвенции OpenAI кэшированные входные токены уже входят в
 	// TokensInput; это поле ведётся отдельно для учёта скидки cache-read

--- a/pkg/runtime/adapter.go
+++ b/pkg/runtime/adapter.go
@@ -73,6 +73,11 @@ type Descriptor struct {
 	Name         string       `json:"name"`
 	Binary       string       `json:"binary"`
 	Capabilities []Capability `json:"capabilities"`
+	// PromptViaStdin — харнесс читает промпт из stdin (codex exec -).
+	// True: оркестратор направляет promptFile в cmd.Stdin. False (opencode):
+	// промпт передаётся только через argv --file, stdin остаётся не тронутым
+	// (иначе opencode получил бы промпт дважды).
+	PromptViaStdin bool `json:"prompt_via_stdin,omitempty"`
 }
 
 // Launch — harness-neutral запрос на запуск этапа. Политика этапа маппится
@@ -92,11 +97,16 @@ type Launch struct {
 // от адаптера, аттестующего источник данных (see CapUsageReported / P1-7);
 // контроллер никогда не угадывает usage сам.
 type Usage struct {
-	TokensInput  int64   `json:"tokens_input,omitempty"`
-	TokensOutput int64   `json:"tokens_output,omitempty"`
-	CostUSD      float64 `json:"cost_usd,omitempty"`
-	Currency     string  `json:"currency,omitempty"`
-	Attested     bool    `json:"attested"`
+	TokensInput int64   `json:"tokens_input,omitempty"`
+	// CachedInputTokens — доля входных токенов, прочитанных из кэша харнесса.
+	// По конвенции OpenAI кэшированные входные токены уже входят в
+	// TokensInput; это поле ведётся отдельно для учёта скидки cache-read
+	// при расчёте cost, но НЕ суммируется с TokensInput.
+	CachedInputTokens int64   `json:"cached_input_tokens,omitempty"`
+	TokensOutput      int64   `json:"tokens_output,omitempty"`
+	CostUSD           float64 `json:"cost_usd,omitempty"`
+	Currency          string  `json:"currency,omitempty"`
+	Attested          bool    `json:"attested"`
 }
 
 // UsageSource — опциональный интерфейс адаптера: разбирает usage из

--- a/pkg/runtime/adapter_test.go
+++ b/pkg/runtime/adapter_test.go
@@ -87,7 +87,7 @@ func (a restrictedAdapter) Describe() Descriptor {
 
 func (a restrictedAdapter) Validate(launch Launch) error { return ValidateLaunch(a, launch) }
 
-func (restrictedAdapter) Command(cli, model, promptFile string) ([]string, error) {
+func (restrictedAdapter) Command(cli string, launch Launch, promptFile string) ([]string, error) {
 	return []string{cli, promptFile}, nil
 }
 

--- a/pkg/runtime/agentcli.go
+++ b/pkg/runtime/agentcli.go
@@ -93,14 +93,17 @@ func (r *AgentCLIRuntime) Execute(ctx context.Context, agent *Agent, task *Task,
 	cmd.Dir = targetDir
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	// Промпт направляется и в argv-флаг (opencode --file), и в stdin: адаптеры,
-	// принимающие промпт из stdin (codex exec -), потребляют его оттуда.
-	stdin, err := os.Open(promptFile)
-	if err != nil {
-		return fmt.Errorf("агент %s: открыть промпт для stdin: %w", agent.Name, err)
+	// Промпт в stdin подаётся только адаптерам, объявляющим PromptViaStdin
+	// (codex exec -). Opencode получает промпт только через argv --file: иначе
+	// промпт дублировался бы (argv + stdin).
+	if adapter.Describe().PromptViaStdin {
+		stdin, err := os.Open(promptFile)
+		if err != nil {
+			return fmt.Errorf("агент %s: открыть промпт для stdin: %w", agent.Name, err)
+		}
+		defer stdin.Close()
+		cmd.Stdin = stdin
 	}
-	defer stdin.Close()
-	cmd.Stdin = stdin
 
 	isolatedEnv, cleanupEnv, err := adapter.Environment(agent, task, inputs...)
 	if err != nil {
@@ -110,7 +113,10 @@ func (r *AgentCLIRuntime) Execute(ctx context.Context, agent *Agent, task *Task,
 	cmd.Env = isolatedEnv
 
 	if err := process.Run(ctx, cmd); err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
+		// Отмена/deadline не зависят от harness-вывода: пробрасываем их ДО
+		// классификатора, иначе context.Canceled/DeadlineExceeded маскируется
+		// под CodexErrorUnknown/ClaudeErrorUnknown.
+		if ctx.Err() != nil {
 			return fmt.Errorf("агент %s: %w", agent.Name, ctx.Err())
 		}
 		if classifier, ok := adapter.(interface{ ClassifyError(output string) error }); ok {

--- a/pkg/runtime/agentcli.go
+++ b/pkg/runtime/agentcli.go
@@ -67,7 +67,7 @@ func (r *AgentCLIRuntime) Execute(ctx context.Context, agent *Agent, task *Task,
 		return fmt.Errorf("агент %s: временный prompt: %w", agent.Name, err)
 	}
 	defer cleanupPrompt()
-	args, err := adapter.Command(cli, agent.Model, promptFile)
+	args, err := adapter.Command(cli, launch, promptFile)
 	if err != nil {
 		return err
 	}
@@ -83,10 +83,25 @@ func (r *AgentCLIRuntime) Execute(ctx context.Context, agent *Agent, task *Task,
 	}
 	defer closeLog()
 
+	// Кап-буферы для классификации ошибок (если адаптер это умеет): всегда
+	// teем вывод в границы, не читая произвольный объём harness-вывода.
+	var capturedStdout, capturedStderr strings.Builder
+	stdout = io.MultiWriter(stdout, &boundedBuilder{Builder: &capturedStdout, limit: 2 << 20})
+	stderr = io.MultiWriter(stderr, &boundedBuilder{Builder: &capturedStderr, limit: 2 << 20})
+
 	cmd := exec.Command(cli, args...)
 	cmd.Dir = targetDir
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	// Промпт направляется и в argv-флаг (opencode --file), и в stdin: адаптеры,
+	// принимающие промпт из stdin (codex exec -), потребляют его оттуда.
+	stdin, err := os.Open(promptFile)
+	if err != nil {
+		return fmt.Errorf("агент %s: открыть промпт для stdin: %w", agent.Name, err)
+	}
+	defer stdin.Close()
+	cmd.Stdin = stdin
+
 	isolatedEnv, cleanupEnv, err := adapter.Environment(agent, task, inputs...)
 	if err != nil {
 		return fmt.Errorf("агент %s: изоляция сессии: %w", agent.Name, err)
@@ -97,6 +112,13 @@ func (r *AgentCLIRuntime) Execute(ctx context.Context, agent *Agent, task *Task,
 	if err := process.Run(ctx, cmd); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return fmt.Errorf("агент %s: %w", agent.Name, ctx.Err())
+		}
+		if classifier, ok := adapter.(interface{ ClassifyError(output string) error }); ok {
+			output := capturedStdout.String()
+			if capturedStderr.Len() > 0 {
+				output += "\n" + capturedStderr.String()
+			}
+			return fmt.Errorf("агент %s: %w", agent.Name, classifier.ClassifyError(output))
 		}
 		return fmt.Errorf("агент %s завершился с ошибкой: %w", agent.Name, err)
 	}
@@ -111,7 +133,7 @@ func AgentCLIArgs(cli, model, promptFile string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return adapter.Command(cli, model, promptFile)
+	return adapter.Command(cli, Launch{Model: model}, promptFile)
 }
 
 // OpenCodeIsolationEnvironment — совместимая обёртка над opencode-адаптером.
@@ -237,6 +259,24 @@ func (r *AgentCLIRuntime) buildPrompt(agent *Agent, task *Task, inputs []Artifac
 	prompt += serviceSection(agent, task)
 
 	return prompt, nil
+}
+
+// boundedBuilder ограничивает накапливаемый текст, не позволяя переполнять
+// память произвольным объёмом вывода харнесса (используется только для
+// классификации ошибок адаптером).
+type boundedBuilder struct {
+	*strings.Builder
+	limit int
+}
+
+func (b *boundedBuilder) Write(value []byte) (int, error) {
+	if remaining := b.limit - b.Len(); remaining > 0 {
+		if len(value) > remaining {
+			value = value[:remaining]
+		}
+		_, _ = b.Builder.Write(value)
+	}
+	return len(value), nil
 }
 
 func sortedMapKeys(values map[string]string) []string {

--- a/pkg/runtime/codex.go
+++ b/pkg/runtime/codex.go
@@ -1,0 +1,238 @@
+package runtime
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// CodexAdapter — реализация RuntimeAdapter для OpenAI Codex CLI.
+// Вся codex-специфика (argv `codex exec --json`, sandbox, CODEX_HOME,
+// JSONL-события, usage-статистика) локализована здесь.
+//
+// Промпт передаётся через stdin (`codex exec -`): оркестратор направляет
+// файл промпта в cmd.Stdin — большие промпты не упираются в ARG_MAX.
+//
+// Политика изоляции: sandbox=workspace-write (записи только внутри workspace),
+// headless without approvals, CODEX_HOME перенаправлен во временный каталог
+// (проектный/user config и MCP-серверы не загружаются), env заменён
+// allow-листом. Ограничение: tool-level deny (webfetch/websearch), который у
+// OpenCode выражается permission-JSON, у Codex требует стабильного execpolicy
+// grammar; пока он в preview — полагаемся на sandbox и zero-approval режим.
+type CodexAdapter struct{}
+
+func (a *CodexAdapter) Name() string { return "codex" }
+
+func (a *CodexAdapter) Describe() Descriptor {
+	return Descriptor{
+		Name:   a.Name(),
+		Binary: "codex",
+		Capabilities: []Capability{
+			CapModelSelection,
+			CapEffortMapping,
+			CapPromptFile,
+			CapSessionIsolation,
+			CapUsageReported,
+		},
+	}
+}
+
+// Validate — fail-closed: запрос capability, отсутствующей у codex, блокирует
+// запуск (см. ValidateLaunch).
+func (a *CodexAdapter) Validate(launch Launch) error {
+	return ValidateLaunch(a, launch)
+}
+
+// Command — argv запуска `codex exec` в headless CI-режиме: JSONL-события на
+// stdout, sandbox-confined workspace writes, чтение промпта из stdin ("-").
+func (a *CodexAdapter) Command(cli string, launch Launch, promptFile string) ([]string, error) {
+	if filepath.Base(cli) != a.Name() {
+		return nil, fmt.Errorf("CLI %q не поддерживается адаптером codex: требуется явный adapter вместо guessed arguments", cli)
+	}
+	args := []string{
+		"exec",
+		"--json",
+		"--sandbox", "workspace-write",
+		// Субпроцесс всегда ограничен sandbox workspace-write: безопаснее
+		// гарантировать границу записей и для eval-каталогов вне git, чем
+		// полагаться на требование git-репозитория (preflight проверил его
+		// для agent-стадий отдельно).
+		"--skip-git-repo-check",
+		"--ephemeral",
+	}
+	if launch.Model != "" && launch.Model != "auto" {
+		args = append(args, "-m", launch.Model)
+	}
+	if launch.Effort != "" {
+		if !validCodexEffort(launch.Effort) {
+			return nil, fmt.Errorf("codex: недопустимый effort %q (low|medium|high)", launch.Effort)
+		}
+		args = append(args, "-c", "model_reasoning_effort="+launch.Effort)
+	}
+	// "-" — явный sentinel: полный промпт читается из stdin.
+	args = append(args, "-")
+	return args, nil
+}
+
+func validCodexEffort(effort string) bool {
+	switch effort {
+	case "low", "medium", "high":
+		return true
+	}
+	return false
+}
+
+// Environment — изоляция codex-сессии: запрет проектного execution surface,
+// CODEX_HOME во временном каталоге (0700) без пользовательских config/MCP,
+// allow-list env субпроцесса.
+func (a *CodexAdapter) Environment(agent *Agent, task *Task, inputs ...Artifact) ([]string, func(), error) {
+	for _, relative := range []string{filepath.Join(".codex", "config.toml")} {
+		if info, err := os.Lstat(filepath.Join(task.TargetDir, relative)); err == nil && (info.IsDir() || info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
+			return nil, func() {}, fmt.Errorf("project execution surface %s запрещена; project config входит в trusted controller, а не в agent runtime", relative)
+		} else if err != nil && !os.IsNotExist(err) {
+			return nil, func() {}, fmt.Errorf("проверка %s: %w", relative, err)
+		}
+	}
+
+	codexHome, err := os.MkdirTemp("", "ai-team-codex-config-*")
+	if err != nil {
+		return nil, func() {}, err
+	}
+	if err := os.Chmod(codexHome, 0700); err != nil {
+		_ = os.RemoveAll(codexHome)
+		return nil, func() {}, err
+	}
+	cleanup := func() { _ = os.RemoveAll(codexHome) }
+
+	// Defense-in-depth: те же policy, что и в argv-флагах; инициализирует
+	// изолированный config, если harness станет читать его (а не только флаги).
+	configContent := "approval_policy = \"never\"\nsandbox_mode = \"workspace-write\"\n"
+	configPath := filepath.Join(codexHome, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		cleanup()
+		return nil, func() {}, err
+	}
+
+	env := withAllowedEnvironmentKeys(os.Environ(), allowedEnvironmentKeys())
+	env = append(env, "CODEX_HOME="+codexHome)
+	sort.Strings(env)
+	return env, cleanup, nil
+}
+
+// ParseUsage — типизированный разбор usage из JSONL-событий `codex exec
+// --json`. Берётся последний turn.completed (финальный); токены аттестуются
+// как реальный расход, cost от харнесса не приходит — остаётся empty.
+func (a *CodexAdapter) ParseUsage(reader io.Reader) (*Usage, error) {
+	var usage *Usage
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), 4<<20)
+	var parseErr error
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var event struct {
+			Type  string `json:"type"`
+			Usage *struct {
+				InputTokens           int64 `json:"input_tokens"`
+				CachedInputTokens     int64 `json:"cached_input_tokens"`
+				OutputTokens          int64 `json:"output_tokens"`
+				ReasoningOutputTokens int64 `json:"reasoning_output_tokens"`
+			} `json:"usage"`
+		}
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			parseErr = err
+			continue
+		}
+		if event.Type == "turn.completed" && event.Usage != nil {
+			usage = &Usage{
+				TokensInput:  event.Usage.InputTokens + event.Usage.CachedInputTokens,
+				TokensOutput: event.Usage.OutputTokens,
+				Attested:     true,
+			}
+		}
+	}
+	if parseErr != nil {
+		return nil, fmt.Errorf("codex: невалидная JSONL-строка: %w", parseErr)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if usage == nil {
+		return nil, fmt.Errorf("codex: событие turn.completed с usage не найдено в выводе")
+	}
+	return usage, nil
+}
+
+// ClassifyError — таксономия ошибок codex-запуска на основе захваченного
+// вывода. Оркестратор вызывает этот метод опционально (см. Execute).
+func (a *CodexAdapter) ClassifyError(output string) error {
+	lower := strings.ToLower(output)
+	switch {
+	case containsAny(lower,
+		"authentication", "authorization", "api key", "credentials",
+		"not logged in", "401", "403", "invalid_api_key"):
+		return &CodexRunError{Category: CodexErrorAuth, Detail: "аутентификация codex недоступна (проверь CODEX_API_KEY или allow-list окружения)"}
+	case containsAny(lower,
+		"model not found", "no such model", "model does not exist", "model not available", "unknown model"):
+		return &CodexRunError{Category: CodexErrorModel, Detail: "запрошенная модель недоступна у codex-провайдера"}
+	case containsAny(lower,
+		"invalid config", "config error", "failed to parse config", "unknown setting", "toml"):
+		return &CodexRunError{Category: CodexErrorConfig, Detail: "некорректная конфигурация codex"}
+	case containsAny(lower,
+		"network", "connection", "timed out", "timeout", "server error", "503", "failed to connect"):
+		return &CodexRunError{Category: CodexErrorNetwork, Detail: "сетевая ошибка при обращении к codex-провайдеру"}
+	case containsAny(lower,
+		"not permitted", "permission denied", "sandbox", "blocked by policy", "denied"):
+		return &CodexRunError{Category: CodexErrorSandbox, Detail: "действие заблокировано политикой sandbox codex"}
+	default:
+		return &CodexRunError{Category: CodexErrorUnknown, Detail: wrapDefaultDetail(output)}
+	}
+}
+
+func containsAny(lower string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// wrapDefaultDetail не детализирует вывод харнесса (может содержать данные
+// репозитория), а лишь сообщает о сбое запуска без утечки содержимого.
+func wrapDefaultDetail(output string) string {
+	return "codex завершился с ошибкой"
+}
+
+// CodexErrorCategory — категория сбоя codex-запуска (error taxonomy).
+type CodexErrorCategory string
+
+const (
+	CodexErrorAuth    CodexErrorCategory = "authentication"
+	CodexErrorModel   CodexErrorCategory = "model"
+	CodexErrorConfig  CodexErrorCategory = "configuration"
+	CodexErrorNetwork CodexErrorCategory = "network"
+	CodexErrorSandbox CodexErrorCategory = "sandbox"
+	CodexErrorUnknown CodexErrorCategory = "unknown"
+)
+
+// CodexRunError — типизированная ошибка запуска codex.
+type CodexRunError struct {
+	Category CodexErrorCategory
+	Detail   string
+}
+
+func (e *CodexRunError) Error() string {
+	return fmt.Sprintf("codex-%s: %s", e.Category, e.Detail)
+}
+
+func init() {
+	RegisterAdapter(&CodexAdapter{})
+}

--- a/pkg/runtime/codex.go
+++ b/pkg/runtime/codex.go
@@ -39,6 +39,7 @@ func (a *CodexAdapter) Describe() Descriptor {
 			CapSessionIsolation,
 			CapUsageReported,
 		},
+		PromptViaStdin: true,
 	}
 }
 
@@ -152,9 +153,10 @@ func (a *CodexAdapter) ParseUsage(reader io.Reader) (*Usage, error) {
 		}
 		if event.Type == "turn.completed" && event.Usage != nil {
 			usage = &Usage{
-				TokensInput:  event.Usage.InputTokens + event.Usage.CachedInputTokens,
-				TokensOutput: event.Usage.OutputTokens,
-				Attested:     true,
+				TokensInput:       event.Usage.InputTokens,
+				CachedInputTokens: event.Usage.CachedInputTokens,
+				TokensOutput:      event.Usage.OutputTokens,
+				Attested:          true,
 			}
 		}
 	}

--- a/pkg/runtime/codex_test.go
+++ b/pkg/runtime/codex_test.go
@@ -86,8 +86,11 @@ func TestCodexParseUsageLastTurnWins(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if usage.TokensInput != 260 || usage.TokensOutput != 40 {
-		t.Errorf("usage = %+v, want input=260 output=40 (последний turn)", usage)
+	if usage.TokensInput != 200 || usage.TokensOutput != 40 {
+		t.Errorf("usage = %+v, want input=200 output=40 (последний turn)", usage)
+	}
+	if usage.CachedInputTokens != 60 {
+		t.Errorf("CachedInputTokens = %d, want 60 (не суммируется с TokensInput)", usage.CachedInputTokens)
 	}
 	if !usage.Attested {
 		t.Error("codex usage должен быть attested (токены из JSONL харнесса)")

--- a/pkg/runtime/codex_test.go
+++ b/pkg/runtime/codex_test.go
@@ -1,0 +1,235 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCodexAdapterRegistered(t *testing.T) {
+	adapter, err := Adapter("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adapter.Name() != "codex" {
+		t.Errorf("expected codex, got %s", adapter.Name())
+	}
+}
+
+func TestCodexDescribeDeclaresContractCapabilities(t *testing.T) {
+	adapter, _ := Adapter("codex")
+	declared := make(map[Capability]bool)
+	for _, capability := range adapter.Describe().Capabilities {
+		declared[capability] = true
+	}
+	for _, capability := range []Capability{
+		CapModelSelection, CapEffortMapping, CapPromptFile, CapSessionIsolation, CapUsageReported,
+	} {
+		if !declared[capability] {
+			t.Errorf("codex должен декларировать capability %q", capability)
+		}
+	}
+}
+
+func TestCodexCommandProducesHeadlessArgs(t *testing.T) {
+	a := &CodexAdapter{}
+	args, err := a.Command("codex", Launch{Model: "gpt-5", Effort: "high", RequireIsolation: true}, "/tmp/prompt.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "exec --json --sandbox workspace-write --skip-git-repo-check --ephemeral -m gpt-5 -c model_reasoning_effort=high -"
+	if got := strings.Join(args, " "); got != want {
+		t.Errorf("argv = %q, want %q", got, want)
+	}
+}
+
+func TestCodexCommandNoModelNoEffort(t *testing.T) {
+	a := &CodexAdapter{}
+	args, err := a.Command("codex", Launch{RequireIsolation: true}, "/tmp/prompt.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.Join(args, " "), "-m") || strings.Contains(strings.Join(args, " "), "effort") {
+		t.Errorf("без model/effort argv не должен содержать эти флаги: %v", args)
+	}
+	if args[len(args)-1] != "-" {
+		t.Errorf("промпт должен передаваться через stdin sentinel '-', got %v", args)
+	}
+}
+
+func TestCodexCommandRejectsGuessedCli(t *testing.T) {
+	a := &CodexAdapter{}
+	if _, err := a.Command("/usr/bin/opencode", Launch{}, "/tmp/prompt.md"); err == nil {
+		t.Fatal("cli, не являющийся codex, должен отклоняться fail-closed")
+	}
+}
+
+func TestCodexCommandRejectsInvalidEffort(t *testing.T) {
+	a := &CodexAdapter{}
+	if _, err := a.Command("codex", Launch{Effort: "extreme"}, "/tmp/prompt.md"); err == nil {
+		t.Fatal("недопустимый effort должен отклоняться")
+	}
+}
+
+func TestCodexParseUsageLastTurnWins(t *testing.T) {
+	a := &CodexAdapter{}
+	stream := strings.Join([]string{
+		`{"type":"thread.started","thread_id":"t1"}`,
+		`{"type":"turn.started"}`,
+		`{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"hi"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":50,"output_tokens":30,"reasoning_output_tokens":5}}`,
+		`{"type":"turn.started"}`,
+		`{"type":"turn.completed","usage":{"input_tokens":200,"cached_input_tokens":60,"output_tokens":40,"reasoning_output_tokens":7}}`,
+	}, "\n")
+	usage, err := a.ParseUsage(strings.NewReader(stream))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.TokensInput != 260 || usage.TokensOutput != 40 {
+		t.Errorf("usage = %+v, want input=260 output=40 (последний turn)", usage)
+	}
+	if !usage.Attested {
+		t.Error("codex usage должен быть attested (токены из JSONL харнесса)")
+	}
+	if usage.CostUSD != 0 {
+		t.Errorf("codex не сообщает cost — он не должен заполняться, got %v", usage.CostUSD)
+	}
+}
+
+func TestCodexParseUsageMissingTurnFails(t *testing.T) {
+	a := &CodexAdapter{}
+	if _, err := a.ParseUsage(strings.NewReader(`{"type":"thread.started","thread_id":"t1"}\n`)); err == nil {
+		t.Fatal("отсутствие turn.completed с usage должно быть ошибкой")
+	}
+}
+
+func TestCodexClassifyErrorTaxonomy(t *testing.T) {
+	a := &CodexAdapter{}
+	for output, want := range map[string]CodexErrorCategory{
+		"error: invalid_api_key":                     CodexErrorAuth,
+		"Authentication failed: 403":                 CodexErrorAuth,
+		"model not found: gpt-5":                     CodexErrorModel,
+		"validation error: model does not exist":     CodexErrorModel,
+		"failed to parse config.toml: unknown field": CodexErrorConfig,
+		"connection timed out to api.openai.com":     CodexErrorNetwork,
+		"503 service unavailable":                    CodexErrorNetwork,
+		"blocked by sandbox policy":                  CodexErrorSandbox,
+		"permission denied: /etc/hosts":              CodexErrorSandbox,
+		"something totally unexpected":               CodexErrorUnknown,
+	} {
+		t.Run(string(want)+":"+output, func(t *testing.T) {
+			err := a.ClassifyError(output)
+			runErr, ok := err.(*CodexRunError)
+			if !ok {
+				t.Fatalf("ожидали *CodexRunError, got %T", err)
+			}
+			if runErr.Category != want {
+				t.Errorf("Category = %q, want %q", runErr.Category, want)
+			}
+		})
+	}
+}
+
+func TestCodexValidateFailClosedOnUnrequestedGapIsSafe(t *testing.T) {
+	a := &CodexAdapter{}
+	if err := a.Validate(Launch{Model: "gpt-5", Effort: "high", RequireIsolation: true}); err != nil {
+		t.Fatalf("codex декларирует все capabilities этого запроса: %v", err)
+	}
+	if err := ValidateLaunchWith(a, Launch{RequireIsolation: true}, []Capability{CapModelSelection}); err != nil {
+		t.Fatalf("CapModelSelection декларирован: %v", err)
+	}
+}
+
+func TestCodexEnvironmentIsolatesConfigAndCreds(t *testing.T) {
+	a := &CodexAdapter{}
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("HOME", "/tmp/home")
+	t.Setenv("SECRET_PARENT_TOKEN", "top-secret")
+	t.Setenv("CODEX_API_KEY", "sk-visible")
+	t.Setenv(HarnessEnvAllowVar, "CODEX_API_KEY")
+
+	target := t.TempDir()
+	env, cleanup, err := a.Environment(&Agent{Name: "coder"}, &Task{TargetDir: target, ArtifactRoot: filepath.Join(target, "artifacts"), Feature: "f"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	merged := strings.Join(env, "\n")
+	if strings.Contains(merged, "SECRET_PARENT_TOKEN") {
+		t.Fatal("секрет родительского env не должен попадать в субпроцесс без opt-in")
+	}
+	if !strings.Contains(merged, "CODEX_API_KEY=sk-visible") {
+		t.Fatal("CODEX_API_KEY, разрешённая через AI_TEAM_HARNESS_ENV_ALLOW, должна присутствовать")
+	}
+	codexHome := ""
+	for _, line := range env {
+		if strings.HasPrefix(line, "CODEX_HOME=") {
+			codexHome = strings.TrimPrefix(line, "CODEX_HOME=")
+		}
+	}
+	if codexHome == "" {
+		t.Fatal("CODEX_HOME должен быть перенаправлен во временный каталог")
+	}
+	if info, err := os.Stat(codexHome); err != nil || info.Mode().Perm() != 0700 {
+		t.Fatalf("CODEX_HOME должен существовать с 0700: err=%v perm=%v", err, info)
+	}
+	config, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(config), `approval_policy = "never"`) || !strings.Contains(string(config), `sandbox_mode = "workspace-write"`) {
+		t.Errorf("config.toml должен фиксировать zero-approval + workspace-write: %s", config)
+	}
+}
+
+func TestCodexEnvironmentRejectsProjectConfigSurface(t *testing.T) {
+	a := &CodexAdapter{}
+	target := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(target, ".codex"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, ".codex", "config.toml"), []byte("model = \"x\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := a.Environment(&Agent{Name: "coder"}, &Task{TargetDir: target, ArtifactRoot: filepath.Join(target, "artifacts"), Feature: "f"}); err == nil {
+		t.Fatal("project .codex/config.toml должен блокировать запуск (execution surface)")
+	}
+}
+
+func TestAgentCLIRuntimeFeedsPromptViaStdin(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(bin, 0755); err != nil {
+		t.Fatal(err)
+	}
+	outPath := filepath.Join(dir, "stdin-capture.md")
+	script := "#!/bin/sh\ncat > \"$AI_TEAM_STDIN_CAPTURE\"\n"
+	mock := filepath.Join(bin, "codex")
+	if err := os.WriteFile(mock, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AI_TEAM_STDIN_CAPTURE", outPath)
+	t.Setenv(HarnessEnvAllowVar, "AI_TEAM_STDIN_CAPTURE")
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	target := filepath.Join(dir, "target")
+	if err := os.MkdirAll(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &AgentCLIRuntime{}
+	agent := &Agent{Name: "t", RuntimeType: "agentcli", CLI: mock, Prompt: "тестовый промпт", Mutation: "tests", AllowedPaths: []string{"**/*.go"}}
+	task := &Task{Feature: "f", TaskDesc: "задача", TargetDir: target, ArtifactRoot: filepath.Join(target, "artifacts")}
+	if err := runtime.Execute(t.Context(), agent, task, nil); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "тестовый промпт") || !strings.Contains(content, "## Фича") {
+		t.Errorf("prompt должен уходить в stdin codex (exec -), got: %q", content)
+	}
+}

--- a/pkg/runtime/opencode.go
+++ b/pkg/runtime/opencode.go
@@ -38,13 +38,13 @@ func (a *OpenCodeAdapter) Validate(launch Launch) error {
 
 // Command — документированный argv OpenCode CLI. Большой промпт прикрепляется
 // файлом (0600), избегая ARG_MAX и случайного продолжения прежней сессии.
-func (a *OpenCodeAdapter) Command(cli, model, promptFile string) ([]string, error) {
+func (a *OpenCodeAdapter) Command(cli string, launch Launch, promptFile string) ([]string, error) {
 	if filepath.Base(cli) != a.Name() {
 		return nil, fmt.Errorf("CLI %q не поддерживается адаптером opencode: требуется явный adapter вместо guessed arguments", cli)
 	}
 	args := []string{"run"}
-	if model != "" && model != "auto" {
-		args = append(args, "-m", model)
+	if launch.Model != "" && launch.Model != "auto" {
+		args = append(args, "-m", launch.Model)
 	}
 	args = append(args, "--file", promptFile, "Выполни все инструкции из прикреплённого workflow-файла.")
 	return args, nil
@@ -193,21 +193,24 @@ var baselineOpenCodeEnvironmentKeys = []string{
 }
 
 // allowedEnvironmentKeys returns the set of environment variable names
-// permitted to reach the opencode subprocess: the fixed baseline above, plus
-// any names the project or user explicitly opts in via
+// permitted to reach a harness subprocess: the fixed baseline above, plus
+// any names the project or user explicitly opts in via either
+// AI_TEAM_HARNESS_ENV_ALLOW (canonical) or the legacy
 // AI_TEAM_OPENCODE_ENV_ALLOW (comma-separated). This replaces passing the
 // full parent environment minus a short deny-list: by default nothing beyond
 // standard OS/locale plumbing crosses into the subprocess, and any provider
-// credential (e.g. an LLM API key opencode itself needs to authenticate)
-// must be named explicitly rather than leaking implicitly.
+// credential (e.g. an LLM API key opencode/codex itself needs to
+// authenticate) must be named explicitly rather than leaking implicitly.
 func allowedEnvironmentKeys() map[string]bool {
 	allowed := make(map[string]bool, len(baselineOpenCodeEnvironmentKeys))
 	for _, key := range baselineOpenCodeEnvironmentKeys {
 		allowed[key] = true
 	}
-	for _, extra := range strings.Split(os.Getenv("AI_TEAM_OPENCODE_ENV_ALLOW"), ",") {
-		if key := strings.TrimSpace(extra); key != "" {
-			allowed[key] = true
+	for _, raw := range []string{os.Getenv(HarnessEnvAllowVar), os.Getenv(HarnessEnvAllowLegacyVar)} {
+		for _, extra := range strings.Split(raw, ",") {
+			if key := strings.TrimSpace(extra); key != "" {
+				allowed[key] = true
+			}
 		}
 	}
 	return allowed
@@ -226,9 +229,16 @@ func withAllowedEnvironmentKeys(environment []string, allowed map[string]bool) [
 	return filtered
 }
 
-// EnvAllowVar — инструмент явного opt-in для проброса переменных окружения
-// в opencode-субпроцесс (список имён через запятую).
+// HarnessEnvAllowVar — инструмент явного opt-in для проброса переменных
+// окружения в harness-субпроцесс (список имён через запятую). Каноническое
+// имя для всех адаптеров.
+const HarnessEnvAllowVar = "AI_TEAM_HARNESS_ENV_ALLOW"
+
+// EnvAllowVar — устаревшее имя AI_TEAM_OPENCODE_ENV_ALLOW; сохраняется как
+// алиас для обратной совместимости.
 const EnvAllowVar = "AI_TEAM_OPENCODE_ENV_ALLOW"
+
+const HarnessEnvAllowLegacyVar = EnvAllowVar
 
 // LookPath проверяет доступность бинарника харнесса в PATH.
 func (a *OpenCodeAdapter) LookPath(cli string) error {


### PR DESCRIPTION
Stack: base = `p1-1-runtime-adapter-contract` (#46).

**ADP-1** — адаптер Codex поверх `codex exec`, launch-carrying `Command` contract.

Дифф этого PR — только ADP-1 (Codex-адаптер).