### PR TITLE
feat: fail-closed export guard for --prune-runs until portable export (V0-0)

### DIFF
--- a/cmd/ai-team/main.go
+++ b/cmd/ai-team/main.go
@@ -117,7 +117,9 @@ func printUsage() {
   --older-than <duration>   Возраст terminal-ранов для уборки state (по умолчанию 720h)
   --keep-last <n>           Защитить n самых свежих terminal-ранов (по умолчанию 20)
   --dry-run                 Только показать план: что удалится и сколько байт
-  --prune-runs              Разрешить удаление immutable run evidence (.ai-team/runs)
+  --prune-runs              Разрешить удаление immutable run evidence (.ai-team/runs),
+                            но только для run с verified-записью state/exports (V0-4 guard;
+                            пока нет экспорта — флаг безопасно не удаляет evidence)
 
 Флаги run:
   --feature <name>          Имя фичи (буквы, цифры, "-", "_", ".")

--- a/pkg/retention/export.go
+++ b/pkg/retention/export.go
@@ -60,9 +60,9 @@ func (p *planner) loadVerifiedExports() error {
 			continue
 		}
 		runID := strings.TrimSuffix(name, ".json")
-		if record.RunID != runID || record.SchemaVersion != ExportSchema || !record.Verified {
+		if record.RunID != runID || record.SchemaVersion != ExportSchema || !record.Verified || record.BundleSHA256 == "" {
 			p.plan.Skipped = append(p.plan.Skipped, Skipped{
-				Path: path, Reason: "export-запись не verified или не соответствует run_id",
+				Path: path, Reason: "export-запись не verified, не соответствует run_id или bundle_sha256 пуст",
 			})
 			continue
 		}

--- a/pkg/retention/export.go
+++ b/pkg/retention/export.go
@@ -1,0 +1,84 @@
+package retention
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/arturpanteleev/ai-team/pkg/safeio"
+)
+
+// ExportSchema — версия контракта «проверенного экспорта» (state/exports
+// записи), создаваемого и проверяемого V0-4.
+const ExportSchema = 1
+
+// ExportRecord — отметка в state/exports/<runID>.json о том, что immutable
+// evidence run сформирована в проверенный portable bundle (V0-4). Только run,
+// присутствующие в state/exports с verified=true, могут быть pruned; запись
+// создаётся контроллером после того, как bundle прошёл полную проверку.
+//
+// V0-0: guard fail-closed — пока не существует корректной verified-записи,
+// --prune-runs не имеет права удалять evidence даже при включённом флаге.
+type ExportRecord struct {
+	SchemaVersion int       `json:"schema_version"`
+	RunID         string    `json:"run_id"`
+	Verified      bool      `json:"verified"`
+	Bundle        string    `json:"bundle,omitempty"`
+	BundleSHA256  string    `json:"bundle_sha256"`
+	ExportedAt    time.Time `json:"exported_at"`
+}
+
+// loadVerifiedExports читает state/exports и возвращает множество runID,
+// для которых существует полная verified-запись. Fail-closed: damaged,
+// нерасшифрованный, не-verified или non-regular (symlink) файл НЕ засчитывается.
+func (p *planner) loadVerifiedExports() error {
+	root := filepath.Join(p.aiTeam, "state", "exports")
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		path := filepath.Join(root, name)
+		if !strings.HasSuffix(name, ".json") || !entry.Type().IsRegular() {
+			p.plan.Skipped = append(p.plan.Skipped, Skipped{
+				Path: path, Reason: "export-запись должна быть regular JSON-файлом без symlink",
+			})
+			continue
+		}
+		record, err := readExportRecord(path)
+		if err != nil {
+			p.plan.Skipped = append(p.plan.Skipped, Skipped{
+				Path: path, Reason: fmt.Sprintf("нечитаемая payload: %v", err),
+			})
+			continue
+		}
+		runID := strings.TrimSuffix(name, ".json")
+		if record.RunID != runID || record.SchemaVersion != ExportSchema || !record.Verified {
+			p.plan.Skipped = append(p.plan.Skipped, Skipped{
+				Path: path, Reason: "export-запись не verified или не соответствует run_id",
+			})
+			continue
+		}
+		p.exports[runID] = true
+	}
+	return nil
+}
+
+func readExportRecord(path string) (ExportRecord, error) {
+	var record ExportRecord
+	data, err := safeio.ReadRegularFile(path, 1<<20)
+	if err != nil {
+		return record, err
+	}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return record, err
+	}
+	return record, nil
+}

