### PR TITLE
feat(runtime): Claude Code adapter over claude -p, JSON usage and deny-list policy (ADP-2)

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -310,8 +310,8 @@ func TestValidate(t *testing.T) {
 	}{
 		{"empty pipeline", &Config{}},
 		{"bad effort", &Config{SchemaVersion: 4, PipelineAgents: []AgentConfig{{Name: "a", Effort: "max"}}}},
-		{"bad global cli", &Config{SchemaVersion: 4, CLI: "claude", PipelineAgents: []AgentConfig{{Name: "a"}}}},
-		{"bad agent cli", &Config{SchemaVersion: 4, PipelineAgents: []AgentConfig{{Name: "a", CLI: "claude"}}}},
+		{"bad global cli", &Config{SchemaVersion: 4, CLI: "nonexistent-cli", PipelineAgents: []AgentConfig{{Name: "a"}}}},
+		{"bad agent cli", &Config{SchemaVersion: 4, PipelineAgents: []AgentConfig{{Name: "a", CLI: "nonexistent-cli"}}}},
 		{"bad timeout", &Config{SchemaVersion: 4, PipelineAgents: []AgentConfig{{Name: "a", Timeout: "30 minutes"}}}},
 		{"bad stage_timeout", &Config{SchemaVersion: 4, PipelineAgents: []AgentConfig{{Name: "a"}}, StageTimeout: "later"}},
 		{"unsupported schema", &Config{SchemaVersion: 99, PipelineAgents: []AgentConfig{{Name: "a"}}}},

--- a/pkg/runtime/claude.go
+++ b/pkg/runtime/claude.go
@@ -1,0 +1,267 @@
+package runtime
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ClaudeAdapter — реализация RuntimeAdapter для Claude Code (print mode).
+// Печать JSON-результата, --effort, deny-list инструментов и изоляция
+// CLAUDE_CONFIG_DIR локализованы здесь.
+//
+// Промпт подаётся через stdin: argv `claude -p` без аргументов-промпта при
+// piped stdin берёт промпт целиком из stdin (оркестратор направляет файл
+// промпта в cmd.Stdin). Один -p прогон — одна headless session без
+// интерактивных permission-промптов.
+//
+// Политика изоляции: permission-mode acceptEdits (автоприём file edits),
+// deny-list эффектных инструментов (Bash/WebFetch/WebSearch/Task/Skill/...),
+// path-deny для секретов (~/.ssh, ~/.aws, *.env), CLAUDE_CONFIG_DIR —
+// временный каталог 0700 (user settings/history не загружаются), env —
+// allow-лист. Результат парсится как JSON result c total_cost_usd (client-side
+// оценка харнесса, attest только этого источника) и usage-tokens.
+type ClaudeAdapter struct{}
+
+func (a *ClaudeAdapter) Name() string { return "claude" }
+
+func (a *ClaudeAdapter) Describe() Descriptor {
+	return Descriptor{
+		Name:   a.Name(),
+		Binary: "claude",
+		Capabilities: []Capability{
+			CapModelSelection,
+			CapEffortMapping,
+			CapPromptFile,
+			CapSessionIsolation,
+			CapUsageReported,
+		},
+	}
+}
+
+// Validate — fail-closed: запрос capability, отсутствующей у claude,
+// блокирует запуск (см. ValidateLaunch).
+func (a *ClaudeAdapter) Validate(launch Launch) error {
+	return ValidateLaunch(a, launch)
+}
+
+// Command — argv headless-запуска: print-режим, JSON-результат, acceptEdits,
+// deny-list эффектных инструментов, явные model/effort.
+func (a *ClaudeAdapter) Command(cli string, launch Launch, promptFile string) ([]string, error) {
+	if filepath.Base(cli) != a.Name() {
+		return nil, fmt.Errorf("CLI %q не поддерживается адаптером claude: требуется явный adapter вместо guessed arguments", cli)
+	}
+	args := []string{
+		"-p",
+		"--output-format", "json",
+		"--permission-mode", "acceptEdits",
+		"--disallowedTools", "Bash,PowerShell,WebFetch,WebSearch,Task,Agent,Skill,LSP,NotebookEdit",
+	}
+	if launch.Model != "" && launch.Model != "auto" {
+		args = append(args, "--model", launch.Model)
+	}
+	if launch.Effort != "" {
+		if !validClaudeEffort(launch.Effort) {
+			return nil, fmt.Errorf("claude: недопустимый effort %q (low|medium|high)", launch.Effort)
+		}
+		args = append(args, "--effort", launch.Effort)
+	}
+	return args, nil
+}
+
+func validClaudeEffort(effort string) bool {
+	switch effort {
+	case "low", "medium", "high":
+		return true
+	}
+	return false
+}
+
+// claudeDenyTools — deny-list инструментов, зеркалящий opencode permission
+// (запрет эффектных/неинспектируемых инструментов: shell, web, subagents,
+// skills, LSP). Записи в settings.permissions.deny дублируются в argv
+// --disallowedTools (приоритет — merge deny).
+const claudeDisallowedTools = "Bash,PowerShell,WebFetch,WebSearch,Task,Agent,Skill,LSP,NotebookEdit"
+
+// claudeSettingsJSON — session policy, записываемая в изолированный
+// CLAUDE_CONFIG_DIR: path-deny секретов и служебных каталогов плюс
+// permission-mode.
+const claudeSettingsJSON = `{
+  "permissionMode": "acceptEdits",
+  "disallowedTools": ["Bash", "PowerShell", "WebFetch", "WebSearch", "Task", "Agent", "Skill", "LSP", "NotebookEdit"],
+  "permissions": {
+    "allow": ["Read", "Edit", "Write", "Glob", "Grep"],
+    "deny": [
+      "Bash(**)", "PowerShell(**)", "WebFetch(**)", "WebSearch", "Task(**)", "Agent(**)", "Skill(**)", "LSP(*)",
+      "Read(~/.ssh/**)", "Read(~/.aws/**)", "Read(**/.env)", "Read(**/.env.*)",
+      "Read(.env)", "Read(.env.*)", "Read(**/.git/**)", "Read(.git/**)",
+      "Edit(**/.git/**)", "Edit(.git/**)", "Edit(**/.ai-team/**)", "Edit(.ai-team/**)"
+    ]
+  }
+}
+`
+
+// Environment — изоляция claude-сессии: project execution surface guard,
+// CLAUDE_CONFIG_DIR во временном каталоге (0700) с session-policy, allow-list
+// env субпроцесса.
+func (a *ClaudeAdapter) Environment(agent *Agent, task *Task, inputs ...Artifact) ([]string, func(), error) {
+	for _, relative := range []string{filepath.Join(".claude", "settings.json")} {
+		if info, err := os.Lstat(filepath.Join(task.TargetDir, relative)); err == nil && (info.IsDir() || info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
+			return nil, func() {}, fmt.Errorf("project execution surface %s запрещена; project settings входят в trusted controller, а не в agent runtime", relative)
+		} else if err != nil && !os.IsNotExist(err) {
+			return nil, func() {}, fmt.Errorf("проверка %s: %w", relative, err)
+		}
+	}
+
+	configDir, err := os.MkdirTemp("", "ai-team-claude-config-*")
+	if err != nil {
+		return nil, func() {}, err
+	}
+	if err := os.Chmod(configDir, 0700); err != nil {
+		_ = os.RemoveAll(configDir)
+		return nil, func() {}, err
+	}
+	cleanup := func() { _ = os.RemoveAll(configDir) }
+
+	settingsPath := filepath.Join(configDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(claudeSettingsJSON), 0600); err != nil {
+		cleanup()
+		return nil, func() {}, err
+	}
+
+	env := withAllowedEnvironmentKeys(os.Environ(), allowedEnvironmentKeys())
+	env = append(env, "CLAUDE_CONFIG_DIR="+configDir)
+	sort.Strings(env)
+	return env, cleanup, nil
+}
+
+// claudeResultLine — JSON result, который печатает `claude -p
+// --output-format json` (последняя строка stdout).
+type claudeResultLine struct {
+	Type         string   `json:"type"`
+	Subtype      string   `json:"subtype"`
+	IsError      bool     `json:"is_error"`
+	TotalCostUSD *float64 `json:"total_cost_usd"`
+	Usage        *struct {
+		InputTokens              int64 `json:"input_tokens"`
+		CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+		OutputTokens             int64 `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+func lastClaudeResult(reader io.Reader) (*claudeResultLine, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), 4<<20)
+	var result *claudeResultLine
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var parsed claudeResultLine
+		if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+			continue
+		}
+		if parsed.Type == "result" {
+			result = &parsed
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, fmt.Errorf("claude: result JSON не найден в stdout (проверь --output-format json)")
+	}
+	return result, nil
+}
+
+// ParseUsage — типизированный разбор usage из JSON-результата claude.
+// Tokens и total_cost_usd берутся из харнесса (CostUSD — client-side оценка,
+// поле Attested=true фиксирует именно этот источник аттестации).
+func (a *ClaudeAdapter) ParseUsage(reader io.Reader) (*Usage, error) {
+	result, err := lastClaudeResult(reader)
+	if err != nil {
+		return nil, err
+	}
+	usage := &Usage{Currency: "USD", Attested: true}
+	if result.Usage != nil {
+		usage.TokensInput = result.Usage.InputTokens + result.Usage.CacheCreationInputTokens + result.Usage.CacheReadInputTokens
+		usage.TokensOutput = result.Usage.OutputTokens
+	}
+	if result.TotalCostUSD != nil {
+		usage.CostUSD = *result.TotalCostUSD
+	}
+	return usage, nil
+}
+
+// ClassifyError — таксономия ошибок claude-запуска на основе захваченного
+// вывода (включая subtype JSON-результата). Вызывается оркестратором
+// опционально (см. Execute).
+func (a *ClaudeAdapter) ClassifyError(output string) error {
+	if result, err := lastClaudeResult(strings.NewReader(output)); err == nil {
+		if result.IsError {
+			switch {
+			case strings.Contains(result.Subtype, "budget"):
+				return &ClaudeRunError{Category: ClaudeErrorBudget, Detail: fmt.Sprintf("claude остановлен по бюджету (%s)", result.Subtype)}
+			case strings.Contains(result.Subtype, "turns"):
+				return &ClaudeRunError{Category: ClaudeErrorTimeout, Detail: fmt.Sprintf("claude исчерпал лимит шагов (%s)", result.Subtype)}
+			case strings.Contains(result.Subtype, "permission"):
+				return &ClaudeRunError{Category: ClaudeErrorPermission, Detail: fmt.Sprintf("действие отклонено политикой permissions (%s)", result.Subtype)}
+			case strings.Contains(result.Subtype, "execution"):
+				return &ClaudeRunError{Category: ClaudeErrorRuntime, Detail: fmt.Sprintf("claude прерван во время исполнения (%s)", result.Subtype)}
+			}
+		}
+	}
+	lower := strings.ToLower(output)
+	switch {
+	case containsAny(lower,
+		"authentication", "authorization", "api key", "invalid key", "401", "403"):
+		return &ClaudeRunError{Category: ClaudeErrorAuth, Detail: "аутентификация claude недоступна (проверь ANTHROPIC_API_KEY и allow-list окружения)"}
+	case containsAny(lower,
+		"model not found", "unknown model", "model does not exist", "invalid model", "model.does.not.exist"):
+		return &ClaudeRunError{Category: ClaudeErrorModel, Detail: "запрошенная модель недоступна"}
+	case containsAny(lower,
+		"invalid config", "config error", "failed to load settings", "invalid settings", "settings file"):
+		return &ClaudeRunError{Category: ClaudeErrorConfig, Detail: "некорректная конфигурация claude"}
+	case containsAny(lower,
+		"network", "connection", "timed out", "network error", "503", "failed to connect"):
+		return &ClaudeRunError{Category: ClaudeErrorNetwork, Detail: "сетевая ошибка при обращении к Anthropic API"}
+	default:
+		return &ClaudeRunError{Category: ClaudeErrorUnknown, Detail: "claude завершился с ошибкой"}
+	}
+}
+
+// ClaudeErrorCategory — категория сбоя claude-запуска (error taxonomy).
+type ClaudeErrorCategory string
+
+const (
+	ClaudeErrorAuth       ClaudeErrorCategory = "authentication"
+	ClaudeErrorModel      ClaudeErrorCategory = "model"
+	ClaudeErrorConfig     ClaudeErrorCategory = "configuration"
+	ClaudeErrorNetwork    ClaudeErrorCategory = "network"
+	ClaudeErrorBudget     ClaudeErrorCategory = "budget"
+	ClaudeErrorTimeout    ClaudeErrorCategory = "timeout"
+	ClaudeErrorPermission ClaudeErrorCategory = "permission"
+	ClaudeErrorRuntime    ClaudeErrorCategory = "runtime"
+	ClaudeErrorUnknown    ClaudeErrorCategory = "unknown"
+)
+
+// ClaudeRunError — типизированная ошибка запуска claude.
+type ClaudeRunError struct {
+	Category ClaudeErrorCategory
+	Detail   string
+}
+
+func (e *ClaudeRunError) Error() string {
+	return fmt.Sprintf("claude-%s: %s", e.Category, e.Detail)
+}
+
+func init() {
+	RegisterAdapter(&ClaudeAdapter{})
+}

--- a/pkg/runtime/claude.go
+++ b/pkg/runtime/claude.go
@@ -41,6 +41,7 @@ func (a *ClaudeAdapter) Describe() Descriptor {
 			CapSessionIsolation,
 			CapUsageReported,
 		},
+		PromptViaStdin: true,
 	}
 }
 
@@ -100,7 +101,9 @@ const claudeSettingsJSON = `{
       "Bash(**)", "PowerShell(**)", "WebFetch(**)", "WebSearch", "Task(**)", "Agent(**)", "Skill(**)", "LSP(*)",
       "Read(~/.ssh/**)", "Read(~/.aws/**)", "Read(**/.env)", "Read(**/.env.*)",
       "Read(.env)", "Read(.env.*)", "Read(**/.git/**)", "Read(.git/**)",
-      "Edit(**/.git/**)", "Edit(.git/**)", "Edit(**/.ai-team/**)", "Edit(.ai-team/**)"
+      "Edit(**/.git/**)", "Edit(.git/**)", "Edit(**/.ai-team/**)", "Edit(.ai-team/**)",
+      "Edit(//**)", "Write(//**)",
+      "Edit(~/**)", "Write(~/**)"
     ]
   }
 }
@@ -191,7 +194,8 @@ func (a *ClaudeAdapter) ParseUsage(reader io.Reader) (*Usage, error) {
 	}
 	usage := &Usage{Currency: "USD", Attested: true}
 	if result.Usage != nil {
-		usage.TokensInput = result.Usage.InputTokens + result.Usage.CacheCreationInputTokens + result.Usage.CacheReadInputTokens
+		usage.TokensInput = result.Usage.InputTokens
+		usage.CachedInputTokens = result.Usage.CacheCreationInputTokens + result.Usage.CacheReadInputTokens
 		usage.TokensOutput = result.Usage.OutputTokens
 	}
 	if result.TotalCostUSD != nil {

--- a/pkg/runtime/claude_test.go
+++ b/pkg/runtime/claude_test.go
@@ -80,8 +80,11 @@ func TestClaudeParseUsageTokensAndCost(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if usage.TokensInput != 1150 || usage.TokensOutput != 2000 {
-		t.Errorf("usage = %+v, want input=1150 output=2000", usage)
+	if usage.TokensInput != 1000 || usage.TokensOutput != 2000 {
+		t.Errorf("usage = %+v, want input=1000 output=2000", usage)
+	}
+	if usage.CachedInputTokens != 150 {
+		t.Errorf("CachedInputTokens = %d, want 150 (не суммируется с TokensInput)", usage.CachedInputTokens)
 	}
 	if usage.CostUSD != 0.42 || usage.Currency != "USD" {
 		t.Errorf("cost = %v %s, want 0.42 USD", usage.CostUSD, usage.Currency)

--- a/pkg/runtime/claude_test.go
+++ b/pkg/runtime/claude_test.go
@@ -1,0 +1,240 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestClaudeAdapterRegistered(t *testing.T) {
+	adapter, err := Adapter("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adapter.Name() != "claude" {
+		t.Errorf("expected claude, got %s", adapter.Name())
+	}
+}
+
+func TestClaudeDescribeDeclaresContractCapabilities(t *testing.T) {
+	adapter, _ := Adapter("claude")
+	declared := make(map[Capability]bool)
+	for _, capability := range adapter.Describe().Capabilities {
+		declared[capability] = true
+	}
+	for _, capability := range []Capability{
+		CapModelSelection, CapEffortMapping, CapPromptFile, CapSessionIsolation, CapUsageReported,
+	} {
+		if !declared[capability] {
+			t.Errorf("claude должен декларировать capability %q", capability)
+		}
+	}
+}
+
+func TestClaudeCommandProducesHeadlessArgs(t *testing.T) {
+	a := &ClaudeAdapter{}
+	args, err := a.Command("claude", Launch{Model: "claude-opus-4-6", Effort: "high", RequireIsolation: true}, "/tmp/prompt.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(args, " ")
+	if !strings.Contains(got, "-p") ||
+		!strings.Contains(got, "--output-format json") ||
+		!strings.Contains(got, "--permission-mode acceptEdits") ||
+		!strings.Contains(got, "--disallowedTools") ||
+		!strings.Contains(got, "--model claude-opus-4-6") ||
+		!strings.Contains(got, "--effort high") {
+		t.Errorf("argv = %q не содержит headless/permission/model/effort контракт", got)
+	}
+	if !strings.Contains(got, "Bash") {
+		t.Errorf("deny-list инструментов должен включать Bash: %q", got)
+	}
+}
+
+func TestClaudeCommandNoModelNoEffort(t *testing.T) {
+	a := &ClaudeAdapter{}
+	args, err := a.Command("claude", Launch{RequireIsolation: true}, "/tmp/prompt.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.Join(args, " "), "--model") || strings.Contains(strings.Join(args, " "), "--effort") {
+		t.Errorf("без model/effort argv не должен содержать эти флаги: %v", args)
+	}
+}
+
+func TestClaudeCommandRejectsGuessedCliAndInvalidEffort(t *testing.T) {
+	a := &ClaudeAdapter{}
+	if _, err := a.Command("codex", Launch{}, "/tmp/prompt.md"); err == nil {
+		t.Fatal("cli, не являющийся claude, должен отклоняться fail-closed")
+	}
+	if _, err := a.Command("claude", Launch{Effort: "xhigh"}, "/tmp/prompt.md"); err == nil {
+		t.Fatal("effort вне контракта low/medium/high должен отклоняться")
+	}
+}
+
+func TestClaudeParseUsageTokensAndCost(t *testing.T) {
+	a := &ClaudeAdapter{}
+	sample := `{"type":"result","subtype":"success","result":"ok","is_error":false,"total_cost_usd":0.42,"usage":{"input_tokens":1000,"cache_creation_input_tokens":100,"cache_read_input_tokens":50,"output_tokens":2000},"session_id":"s1"}`
+	usage, err := a.ParseUsage(strings.NewReader(sample))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.TokensInput != 1150 || usage.TokensOutput != 2000 {
+		t.Errorf("usage = %+v, want input=1150 output=2000", usage)
+	}
+	if usage.CostUSD != 0.42 || usage.Currency != "USD" {
+		t.Errorf("cost = %v %s, want 0.42 USD", usage.CostUSD, usage.Currency)
+	}
+	if !usage.Attested {
+		t.Error("claude usage должен быть attested (поля из JSON-результата харнесса)")
+	}
+}
+
+func TestClaudeParseUsageMissingResultFails(t *testing.T) {
+	a := &ClaudeAdapter{}
+	if _, err := a.ParseUsage(strings.NewReader("просто текст, не JSON\n")); err == nil {
+		t.Fatal("отсутствие result JSON должно быть ошибкой")
+	}
+}
+
+func TestClaudeClassifyErrorTaxonomyFromSubtype(t *testing.T) {
+	a := &ClaudeAdapter{}
+	for subtype, want := range map[string]ClaudeErrorCategory{
+		"error_max_budget_usd":                 ClaudeErrorBudget,
+		"error_max_turns":                      ClaudeErrorTimeout,
+		"error_during_execution_no_permission": ClaudeErrorPermission,
+		"error_during_execution":               ClaudeErrorRuntime,
+	} {
+		t.Run(subtype, func(t *testing.T) {
+			output := `{"type":"result","subtype":"` + subtype + `","is_error":true,"result":""}`
+			err := a.ClassifyError(output)
+			runErr, ok := err.(*ClaudeRunError)
+			if !ok {
+				t.Fatalf("ожидали *ClaudeRunError, got %T", err)
+			}
+			if runErr.Category != want {
+				t.Errorf("Category = %q, want %q", runErr.Category, want)
+			}
+		})
+	}
+}
+
+func TestClaudeClassifyErrorStringHeuristics(t *testing.T) {
+	a := &ClaudeAdapter{}
+	for output, want := range map[string]ClaudeErrorCategory{
+		"Authentication: invalid api key": ClaudeErrorAuth,
+		"error 403 from api":              ClaudeErrorAuth,
+		"model not found: claude-opus-4":  ClaudeErrorModel,
+		"failed to load settings.json":    ClaudeErrorConfig,
+		"network error while streaming":   ClaudeErrorNetwork,
+		"случилось что-то совсем иное":    ClaudeErrorUnknown,
+	} {
+		t.Run(string(want)+":"+output, func(t *testing.T) {
+			err := a.ClassifyError(output)
+			runErr, ok := err.(*ClaudeRunError)
+			if !ok {
+				t.Fatalf("ожидали *ClaudeRunError, got %T", err)
+			}
+			if runErr.Category != want {
+				t.Errorf("Category = %q, want %q", runErr.Category, want)
+			}
+		})
+	}
+}
+
+func TestClaudeEnvironmentIsolatesConfigAndCreds(t *testing.T) {
+	a := &ClaudeAdapter{}
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("HOME", "/tmp/home")
+	t.Setenv("SECRET_PARENT_TOKEN", "top-secret")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-visible")
+	t.Setenv(HarnessEnvAllowVar, "ANTHROPIC_API_KEY")
+
+	target := t.TempDir()
+	env, cleanup, err := a.Environment(&Agent{Name: "coder"}, &Task{TargetDir: target, ArtifactRoot: filepath.Join(target, "artifacts"), Feature: "f"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	merged := strings.Join(env, "\n")
+	if strings.Contains(merged, "SECRET_PARENT_TOKEN") {
+		t.Fatal("секрет родительского env не должен попадать в субпроцесс без opt-in")
+	}
+	if !strings.Contains(merged, "ANTHROPIC_API_KEY=sk-ant-visible") {
+		t.Fatal("ANTHROPIC_API_KEY, разрешённая через AI_TEAM_HARNESS_ENV_ALLOW, должна присутствовать")
+	}
+	configDir := ""
+	for _, line := range env {
+		if strings.HasPrefix(line, "CLAUDE_CONFIG_DIR=") {
+			configDir = strings.TrimPrefix(line, "CLAUDE_CONFIG_DIR=")
+		}
+	}
+	if configDir == "" {
+		t.Fatal("CLAUDE_CONFIG_DIR должен быть перенаправлен во временный каталог")
+	}
+	if info, err := os.Stat(configDir); err != nil || info.Mode().Perm() != 0700 {
+		t.Fatalf("CLAUDE_CONFIG_DIR должен существовать с 0700: err=%v perm=%v", err, info)
+	}
+	settings, err := os.ReadFile(filepath.Join(configDir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(settings)
+	for _, needled := range []string{"permissionMode", "acceptEdits", "disallowedTools", "Read(~/.ssh/**)", "**/.env"} {
+		if !strings.Contains(content, needled) {
+			t.Errorf("settings.json должен содержать %q: %s", needled, content)
+		}
+	}
+}
+
+func TestClaudeEnvironmentRejectsProjectSettingsSurface(t *testing.T) {
+	a := &ClaudeAdapter{}
+	target := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(target, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, ".claude", "settings.json"), []byte(`{"model":"x"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := a.Environment(&Agent{Name: "coder"}, &Task{TargetDir: target, ArtifactRoot: filepath.Join(target, "artifacts"), Feature: "f"}); err == nil {
+		t.Fatal("project .claude/settings.json должен блокировать запуск (execution surface)")
+	}
+}
+
+func TestClaudeStdinPromptWiringThroughOrchestrator(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(bin, 0755); err != nil {
+		t.Fatal(err)
+	}
+	outPath := filepath.Join(dir, "stdin-capture.md")
+	script := "#!/bin/sh\ncat > \"$AI_TEAM_CLAUDE_STDIN_CAPTURE\"\n"
+	mock := filepath.Join(bin, "claude")
+	if err := os.WriteFile(mock, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AI_TEAM_CLAUDE_STDIN_CAPTURE", outPath)
+	t.Setenv(HarnessEnvAllowVar, "AI_TEAM_CLAUDE_STDIN_CAPTURE")
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	target := filepath.Join(dir, "target")
+	if err := os.MkdirAll(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &AgentCLIRuntime{}
+	agent := &Agent{Name: "t", RuntimeType: "agentcli", CLI: mock, Prompt: "тестовый промпт claude", Mutation: "tests", AllowedPaths: []string{"**/*.go"}}
+	task := &Task{Feature: "f", TaskDesc: "задача", TargetDir: target, ArtifactRoot: filepath.Join(target, "artifacts")}
+	if err := runtime.Execute(t.Context(), agent, task, nil); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "тестовый промпт claude") || !strings.Contains(content, "## Служебные требования") {
+		t.Errorf("prompt должен уходить в stdin claude -p, got: %q", content)
+	}
+}


### PR DESCRIPTION
Stack: base = `adp-1-codex-adapter` (#47).

**ADP-2** — адаптер Claude Code поверх `claude -p`, JSON usage и deny-list policy.

Дифф — только ADP-2 (плюс статус-chore).