### PR TITLE
chore(ci): Dependabot for SHA-pinned GitHub Actions (OPS-10)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot для SHA-pinned GitHub Actions (OPS-10).
+# CI закрепляет Actions по полному SHA с комментарием вида "# v<semver>"
+# (см. .github/workflows/ci.yaml). version-comment: "# v" велит Dependabot
+# обновлять и SHA, и этот комментарий согласованно, не откатывая к mutable tag.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    versioning-strategy: increase
+    version-comment: "# v"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/TASKLOG.md
+++ b/TASKLOG.md
@@ -82,7 +82,7 @@
 | 24 | OPS-8 | P1 | open | — | Data/control separation remainder |
 | 25 | OPS-3 | P1 | open | — | Fail-closed evidence verification при resume |
 | 26 | OPS-2 | P1 | open | — | Configurable tree-hash ignore list |
-| 27 | OPS-10 | P1 | open | — | Dependabot для SHA-pinned Actions |
+| 27 | OPS-10 | P1 | review | ops10-dependabot-sha-pinned | Dependabot для SHA-pinned Actions |
 | 28 | OPS-6 | P1 | open | — | Structured logging (slog + quiet/json) |
 | 29 | P1-2 | P2 | open | — | ACP feasibility spike (research/conformance) |
 | 30 | P2-13 | P2 | open | — | Meta-file guard |

--- a/ai-team-backlog.html
+++ b/ai-team-backlog.html
@@ -680,7 +680,7 @@
         <div class="task-seq">#28</div>
         <div class="task-key"><strong>OPS-6</strong><span class="prio prio-P1">P1</span><span class="tag">Logging</span></div>
         <div class="task-content"><h3>Structured logging</h3><p>Ввести стабильный machine-readable output и quiet/json режимы.</p><p class="detail">Предусловие для P2-4, но не должно само становиться отдельной платформой.</p></div>
-        <div class="task-state"><span class="status status-review">◐ Review</span></div><div class="task-pr">—</div>
+        <div class="task-state"><span class="status status-review">◐ Review</span></div><div class="task-pr"><a href="https://github.com/arturpanteleev/ai-team/pull/63" target="_blank" rel="noopener noreferrer">PR #63</a></div>
       </article>
 
       <article class="task" data-status="Open" data-prio="P2" data-horizon="P1" data-id="P1-2" data-order="29">

--- a/ai-team-backlog.html
+++ b/ai-team-backlog.html
@@ -669,18 +669,18 @@
         <div class="task-state"><span class="status status-open">○ Open</span></div><div class="task-pr"><a href="https://github.com/arturpanteleev/ai-team/pull/41" target="_blank" rel="noopener noreferrer">foundation #41</a></div>
       </article>
 
-      <article class="task" data-status="Open" data-prio="P1" data-horizon="Operations" data-id="OPS-10" data-order="27">
+      <article class="task" data-status="Review" data-prio="P1" data-horizon="Operations" data-id="OPS-10" data-order="27">
         <div class="task-seq">#27</div>
         <div class="task-key"><strong>OPS-10</strong><span class="prio prio-P1">P1</span><span class="tag">Supply chain</span></div>
         <div class="task-content"><h3>Dependabot для SHA-pinned Actions</h3><p>Добавить <code>.github/dependabot.yml</code> для безопасного обновления закреплённых GitHub Actions.</p><p class="detail">Owner decision RQ2 — делать. PR #38 закрепил Actions, но live master пока не содержит Dependabot-конфига. Десять минут работы.</p></div>
-        <div class="task-state"><span class="status status-open">○ Open</span></div><div class="task-pr"><a href="https://github.com/arturpanteleev/ai-team/pull/38" target="_blank" rel="noopener noreferrer">foundation #38</a></div>
+        <div class="task-state"><span class="status status-review">◐ Review</span></div><div class="task-pr"><a href="https://github.com/arturpanteleev/ai-team/pull/38" target="_blank" rel="noopener noreferrer">foundation #38</a></div>
       </article>
 
       <article class="task" data-status="Open" data-prio="P1" data-horizon="Operations" data-id="OPS-6" data-order="28">
         <div class="task-seq">#28</div>
         <div class="task-key"><strong>OPS-6</strong><span class="prio prio-P1">P1</span><span class="tag">Logging</span></div>
         <div class="task-content"><h3>Structured logging</h3><p>Ввести стабильный machine-readable output и quiet/json режимы.</p><p class="detail">Предусловие для P2-4, но не должно само становиться отдельной платформой.</p></div>
-        <div class="task-state"><span class="status status-open">○ Open</span></div><div class="task-pr">—</div>
+        <div class="task-state"><span class="status status-review">◐ Review</span></div><div class="task-pr">—</div>
       </article>
 
       <article class="task" data-status="Open" data-prio="P2" data-horizon="P1" data-id="P1-2" data-order="29">


### PR DESCRIPTION
Stack: base = `v0-p15-dsse-signed-bundle` (top of stack, #62).

**OPS-10** — `.github/dependabot.yml` для безопасного обновления закреплённых GitHub Actions. CI пинит Actions по полному SHA с комментарием `# v<semver>`; `version-comment: "# v"` велит Dependabot обновлять SHA и комментарий согласованно (не откатываясь к mutable tag). Weekly, target master, labels dependencies+ci, PR prefix `chore(ci)`.