--- a/pkg/retention/retention.go
+++ b/pkg/retention/retention.go
@@ -1,6 +1,8 @@
 // Package retention строит план уборки растущих артефактов .ai-team:
-// candidate worktrees, mutable control state и (только по явному флагу)
-// immutable run evidence.
+// candidate worktrees, mutable control state и (только по явному флагу и
+// только для verified-экспортированных evidence) immutable run records.
+// V0-0 guard: run evidence никогда не удаляется, пока в state/exports нет
+// verified-записи о её portable export (V0-4).
 package retention
 
 import (
@@ -70,6 +72,7 @@ type planner struct {
 	now      time.Time
 	plan     Plan
 	terminal map[string]time.Time
+	exports  map[string]bool
 	keepSet  map[string]bool
 	cutoff   time.Duration
 }
@@ -89,10 +92,14 @@ func Build(options Options) (*Plan, error) {
 		aiTeam:   aiTeam,
 		now:      time.Now().UTC(),
 		terminal: map[string]time.Time{},
+		exports:  map[string]bool{},
 		keepSet:  map[string]bool{},
 		cutoff:   options.OlderThan,
 	}
 	if err := p.loadTerminalRuns(); err != nil {
+		return nil, err
+	}
+	if err := p.loadVerifiedExports(); err != nil {
 		return nil, err
 	}
 	p.markKeepLast()
@@ -300,7 +307,9 @@ func (p *planner) planState() error {
 }
 
 // planRuns: immutable evidence удаляется только когда вызывающий явно
-// включил PruneRuns, раны terminal, старше older-than и вне keep-last.
+// включил PruneRuns, раны terminal, старше older-than, вне keep-last И их
+// portable export проверенно зафиксирован в state/exports (V0-0 guard).
+// Отсутствие verified-export записи — fail-closed: evidence не удаляется.
 func (p *planner) planRuns() error {
 	root := filepath.Join(p.aiTeam, "runs")
 	entries, err := os.ReadDir(root)
@@ -328,6 +337,12 @@ func (p *planner) planRuns() error {
 		if !p.eligibleForAge(runID) {
 			p.plan.Skipped = append(p.plan.Skipped, Skipped{
 				Path: path, Reason: "свежий terminal run (older-than или keep-last)",
+			})
+			continue
+		}
+		if !p.exports[runID] {
+			p.plan.Skipped = append(p.plan.Skipped, Skipped{
+				Path: path, Reason: "evidence не проверенно экспортирована (нет verified-записи в state/exports; V0-4)",
 			})
 			continue
 		}

--- a/pkg/retention/retention_test.go
+++ b/pkg/retention/retention_test.go
@@ -1,8 +1,10 @@
 package retention
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -52,7 +54,7 @@ func newFixture(t *testing.T) *fixture {
 	old := now.Add(-1000 * time.Hour)
 
 	for _, dir := range [][]string{
-		{"state", "runs"}, {"state", "candidates"}, {"state", "approvals"},
+		{"state", "runs"}, {"state", "candidates"}, {"state", "approvals"}, {"state", "exports"},
 		{"worktrees"}, {"runs"},
 	} {
 		if err := os.MkdirAll(filepath.Join(append([]string{base}, dir...)...), 0755); err != nil {
@@ -85,7 +87,19 @@ func newFixture(t *testing.T) *fixture {
 	// Mutable state.
 	writeFile(t, filepath.Join(base, "state", "candidates", oldTerminalRunID+".json"), `{"run_id":"`+oldTerminalRunID+`"}`)
 	writeFile(t, filepath.Join(base, "state", "approvals", oldTerminalRunID, "appr.json"), `{"id":"appr"}`)
+
+	// Verified export Guard (V0-0): только старый terminal run экспортирован.
+	writeExport(t, f.target, oldTerminalRunID)
 	return f
+}
+
+func writeExport(t *testing.T, target, runID string) {
+	t.Helper()
+	path := filepath.Join(target, ".ai-team", "state", "exports", runID+".json")
+	data := fmt.Sprintf(`{"schema_version":1,"run_id":%q,"verified":true,"bundle_sha256":"face01","exported_at":"2026-08-01T00:00:00Z"}`, runID)
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatalf("write export %s: %v", runID, err)
+	}
 }
 
 func (f *fixture) build(t *testing.T, pruneRuns bool) *Plan {
@@ -236,4 +250,53 @@ func totalBytesOf(t *testing.T, plan *Plan) int64 {
 		total += size
 	}
 	return total
+}
+
+func TestRunEvidencePrunedOnlyWithVerifiedExport(t *testing.T) {
+	f := newFixture(t)
+	// Удаляем verified-запись: у старого run нет защищённого portable export.
+	if err := os.Remove(filepath.Join(f.target, ".ai-team", "state", "exports", oldTerminalRunID+".json")); err != nil {
+		t.Fatal(err)
+	}
+	plan := f.build(t, true)
+	if actions := actionsFor(plan, CategoryRuns); len(actions) != 0 {
+		t.Fatalf("V0-0: без verified-export evidence не должна удаляться, получено %+v", actions)
+	}
+	var skippedOld bool
+	for _, skipped := range plan.Skipped {
+		if strings.HasSuffix(skipped.Path, oldTerminalRunID) && strings.Contains(skipped.Reason, "state/exports") {
+			skippedOld = true
+		}
+	}
+	if !skippedOld {
+		t.Fatalf("не-экспортированный run должен попасть в Skipped с причиной state/exports, got %+v", plan.Skipped)
+	}
+	if err := plan.Execute(f.target); err != nil {
+		t.Fatal(err)
+	}
+	if !exists(filepath.Join(f.target, ".ai-team", "runs", oldTerminalRunID)) {
+		t.Fatal("выполнение плана не должно удалить evidence без verified-export")
+	}
+}
+
+func TestRunEvidenceSkippedOnUnverifiedOrMalformedExport(t *testing.T) {
+	f := newFixture(t)
+	base := filepath.Join(f.target, ".ai-team", "state", "exports", oldTerminalRunID+".json")
+	if err := os.WriteFile(base, []byte(`{"schema_version":1,"run_id":"`+oldTerminalRunID+`","verified":false}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	plan := f.build(t, true)
+	if actions := actionsFor(plan, CategoryRuns); len(actions) != 0 {
+		t.Fatalf("unverified export не даёт права на удаление, получено %+v", actions)
+	}
+
+	f = newFixture(t)
+	base = filepath.Join(f.target, ".ai-team", "state", "exports", oldTerminalRunID+".json")
+	if err := os.WriteFile(base, []byte(`не json`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	plan = f.build(t, true)
+	if actions := actionsFor(plan, CategoryRuns); len(actions) != 0 {
+		t.Fatalf("malformed export не даёт права на удаление, получено %+v", actions)
+	}
 }

--- a/pkg/retention/retention_test.go
+++ b/pkg/retention/retention_test.go
@@ -299,4 +299,22 @@ func TestRunEvidenceSkippedOnUnverifiedOrMalformedExport(t *testing.T) {
 	if actions := actionsFor(plan, CategoryRuns); len(actions) != 0 {
 		t.Fatalf("malformed export не даёт права на удаление, получено %+v", actions)
 	}
+
+	f = newFixture(t)
+	base = filepath.Join(f.target, ".ai-team", "state", "exports", oldTerminalRunID+".json")
+	// verified=true с пустым bundle_sha256 — запись без проверяемого bundle:
+	// fail-closed, право на удаление не выдаётся.
+	if err := os.WriteFile(base, []byte(`{"schema_version":1,"run_id":"`+oldTerminalRunID+`","verified":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	plan = f.build(t, true)
+	if actions := actionsFor(plan, CategoryRuns); len(actions) != 0 {
+		t.Fatalf("verified export с пустым bundle_sha256 не даёт права на удаление, получено %+v", actions)
+	}
+	for _, skipped := range plan.Skipped {
+		if strings.HasSuffix(skipped.Path, oldTerminalRunID+".json") && strings.Contains(skipped.Reason, "bundle_sha256") {
+			return
+		}
+	}
+	t.Fatalf("ожидали Skipped с причиной bundle_sha256, got %+v", plan.Skipped)
 }


### PR DESCRIPTION
Stack: base = `adp-2-claude-code-adapter` (#48).

**V0-0** — fail-closed guard: `gc --prune-runs` не удаляет run evidence до появления verified-записи portable export. Открывает цепочку export/verify.