### PR TITLE
feat(pipeline): consolidated gate delivery, deferred gate approvals and re-use on re-traversal (APF-1)

### DIFF
--- a/cmd/ai-team/main.go
+++ b/cmd/ai-team/main.go
@@ -127,7 +127,10 @@ func printUsage() {
   --target <path>           Путь к целевому проекту (по умолчанию текущая директория)
 	  --resume <run_id>         Продолжить non-terminal run с той же identity
 	  --approve-gates           Явно подтвердить обычные gate-точки в non-interactive режиме
+	                            (в default-профилях forward-гейты отложены — одно consolidated
+	                            delivery-решение на весь run, APF-1)
 	  --approve-plan <sha256>    Разрешить только показанный canonical delivery plan
+	                            (ratify-ит и все отложенные гейты run'а)
 
 Exit-коды run: 0 — успех, 1 — ошибка или негативный вердикт,
                2 — BLOCKED (нужно вмешательство), 3 — остановлен пользователем
@@ -724,8 +727,8 @@ func cmdRun() {
 	taskDesc := runFlags.String("task", "", "Описание задачи")
 	target := runFlags.String("target", ".", "Путь к целевому проекту")
 	resumeRunID := runFlags.String("resume", "", "Продолжить non-terminal run")
-	approveGates := runFlags.Bool("approve-gates", false, "Подтвердить gate-точки в non-interactive режиме")
-	approvePlan := runFlags.String("approve-plan", "", "SHA-256 ранее показанного delivery plan")
+	approveGates := runFlags.Bool("approve-gates", false, "Подтвердить gate-точки в non-interactive режиме (forward-гейты default-профилей отложены до delivery-решения, APF-1)")
+	approvePlan := runFlags.String("approve-plan", "", "SHA-256 ранее показанного delivery plan (ratify-ит отложенные гейты run'а)")
 
 	runFlags.Parse(os.Args[2:])
 	absTarget, err := absoluteTarget(*target)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,6 +134,16 @@ evidence. Решения сериализуются in-process mutex и flock н
 `approval_requested` и `approval_decided` входят и в immutable hash chain,
 и в SQLite/WebSocket projection.
 
+Deferred-гейты (APF-1): для стандартного и fast профилей forward-gate рёбра
+помечаются `deferred: true` — переход не паузит и не решается по отдельности,
+а аттестуется отдельным approval с точным subject и разрешается одним
+consolidated delivery-решением run'а (`--approve-plan` или интерактивный
+delivery). Rоль/кворум отдельного гейта в этом случае осознанно замещаются
+единым delivery-контрпоинтом (роль `release_manager`); regulated-профиль
+сохраняет пошаговые approvals. Повторный проход того же перехода с тем же
+subject не создаёт новое ожидание и не перевалидируется (событие
+`approval_reused`).
+
 Локальный `RunController` связывает HTTP с тем же `RunEngine`, резервирует
 run ID до запуска worker goroutine и запрещает дублирующий active worker.
 `POST /api/runs`, `/resume`, `/cancel` и approval `/decisions` возвращают

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -303,9 +304,16 @@ func TestE2E_DisposableWorkerPersistsPendingApproval(t *testing.T) {
 		t.Fatalf("worker не сохранил waiting lifecycle: err=%v\n%s", err, state)
 	}
 	approvals, err := filepath.Glob(filepath.Join(dir, ".ai-team", "state", "approvals", runID, "*.json"))
-	if err != nil || len(approvals) != 1 {
-		t.Fatalf("worker не сохранил exact pending approval: %v err=%v", approvals, err)
+	if err != nil || len(approvals) == 0 {
+		t.Fatalf("worker не сохранил pending approval: %v err=%v", approvals, err)
 	}
+	var waiting struct {
+		ApprovalID string `json:"pending_approval_id"`
+	}
+	if json.Unmarshal(state, &waiting) != nil || waiting.ApprovalID == "" {
+		t.Fatalf("waiting state без pending_approval_id:\n%s", state)
+	}
+	checkFile(t, filepath.Join(dir, ".ai-team", "state", "approvals", runID, waiting.ApprovalID+".json"))
 	checkFile(t, filepath.Join(dir, ".ai-team", "state", "candidates", runID+".json"))
 	checkFile(t, filepath.Join(dir, ".ai-team", "web.db"))
 }
@@ -623,8 +631,11 @@ func TestE2E_WebDecisionAndResumeSameRun(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer response.Body.Close()
+		raw, _ := io.ReadAll(response.Body)
 		var result map[string]any
-		_ = json.NewDecoder(response.Body).Decode(&result)
+		if json.Unmarshal(raw, &result) != nil {
+			result = map[string]any{"raw": string(raw)}
+		}
 		return response.StatusCode, result
 	}
 	status, started := post("/api/runs", map[string]string{
@@ -635,8 +646,9 @@ func TestE2E_WebDecisionAndResumeSameRun(t *testing.T) {
 		t.Fatalf("web start: status=%d body=%v\n%s", status, started, serverOutput.String())
 	}
 	type approvalState struct {
-		ID          string `json:"id"`
-		SubjectHash string `json:"subject_hash"`
+		ID            string   `json:"id"`
+		SubjectHash   string   `json:"subject_hash"`
+		RequiredRoles []string `json:"required_roles"`
 	}
 	readPending := func() approvalState {
 		statePath := filepath.Join(dir, ".ai-team", "state", "runs", runID+".json")
@@ -666,21 +678,30 @@ func TestE2E_WebDecisionAndResumeSameRun(t *testing.T) {
 		first = readPending()
 		return first.ID != ""
 	}, func() string { return serverOutput.String() })
-	status, _ = post("/api/runs/"+runID+"/approvals/"+first.ID+"/decisions", map[string]string{
-		"actor_id": "product-1", "actor_role": "product_owner",
+	role := "product_owner"
+	if len(first.RequiredRoles) > 0 {
+		role = first.RequiredRoles[0]
+	}
+	status, decided := post("/api/runs/"+runID+"/approvals/"+first.ID+"/decisions", map[string]string{
+		"actor_id": "product-1", "actor_role": role,
 		"action": "approve", "subject_hash": first.SubjectHash,
 	})
 	if status != http.StatusOK {
-		t.Fatalf("web decision status=%d", status)
+		t.Fatalf("web decision status=%d role=%s body=%v", status, role, decided)
 	}
-	status, _ = post("/api/runs/"+runID+"/resume", map[string]string{})
-	if status != http.StatusAccepted {
-		t.Fatalf("web resume status=%d\n%s", status, serverOutput.String())
-	}
-	var second approvalState
+	var resumed map[string]any
 	waitUntil(t, 10*time.Second, func() bool {
-		second = readPending()
-		return second.ID != "" && second.ID != first.ID
+		status, resumed = post("/api/runs/"+runID+"/resume", map[string]string{})
+		return status == http.StatusAccepted
+	}, func() string { return fmt.Sprintf("status=%d body=%v\n%s", status, resumed, serverOutput.String()) })
+	statePath := filepath.Join(dir, ".ai-team", "state", "runs", runID+".json")
+	waitUntil(t, 15*time.Second, func() bool {
+		stateData, err := os.ReadFile(statePath)
+		if err != nil {
+			return false
+		}
+		return strings.Contains(string(stateData), `"phase": "terminal"`) ||
+			(readPending().ID != "" && readPending().ID != first.ID)
 	}, func() string { return serverOutput.String() })
 
 	events, err := os.ReadFile(filepath.Join(dir, ".ai-team", "runs", runID, "events.jsonl"))

--- a/pkg/approval/store.go
+++ b/pkg/approval/store.go
@@ -56,10 +56,15 @@ type PendingApproval struct {
 	Actions         []string          `json:"actions"`
 	Targets         map[string]string `json:"targets"`
 	Status          Status            `json:"status"`
-	Decisions       []Decision        `json:"decisions,omitempty"`
-	ResolvedAction  string            `json:"resolved_action,omitempty"`
-	CreatedAt       time.Time         `json:"created_at"`
-	ResolvedAt      time.Time         `json:"resolved_at,omitempty"`
+	// Deferred — подтверждение перехода отложено и будет разрешено одним
+	// consolidated delivery-решением run'а (APF-1). Deferred approval не
+	// содержит per-gate человеческих решений: их роль/кворум замещаются
+	// единым delivery-контрпоинтом, subject при этом сохраняется точно.
+	Deferred       bool       `json:"deferred,omitempty"`
+	Decisions      []Decision `json:"decisions,omitempty"`
+	ResolvedAction string     `json:"resolved_action,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	ResolvedAt     time.Time  `json:"resolved_at,omitempty"`
 	// Payload содержит машиночитаемое представление subject (например,
 	// canonical JSON delivery plan) для осознанного решения без доступа к
 	// filesystem. Не является частью identity: subject уже зафиксирован hash.
@@ -201,6 +206,9 @@ func (s *Store) Decide(runID, approvalID string, decision Decision) (PendingAppr
 	if err != nil {
 		return PendingApproval{}, err
 	}
+	if value.Deferred {
+		return PendingApproval{}, errors.New("deferred approval разрешается consolidated delivery-решением (ResolveDeferred)")
+	}
 	decision.ApprovalID = approvalID
 	decision.ActorID = strings.TrimSpace(decision.ActorID)
 	decision.ActorRole = strings.TrimSpace(decision.ActorRole)
@@ -255,6 +263,63 @@ func (s *Store) Decide(runID, approvalID string, decision Decision) (PendingAppr
 	return value, nil
 }
 
+// ResolveDeferred разрешает deferred-approval одним consolidated
+// delivery-решением run'а (APF-1). В отличие от Decide, не требует
+// принадлежности actor'а к RequiredRoles: для deferred-гейта роль и кворум
+// замещаются единым delivery-контрпоинтом, но subject/action проверяются
+// строго (exact subject hash, action из Actions).
+func (s *Store) ResolveDeferred(runID, approvalID string, decision Decision) (PendingApproval, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	unlock, err := s.lockRun(runID)
+	if err != nil {
+		return PendingApproval{}, err
+	}
+	defer unlock()
+	value, err := s.Load(runID, approvalID)
+	if err != nil {
+		return PendingApproval{}, err
+	}
+	if !value.Deferred {
+		return PendingApproval{}, errors.New("ResolveDeferred применяется только к deferred approval")
+	}
+	if value.Status == StatusResolved {
+		return PendingApproval{}, errors.New("deferred approval уже разрешён")
+	}
+	decision.ApprovalID = approvalID
+	decision.ActorID = strings.TrimSpace(decision.ActorID)
+	decision.ActorRole = strings.TrimSpace(decision.ActorRole)
+	decision.Action = strings.TrimSpace(decision.Action)
+	decision.SubjectHash = strings.ToLower(strings.TrimSpace(decision.SubjectHash))
+	decision.Comment = strings.TrimSpace(decision.Comment)
+	if decision.DecidedAt.IsZero() {
+		decision.DecidedAt = time.Now().UTC()
+	} else {
+		decision.DecidedAt = decision.DecidedAt.UTC()
+	}
+	if decision.SubjectHash != value.SubjectHash {
+		return PendingApproval{}, errors.New("subject hash решения не совпадает с ожидаемым")
+	}
+	if decision.ActorID == "" || decision.ActorRole == "" || !contains(value.Actions, decision.Action) {
+		return PendingApproval{}, errors.New("delivery решение содержит недопустимого actor, role или action")
+	}
+	value.Decisions = append(value.Decisions, decision)
+	value.Status = StatusResolved
+	value.ResolvedAction = decision.Action
+	value.ResolvedAt = decision.DecidedAt
+	if err := validate(value); err != nil {
+		return PendingApproval{}, err
+	}
+	path, err := s.path(runID, approvalID)
+	if err != nil {
+		return PendingApproval{}, err
+	}
+	if err := s.write(path, value); err != nil {
+		return PendingApproval{}, err
+	}
+	return value, nil
+}
+
 func normalize(value *PendingApproval) {
 	value.SubjectHash = strings.ToLower(strings.TrimSpace(value.SubjectHash))
 	for index := range value.RequiredRoles {
@@ -295,7 +360,9 @@ func validate(value PendingApproval) error {
 	}
 	for _, decision := range value.Decisions {
 		if decision.ApprovalID != value.ID || decision.ActorID == "" ||
-			!contains(value.RequiredRoles, decision.ActorRole) || !contains(value.Actions, decision.Action) ||
+			decision.ActorRole == "" ||
+			(!value.Deferred && !contains(value.RequiredRoles, decision.ActorRole)) ||
+			!contains(value.Actions, decision.Action) ||
 			decision.SubjectHash != value.SubjectHash || decision.DecidedAt.IsZero() {
 			return errors.New("approval содержит недопустимое решение")
 		}
@@ -309,7 +376,7 @@ func validate(value PendingApproval) error {
 		if !contains(value.Actions, value.ResolvedAction) || value.ResolvedAt.IsZero() || len(value.Decisions) == 0 {
 			return errors.New("resolved approval не содержит итогового решения")
 		}
-		if value.Quorum == QuorumAll && !coversAllRoles(value.RequiredRoles, value.Decisions) {
+		if value.Quorum == QuorumAll && !value.Deferred && !coversAllRoles(value.RequiredRoles, value.Decisions) {
 			return errors.New("resolved approval не достиг quorum all")
 		}
 	default:
@@ -324,7 +391,8 @@ func sameRequest(left, right PendingApproval) bool {
 		left.FromStage == right.FromStage && left.ToStage == right.ToStage &&
 		left.Trigger == right.Trigger && left.SubjectHash == right.SubjectHash &&
 		left.CandidateSHA256 == right.CandidateSHA256 &&
-		left.Quorum == right.Quorum && fmt.Sprint(left.RequiredRoles) == fmt.Sprint(right.RequiredRoles) &&
+		left.Deferred == right.Deferred && left.Quorum == right.Quorum &&
+		fmt.Sprint(left.RequiredRoles) == fmt.Sprint(right.RequiredRoles) &&
 		fmt.Sprint(left.Actions) == fmt.Sprint(right.Actions) && fmt.Sprint(left.Targets) == fmt.Sprint(right.Targets) &&
 		bytes.Equal(left.Payload, right.Payload)
 }

--- a/pkg/approval/store_test.go
+++ b/pkg/approval/store_test.go
@@ -221,6 +221,105 @@ func TestStoreConcurrentDecisionsLoseNoUpdate(t *testing.T) {
 	}
 }
 
+func TestStoreDeferredResolvedByConsolidatedDeliveryDecision(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := store.Create(PendingApproval{
+		RunID: "run-deferred", AttemptID: "attempt-1", FromStage: "coder", ToStage: "reviewer",
+		Trigger: "stage_completed", SubjectHash: testSubject,
+		RequiredRoles: []string{"developer"}, Actions: []string{"approve", "reject"},
+		Targets:  map[string]string{"approve": "reviewer", "reject": ".ai-team"},
+		Deferred: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !value.Deferred {
+		t.Fatal("deferred flag не сохранён")
+	}
+	// per-gate Decide запрещён для deferred.
+	if _, err := store.Decide(value.RunID, value.ID, Decision{
+		ActorID: "user-1", ActorRole: "developer", Action: "approve", SubjectHash: testSubject,
+	}); err == nil || !strings.Contains(err.Error(), "deferred") {
+		t.Fatalf("Decide не должен разрешать deferred approval, got %v", err)
+	}
+	// Consolidated delivery-решение: роль delivery-контрпоинта не обязана быть
+	// в RequiredRoles гейта, subject и action проверяются строго.
+	resolved, err := store.ResolveDeferred(value.RunID, value.ID, Decision{
+		ActorID: "release-1", ActorRole: "release_manager", Action: "approve",
+		SubjectHash: testSubject, Comment: "consolidated delivery decision",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Status != StatusResolved || resolved.ResolvedAction != "approve" ||
+		len(resolved.Decisions) != 1 || resolved.Decisions[0].ActorRole != "release_manager" {
+		t.Fatalf("неожиданный consolidated результат: %+v", resolved)
+	}
+	reloaded, err := store.Load(value.RunID, value.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Status != StatusResolved || reloaded.Deferred != true ||
+		reloaded.Decisions[0].ActorRole != "release_manager" {
+		t.Fatalf("resolved deferred не пережил reload: %+v", reloaded)
+	}
+	// Повторное разрешение запрещено.
+	if _, err := store.ResolveDeferred(value.RunID, value.ID, Decision{
+		ActorID: "release-2", ActorRole: "release_manager", Action: "approve",
+		SubjectHash: testSubject,
+	}); err == nil || !strings.Contains(err.Error(), "уже разрешён") {
+		t.Fatalf("двойное разрешение deferred принято: %v", err)
+	}
+}
+
+func TestStoreDeferredStrictSubjectAndAction(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := store.Create(PendingApproval{
+		RunID: "run-deferred-strict", AttemptID: "attempt-1", FromStage: "a", ToStage: "b",
+		Trigger: "stage_completed", SubjectHash: testSubject,
+		RequiredRoles: []string{"owner"}, Actions: []string{"approve", "reject"},
+		Targets:  map[string]string{"approve": "b", "reject": "b"},
+		Deferred: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ResolveDeferred(value.RunID, value.ID, Decision{
+		ActorID: "release-1", ActorRole: "release_manager", Action: "approve",
+		SubjectHash: strings.Repeat("b", 64),
+	}); err == nil || !strings.Contains(err.Error(), "subject hash") {
+		t.Fatalf("несовпадающий subject должен быть отклонён: %v", err)
+	}
+	if _, err := store.ResolveDeferred(value.RunID, value.ID, Decision{
+		ActorID: "release-1", ActorRole: "release_manager", Action: "override_approve",
+		SubjectHash: testSubject,
+	}); err == nil || !strings.Contains(err.Error(), "action") {
+		t.Fatalf("недопустимый action должен быть отклонён: %v", err)
+	}
+	// ResolveDeferred не применяется к обычным (не deferred) approvals.
+	plain, err := store.Create(PendingApproval{
+		RunID: "run-plain", AttemptID: "attempt-1", FromStage: "a", ToStage: "b",
+		Trigger: "stage_completed", SubjectHash: testSubject,
+		RequiredRoles: []string{"owner"}, Actions: []string{"approve", "reject"},
+		Targets: map[string]string{"approve": "b", "reject": "b"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ResolveDeferred(plain.RunID, plain.ID, Decision{
+		ActorID: "release-1", ActorRole: "release_manager", Action: "approve",
+		SubjectHash: testSubject,
+	}); err == nil || !strings.Contains(err.Error(), "deferred approval") {
+		t.Fatalf("ResolveDeferred не должен применяться к обычному approval: %v", err)
+	}
+}
+
 func TestStorePayloadRoundTripAndValidation(t *testing.T) {
 	target := t.TempDir()
 	store, err := NewStore(target)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,8 @@ type WorkflowApprovalConfig struct {
 	Roles   []string          `yaml:"roles"`
 	Quorum  string            `yaml:"quorum"`
 	Actions map[string]string `yaml:"actions"`
+	// Deferred — см. workflow.ApprovalPolicy.Deferred.
+	Deferred bool `yaml:"deferred,omitempty"`
 }
 
 func (c *Config) UnmarshalYAML(value *yaml.Node) error {
@@ -164,7 +166,7 @@ func (e *WorkflowEdgeConfig) UnmarshalYAML(value *yaml.Node) error {
 
 func (a *WorkflowApprovalConfig) UnmarshalYAML(value *yaml.Node) error {
 	if err := validateMappingKeys(value, map[string]bool{
-		"roles": true, "quorum": true, "actions": true,
+		"roles": true, "quorum": true, "actions": true, "deferred": true,
 	}, "config: workflow approval"); err != nil {
 		return err
 	}
@@ -256,9 +258,10 @@ func (c *Config) CompiledGraph() (workflow.Graph, error) {
 		}
 		if edge.Approval != nil {
 			compiled.Approval = &workflow.ApprovalPolicy{
-				Roles:   append([]string(nil), edge.Approval.Roles...),
-				Quorum:  edge.Approval.Quorum,
-				Actions: copyTargets(edge.Approval.Actions),
+				Roles:    append([]string(nil), edge.Approval.Roles...),
+				Quorum:   edge.Approval.Quorum,
+				Actions:  copyTargets(edge.Approval.Actions),
+				Deferred: edge.Approval.Deferred,
 			}
 		}
 		graph.Edges = append(graph.Edges, compiled)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -420,3 +420,92 @@ func TestDefaultProfiles(t *testing.T) {
 		t.Fatal("неизвестный профиль должен быть отклонён")
 	}
 }
+
+func TestDefaultProfilesDeferredGates(t *testing.T) {
+	for _, profile := range []string{ProfileFast, ProfileStandard} {
+		cfg, err := DefaultProfile(profile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, edge := range cfg.Workflow.Edges {
+			switch {
+			case edge.Outcome == "rejected":
+				if edge.Approval != nil && edge.Approval.Deferred {
+					t.Fatalf("%s: loopback-ребро %s→%s не должно быть deferred", profile, edge.From, edge.To)
+				}
+			case edge.To != "$complete" && edge.Approval == nil:
+				t.Fatalf("%s: forward-ребро %s→%s без approval", profile, edge.From, edge.To)
+			case edge.To != "$complete" && !edge.Approval.Deferred:
+				t.Fatalf("%s: forward-ребро %s→%s должно быть deferred (APF-1 consolidation)", profile, edge.From, edge.To)
+			}
+		}
+		graph, err := cfg.CompiledGraph()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, edge := range graph.Edges {
+			if edge.Approval != nil && edge.Approval.Deferred && edge.Outcome == "rejected" {
+				t.Fatalf("%s: compile потерял deferred distinction на loopback %s→%s", profile, edge.From, edge.To)
+			}
+		}
+	}
+	regulated, err := DefaultProfile(ProfileRegulated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, edge := range regulated.Workflow.Edges {
+		if edge.Approval != nil && edge.Approval.Deferred {
+			t.Fatalf("regulated: ребро %s→%s не должно быть deferred (строгий пошаговый контроль)", edge.From, edge.To)
+		}
+	}
+}
+
+func TestWorkflowApprovalDeferredParsesAndCompiles(t *testing.T) {
+	cfg := Default()
+	cfg.Workflow.Edges[0].Approval.Deferred = true
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Config
+	if err := yaml.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !decoded.Workflow.Edges[0].Approval.Deferred {
+		t.Fatal("deferred не должен потеряться при YAML round-trip")
+	}
+	// CompiledGraph должен нести флаг в runtime-контракт.
+	graph, err := decoded.CompiledGraph()
+	if err != nil {
+		t.Fatal(err)
+	}
+	edge, found := graph.Edge("analyst", "passed")
+	if !found || edge.Approval == nil || !edge.Approval.Deferred {
+		t.Fatalf("compiled edge analyst→passed deferred=%v approval=%v found=%v", edge.Approval, edge.Approval, found)
+	}
+	// Неизвестный ключ approval должен оставаться запрещённым.
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `
+schema_version: 4
+pipeline:
+  - name: a
+workflow:
+  entry: a
+  edges:
+    - from: a
+      outcome: passed
+      to: $complete
+      approval:
+        roles: [operator]
+        quorum: any
+        actions:
+          approve: $complete
+        bogus_key: true
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "workflow approval") {
+		t.Fatalf("неизвестный approval-ключ должен отклоняться, got %v", err)
+	}
+}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -142,6 +142,10 @@ func buildWorkflow(profile string, names []string, stages []stageSpec, quorum, l
 		specByName[s.name] = s
 	}
 	workflowConfig := &WorkflowConfig{Entry: names[0], MaxVisits: map[string]int{}}
+	// APF-1: в standard/fast профилях forward gate-переходы откладываются и
+	// подтверждаются одним consolidated delivery-решением (1–2 клика на фичу);
+	// regulated сохраняет пошаговые approvals (quorum all).
+	deferredGates := profile == ProfileStandard || profile == ProfileFast
 	for i, name := range names {
 		target := "$complete"
 		if i+1 < len(names) {
@@ -154,7 +158,7 @@ func buildWorkflow(profile string, names []string, stages []stageSpec, quorum, l
 				roles = []string{"operator"}
 			}
 			edge.Approval = &WorkflowApprovalConfig{
-				Roles: roles, Quorum: quorum,
+				Roles: roles, Quorum: quorum, Deferred: deferredGates,
 				Actions: map[string]string{"approve": target, "reject": "$stop"},
 			}
 		}
@@ -191,7 +195,6 @@ func buildWorkflow(profile string, names []string, stages []stageSpec, quorum, l
 			workflowConfig.MaxVisits[name] = defaultMaxVisits
 		}
 	}
-	_ = profile
 	return workflowConfig
 }
 

--- a/pkg/pipeline/approvals.go
+++ b/pkg/pipeline/approvals.go
@@ -34,6 +34,7 @@ func (rs *runState) authorizeTransition(
 	quorum string,
 	actions []string,
 	targets map[string]string,
+	deferred bool,
 ) (string, error) {
 	if quorum == "" {
 		quorum = approval.QuorumAny
@@ -51,12 +52,38 @@ func (rs *runState) authorizeTransition(
 		}
 		candidateSHA = identity.WorkspaceSHA256
 	}
+
+	// APF-1: повторный проход того же перехода с тем же subject не создаёт
+	// новое ожидание и не требует повторного решения (нет перевалидации
+	// прежних этапов при loopback).
+	if list, listErr := rs.approvalStore.List(rs.runID); listErr == nil {
+		if prior := priorApprovalIn(list, fromStage, toStage, trigger, subjectHash, deferred); prior != nil {
+			action := prior.ResolvedAction
+			if prior.Status == approval.StatusPending {
+				action = actions[0]
+			}
+			reusedAt := time.Now().UTC()
+			if err := rs.evidence.Append(evidence.Event{
+				Type: "approval_reused", AttemptID: result.AttemptID,
+				Timestamp: reusedAt, Data: map[string]any{
+					"approval_id": prior.ID, "prior_status": prior.Status,
+					"from_stage": fromStage, "to_stage": toStage, "trigger": trigger,
+					"subject_hash": subjectHash,
+				},
+			}); err != nil {
+				return "", err
+			}
+			return action, nil
+		}
+	}
+
 	value, err := rs.approvalStore.Create(approval.PendingApproval{
 		RunID: rs.runID, AttemptID: result.AttemptID,
 		FromStage: fromStage, ToStage: toStage, Trigger: trigger,
 		SubjectHash: subjectHash, CandidateSHA256: candidateSHA,
 		RequiredRoles: append([]string(nil), roles...),
 		Quorum:        quorum, Actions: append([]string(nil), actions...), Targets: targets,
+		Deferred: deferred,
 	})
 	if err != nil {
 		return "", err
@@ -70,6 +97,13 @@ func (rs *runState) authorizeTransition(
 	}
 	if rs.p.recorder != nil {
 		rs.p.recorder.ApprovalRequested(rs.runID, value.ID, result.AttemptID, requestedAt, approvalEventData(value))
+	}
+
+	// Deferred гейт: переход не паузит и не решается здесь — отдельный
+	// approval аттестуется с точным subject и разрешится одним
+	// consolidated delivery-решением run'а (APF-1).
+	if deferred {
+		return actions[0], nil
 	}
 
 	action := ""
@@ -131,6 +165,35 @@ func (rs *runState) authorizeTransition(
 		rs.p.recorder.ApprovalDecided(rs.runID, value.ID, result.AttemptID, decidedAt, approvalEventData(value))
 	}
 	return value.ResolvedAction, nil
+}
+
+// priorApprovalIn — APF-1: поиск в списке ранее зафиксированного approval
+// того же перехода и точного subject. Возвращает первый (по времени создания)
+// подходящий approval, если:
+//
+//   - pending deferred-гейт того же перехода/subject ещё не разрешён — новый
+//     не создаётся, повтора при loopback не бывает;
+//   - resolved-approval, чьё действие ведёт в тот же toStage и остаётся
+//     валидным action'ом ребра — решение не запрашивается повторно (нет
+//     перевалидации прежних этапов).
+func priorApprovalIn(list []approval.PendingApproval, from, to, trigger, subject string, deferred bool) *approval.PendingApproval {
+	for i := range list {
+		value := &list[i]
+		if value.FromStage != from || value.ToStage != to || value.Trigger != trigger || value.SubjectHash != subject {
+			continue
+		}
+		switch value.Status {
+		case approval.StatusPending:
+			if value.Deferred == deferred {
+				return value
+			}
+		case approval.StatusResolved:
+			if value.Targets[value.ResolvedAction] == to && containsString(list[i].Actions, value.ResolvedAction) {
+				return value
+			}
+		}
+	}
+	return nil
 }
 
 func approvalEventData(value approval.PendingApproval) map[string]any {

--- a/pkg/pipeline/approvals.go
+++ b/pkg/pipeline/approvals.go
@@ -184,7 +184,7 @@ func priorApprovalIn(list []approval.PendingApproval, from, to, trigger, subject
 		}
 		switch value.Status {
 		case approval.StatusPending:
-			if value.Deferred == deferred {
+			if value.Deferred && value.Deferred == deferred {
 				return value
 			}
 		case approval.StatusResolved:

--- a/pkg/pipeline/approvals_test.go
+++ b/pkg/pipeline/approvals_test.go
@@ -50,6 +50,14 @@ func TestPriorApprovalIn(t *testing.T) {
 			t.Fatal("deferred гейт не должен совпадать с обычным запросом")
 		}
 	})
+	t.Run("pending non-deferred не переиспользуется (латентный fail-open)", func(t *testing.T) {
+		value := base()
+		value.Status = approval.StatusPending
+		value.Deferred = false
+		if got := priorApprovalIn([]approval.PendingApproval{value}, "approver", "deployer", "graph_outcome:passed", subject, false); got != nil {
+			t.Fatalf("pending non-deferred approval не должен авто-переиспользоваться (fail-open), got %+v", got)
+		}
+	})
 	t.Run("resolved к другому target не переиспользуется", func(t *testing.T) {
 		value := base()
 		value.Status = approval.StatusResolved

--- a/pkg/pipeline/approvals_test.go
+++ b/pkg/pipeline/approvals_test.go
@@ -1,0 +1,71 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/arturpanteleev/ai-team/pkg/approval"
+)
+
+func TestPriorApprovalIn(t *testing.T) {
+	subject := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	base := func() approval.PendingApproval {
+		return approval.PendingApproval{
+			ID: "approval-x", RunID: "run-1", AttemptID: "attempt-1",
+			FromStage: "approver", ToStage: "deployer", Trigger: "graph_outcome:passed",
+			SubjectHash: subject, RequiredRoles: []string{"operator"},
+			Actions: []string{"approve", "reject"},
+			Targets: map[string]string{"approve": "deployer", "reject": "$stop"},
+		}
+	}
+	t.Run("пустой список", func(t *testing.T) {
+		if got := priorApprovalIn(nil, "approver", "deployer", "graph_outcome:passed", subject, false); got != nil {
+			t.Fatalf("ожидался nil: %+v", got)
+		}
+	})
+	t.Run("resolved approve повторно не запрашивается", func(t *testing.T) {
+		value := base()
+		value.Status = approval.StatusResolved
+		value.ResolvedAction = "approve"
+		if got := priorApprovalIn([]approval.PendingApproval{value}, "approver", "deployer", "graph_outcome:passed", subject, false); got == nil {
+			t.Fatal("resolved approval того же subject должен находиться")
+		}
+	})
+	t.Run("другой subject не совпадает", func(t *testing.T) {
+		value := base()
+		value.Status = approval.StatusResolved
+		value.ResolvedAction = "approve"
+		if got := priorApprovalIn([]approval.PendingApproval{value}, "approver", "deployer", "graph_outcome:passed", subject[:63]+"b", false); got != nil {
+			t.Fatal("другой subject не должен совпадать")
+		}
+	})
+	t.Run("pending deferred гейт того же перехода не дублируется", func(t *testing.T) {
+		value := base()
+		value.Status = approval.StatusPending
+		value.Deferred = true
+		list := []approval.PendingApproval{value}
+		if got := priorApprovalIn(list, "approver", "deployer", "graph_outcome:passed", subject, true); got == nil {
+			t.Fatal("pending deferred гейт того же subject должен находиться")
+		}
+		if got := priorApprovalIn(list, "approver", "deployer", "graph_outcome:passed", subject, false); got != nil {
+			t.Fatal("deferred гейт не должен совпадать с обычным запросом")
+		}
+	})
+	t.Run("resolved к другому target не переиспользуется", func(t *testing.T) {
+		value := base()
+		value.Status = approval.StatusResolved
+		value.ResolvedAction = "reject"
+		if got := priorApprovalIn([]approval.PendingApproval{value}, "approver", "deployer", "graph_outcome:passed", subject, false); got != nil {
+			t.Fatal("resolved reject к $stop не должен совпадать с переходом к deployer")
+		}
+	})
+	t.Run("resolved action вне Actions ребра не переиспользуется", func(t *testing.T) {
+		value := base()
+		value.Status = approval.StatusResolved
+		value.ResolvedAction = "override_approve"
+		value.Targets = map[string]string{"override_approve": "deployer"}
+		value.Actions = []string{"approve"}
+		if got := priorApprovalIn([]approval.PendingApproval{value}, "approver", "deployer", "graph_outcome:passed", subject, false); got != nil {
+			t.Fatal("resolved action вне текущих actions не должен переиспользоваться")
+		}
+	})
+}

--- a/pkg/pipeline/delivery_auth.go
+++ b/pkg/pipeline/delivery_auth.go
@@ -120,6 +120,11 @@ func (rs *runState) authorizeDelivery(name string, result notifier.StageResult, 
 		if rs.approvedPlanHash != planHash {
 			return fmt.Errorf("delivery approval hash mismatch: approved=%s actual=%s", rs.approvedPlanHash, planHash)
 		}
+		// Явное подтверждение точного canonical plan (--approve-plan) расширяется
+		// на отложенные гейты run'а (APF-1).
+		if err := rs.ratifyDeferredGates("local-user", "approve"); err != nil {
+			return err
+		}
 		return recordApproval("hash_flag")
 	}
 
@@ -159,8 +164,13 @@ func (rs *runState) authorizeDelivery(name string, result notifier.StageResult, 
 
 	action := ""
 	if rs.p.prompter.Interactive() {
-		ans := rs.p.prompter.Ask(fmt.Sprintf("%s %s может выполнить commit/push/PR. Продолжить? [y/N]",
-			ui.Colorize("Delivery:", ui.ColorBold), ui.Colorize(name, ui.ColorYellow)))
+		prompt := fmt.Sprintf("%s %s может выполнить commit/push/PR. Продолжить? [y/N]",
+			ui.Colorize("Delivery:", ui.ColorBold), ui.Colorize(name, ui.ColorYellow))
+		if deferredCount := rs.pendingDeferredCount(); deferredCount > 0 {
+			prompt = fmt.Sprintf("%s %s консолидирует %d отложенных approval-гейта. Продолжить? [y/N]",
+				ui.Colorize("Delivery:", ui.ColorBold), ui.Colorize(name, ui.ColorYellow), deferredCount)
+		}
+		ans := rs.p.prompter.Ask(prompt)
 		if ans == "y" {
 			action = "approve"
 		} else {
@@ -198,9 +208,87 @@ func (rs *runState) authorizeDelivery(name string, result notifier.StageResult, 
 		rs.p.recorder.ApprovalDecided(rs.runID, value.ID, result.AttemptID, decidedAt, approvalEventData(value))
 	}
 	if action == "reject" {
+		if err := rs.ratifyDeferredGates("local-user", "reject"); err != nil {
+			return err
+		}
 		return fmt.Errorf("%w: delivery перед %s отклонён человеком", ErrUserStopped, name)
 	}
+	if err := rs.ratifyDeferredGates("local-user", "approve"); err != nil {
+		return err
+	}
 	return recordApproval("resolved_approval")
+}
+
+// pendingDeferredCount — число ждущих consolidated-подтверждения deferred-гейтов
+// текущего run (для осмысленного решения человека в delivery-промпте, APF-1).
+func (rs *runState) pendingDeferredCount() int {
+	list, err := rs.approvalStore.List(rs.runID)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, value := range list {
+		if value.Status == approval.StatusPending && value.Deferred {
+			count++
+		}
+	}
+	return count
+}
+
+// ratifyDeferredGates разрешает все pending deferred-гейты run'а одним
+// consolidated delivery-решением (APF-1). Действие человека (approve/reject)
+// распространяется на каждый отложенный гейт; точный subject каждого approval
+// проверяется в approval store. Уже разрешённые гейты не трогаются.
+func (rs *runState) ratifyDeferredGates(actorID, action string) error {
+	list, err := rs.approvalStore.List(rs.runID)
+	if err != nil {
+		return err
+	}
+	ratified := make([]map[string]string, 0)
+	for _, value := range list {
+		if value.Status != approval.StatusPending || !value.Deferred {
+			continue
+		}
+		decidedAction := action
+		if !containsString(value.Actions, decidedAction) {
+			if containsString(value.Actions, "reject") {
+				decidedAction = "reject"
+			} else {
+				decidedAction = value.Actions[0]
+			}
+		}
+		resolved, err := rs.approvalStore.ResolveDeferred(rs.runID, value.ID, approval.Decision{
+			ActorID: actorID, ActorRole: deliveryApprovalRole,
+			Action: decidedAction, SubjectHash: value.SubjectHash,
+			Comment: "consolidated delivery decision",
+		})
+		if err != nil {
+			return fmt.Errorf("deferred approval %s: %w", value.ID, err)
+		}
+		decidedAt := time.Now().UTC()
+		if err := rs.evidence.Append(evidence.Event{
+			Type: "approval_decided", AttemptID: resolved.AttemptID,
+			Timestamp: decidedAt, Data: approvalEventData(resolved),
+		}); err != nil {
+			return err
+		}
+		if rs.p.recorder != nil {
+			rs.p.recorder.ApprovalDecided(rs.runID, resolved.ID, resolved.AttemptID, decidedAt, approvalEventData(resolved))
+		}
+		ratified = append(ratified, map[string]string{
+			"approval_id": resolved.ID, "subject_hash": resolved.SubjectHash, "action": resolved.ResolvedAction,
+		})
+	}
+	if len(ratified) > 0 {
+		ratifiedAt := time.Now().UTC()
+		if err := rs.evidence.Append(evidence.Event{
+			Type: "deferred_gates_ratified", Timestamp: ratifiedAt,
+			Data: map[string]any{"action": action, "approver": actorID, "gates": ratified},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (rs *runState) writeDeliveryPlan(ctx context.Context, a *agent.Agent, preconditions map[string]delivery.PreconditionEvidence) error {

--- a/pkg/pipeline/execute.go
+++ b/pkg/pipeline/execute.go
@@ -106,6 +106,7 @@ func (rs *runState) executeGraph(ctx context.Context) error {
 			selected, err := rs.authorizeTransition(
 				current, edge.To, "graph_outcome:"+string(edge.Outcome), result,
 				edge.Approval.Roles, edge.Approval.Quorum, actions, edge.Approval.Actions,
+				edge.Approval.Deferred,
 			)
 			if err != nil {
 				return err

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -890,6 +890,77 @@ func TestRun_DeliveryApprovalPersistedAndResumable(t *testing.T) {
 	}
 }
 
+func TestRun_DeferredGateConsolidatedIntoDeliveryDecision(t *testing.T) {
+	dir := env(t)
+	approvedPlanHash := prepareDelivery(t, dir)
+	rt := newScripted()
+	rt.content["approver"] = map[string]string{"review": "**Verdict:** APPROVED\n"}
+	service := &fakeDeliveryService{}
+	cfg := cfgForGraph(func(wf *config.WorkflowConfig) {
+		wf.Edges[0].Approval.Deferred = true
+	}, config.AgentConfig{Name: "approver"}, config.AgentConfig{Name: "deployer"})
+	p := New(cfg, deliveryRegistry(),
+		WithRuntimeFactory(rt.factory), WithPrompter(&scriptedPrompter{}), WithDeliveryService(service))
+
+	// Первый прогон — non-interactive БЕЗ --approve-gates: deferred-гейт не
+	// паузит, run доходит до единственного consolidated delivery-решения.
+	err := p.Run(context.Background(), RunConfig{Feature: "feat", TaskDesc: "t", TargetDir: dir})
+	var approvalErr *ApprovalRequiredError
+	if !errors.As(err, &approvalErr) {
+		t.Fatalf("ожидался ApprovalRequiredError на delivery, got: %v", err)
+	}
+	if got := strings.Join(rt.executed, ","); got != "approver" {
+		t.Fatalf("deferral не должен паузить у гейта: %s", got)
+	}
+	store, storeErr := approval.NewStore(dir)
+	if storeErr != nil {
+		t.Fatal(storeErr)
+	}
+	deliveryApproval, loadErr := store.Load(approvalErr.RunID, approvalErr.ApprovalID)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if deliveryApproval.Trigger != "delivery_plan" {
+		t.Fatalf("run должен остановиться именно на delivery, trigger=%s", deliveryApproval.Trigger)
+	}
+	values, listErr := store.List(approvalErr.RunID)
+	if listErr != nil {
+		t.Fatal(listErr)
+	}
+	var gate *approval.PendingApproval
+	for i := range values {
+		if values[i].Deferred {
+			gate = &values[i]
+			break
+		}
+	}
+	if gate == nil {
+		t.Fatal("deferred-гейт не создан")
+	}
+	if gate.Status != approval.StatusPending || gate.FromStage != "approver" || gate.ToStage != "deployer" {
+		t.Fatalf("неожиданный deferred-гейт: %+v", gate)
+	}
+
+	// Resume с точным canonical plan hash решает delivery и ratify-ит гейт.
+	err = p.Run(context.Background(), RunConfig{
+		ResumeRunID: approvalErr.RunID, TargetDir: dir, ApprovePlanHash: approvedPlanHash,
+	})
+	if err != nil {
+		t.Fatalf("resume с --approve-plan должен завершиться: %v", err)
+	}
+	if service.calls != 1 {
+		t.Fatalf("delivery должен выполниться после решения, calls=%d", service.calls)
+	}
+	resolvedGate, loadErr := store.Load(gate.RunID, gate.ID)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if resolvedGate.Status != approval.StatusResolved || resolvedGate.ResolvedAction != "approve" ||
+		len(resolvedGate.Decisions) != 1 || resolvedGate.Decisions[0].ActorRole != "release_manager" {
+		t.Fatalf("deferred-гейт не ratify-ён consolidated delivery-решением: %+v", resolvedGate)
+	}
+}
+
 func TestRun_DeliveryResumeRejectsMismatchedPlanHash(t *testing.T) {
 	dir := env(t)
 	prepareDelivery(t, dir)

--- a/pkg/workflow/graph.go
+++ b/pkg/workflow/graph.go
@@ -13,6 +13,11 @@ type ApprovalPolicy struct {
 	Roles   []string          `json:"roles"`
 	Quorum  string            `json:"quorum"`
 	Actions map[string]string `json:"actions"`
+	// Deferred — подтверждение перехода откладывается до delivery-решения
+	// run'а (одно consolidated решение на весь delivery-план, APF-1). Пока
+	// delivery не разрешён, deferred approval остаётся pending и attestуется
+	// со своим точным subject; в strict/regulated профилях deferred=false.
+	Deferred bool `json:"deferred,omitempty"`
 }
 
 type Node struct {


### PR DESCRIPTION
Stack: base = `v0-0-prune-runs-export-guard` (#49).

**APF-1** — consolidated gate delivery, deferred gate approvals и reuse на re-traversal.