### PR TITLE
OPS-2: Configurable tree-hash ignore list

### DIFF
--- a/TASKLOG.md
+++ b/TASKLOG.md
@@ -81,7 +81,7 @@
 | 23 | P1-8 | P1 | open | — | CI-parity check import |
 | 24 | OPS-8 | P1 | open | — | Data/control separation remainder |
 | 25 | OPS-3 | P1 | review | ops3-fail-closed-resume | PR #65 |
-| 26 | OPS-2 | P1 | open | — | Configurable tree-hash ignore list |
+| 26 | OPS-2 | P1 | review | ops2-configurable-tree-hash-ignore | PR #66 |
 | 27 | OPS-10 | P1 | review | ops10-dependabot-sha-pinned | Dependabot для SHA-pinned Actions |
 | 28 | OPS-6 | P1 | review | ops6-structured-output | PR #64 |
 | 29 | P1-2 | P2 | open | — | ACP feasibility spike (research/conformance) |

--- a/ai-team-backlog.html
+++ b/ai-team-backlog.html
@@ -662,11 +662,11 @@
         <div class="task-state"><span class="status status-review">◐ Review</span></div><div class="task-pr"><a href="https://github.com/arturpanteleev/ai-team/pull/65" target="_blank" rel="noopener noreferrer">PR #65</a></div>
       </article>
 
-      <article class="task" data-status="Open" data-prio="P1" data-horizon="Operations" data-id="OPS-2" data-order="26">
+      <article class="task" data-status="Review" data-prio="P1" data-horizon="Operations" data-id="OPS-2" data-order="26">
         <div class="task-seq">#26</div>
         <div class="task-key"><strong>OPS-2</strong><span class="prio prio-P1">P1</span><span class="tag">Config</span></div>
         <div class="task-content"><h3>Configurable tree-hash ignore list</h3><p>Вынести project-specific ignore patterns в строгий config без ослабления baseline identity.</p><p class="detail">Решение RQ8 принято. Основа unified tree hashing доставлена в #41. Нужно внешним adopter-репозиториям с нетипичными артефактами.</p></div>
-        <div class="task-state"><span class="status status-open">○ Open</span></div><div class="task-pr"><a href="https://github.com/arturpanteleev/ai-team/pull/41" target="_blank" rel="noopener noreferrer">foundation #41</a></div>
+        <div class="task-state"><span class="status status-review">◐ Review</span></div><div class="task-pr"><a href="https://github.com/arturpanteleev/ai-team/pull/66" target="_blank" rel="noopener noreferrer">PR #66</a></div>
       </article>
 
       <article class="task" data-status="Review" data-prio="P1" data-horizon="Operations" data-id="OPS-10" data-order="27">

--- a/openspec/changes/configurable-tree-hash-ignore/design.md
+++ b/openspec/changes/configurable-tree-hash-ignore/design.md
@@ -1,0 +1,48 @@
+# Design — Configurable tree-hash ignore list (OPS-2)
+
+## Контекст
+
+`pkg/checks.WorkspaceDigest(target)` — единственная каноническая функция
+tree hashing. Она вызывается из нескольких независимых путей: verification
+(`pkg/checks`), кандидатное evidence (`pkg/candidate`), планирование и
+исполнение delivery (`pkg/delivery/planner.go`/`executor.go`), pipeline
+(`pkg/pipeline`). Критический инвариант целостности: всё это — **одно и то же
+значение digest для одного workspace**. Если бы ignore-list различался между
+этими точками, binding проверенного digest к delivery молча ломался бы.
+
+Поэтому конфигурируемые ignore нельзя прокидывать только через часть
+call-site'ов — нужен единый источник истины.
+
+## Решение: процесс-глобальный extra-набор в pkg/checks
+
+Один процесс управляет одним проектом (CLI/daemon держит target под workspace
+lock). Следовательно, регистрация project-specific ignore-имён как
+**процесс-глобального** дополнительного набора безопасна и гарантирует, что
+все вычисления digest используют идентичный ignore-list без изменения ни одного
+call-site сигнатурой.
+
+- `pkg/checks/ignore.go`:
+  - `SetExtraIgnoreDirs([]string)` — mutex-защищённая установка (копия во
+    внутреннюю map), вызывается однократно при `config.Load` с валидированным
+    `TreeHash.IgnoreDirs`.
+  - `ResetExtraIgnoreDirs()` — для тестов и повторного конфига.
+  - `DefaultIgnoreDirs()` — возвращает baseline (неизменяемый) + extra.
+  - `ValidIgnoreDirName(string) bool` — строгий канонический валидатор.
+- `pkg/config`: `Config.TreeHash *TreeHashConfig{IgnoreDirs []string}` (yaml
+  `tree_hash`), строгая валидация имён + анти-дубликат, включена в
+  `Config.Validate`. `Load()` применяет набор (`checks.SetExtraIgnoreDirs`).
+
+## Строгость и безопасность
+
+- Только простые имена каталогов: `[A-Za-z0-9._-]`, непустое, не `.`/`..`,
+  без ведущего `-`, без `/`/`\`/NUL/пробелов, ≤128 байт.
+- Поиск — по имени компонента на любой глубине walk'а (как baseline).
+- Baseline (`DefaultIgnoreDirs`) не расширяется удалением — extra только
+  добавляет имена. Ослабления digest identity невозможны.
+
+## Почему не variadic/конtext-вариант
+
+Вариант `WorkspaceDigestEx(target, extra)` потребовал бы threading через ~7
+call-site'ов в трёх пакетах и создал бы риск mismatch (пропущенный call-site).
+Глобальный набор устраняет класс ошибок "забрали ignore у одного пути",
+сохраняя единственный источник истины.

--- a/openspec/changes/configurable-tree-hash-ignore/proposal.md
+++ b/openspec/changes/configurable-tree-hash-ignore/proposal.md
@@ -1,0 +1,39 @@
+# Configurable tree-hash ignore list (OPS-2)
+
+## Why
+
+`pkg/checks.DefaultIgnoreDirs()` — единственный канонический ignore-list для
+workspace tree hashing — жёстко зашит. Проекты не могут исключать из digest
+собственные каталоги артефактов (coverage, вендорные таргеты, кэши сборки и
+т.п.), что приводит к ложной "грязи" workspace и срывам проверок/delivery на
+нерелевантных файлах. Нужен строгий project-specific ignore config БЕЗ
+ослабления baseline identity.
+
+## What Changes
+
+- **`pkg/checks`**:
+  - `ValidIgnoreDirName(name)` — строгий шаблон простого имени каталога
+    (без `/`, не `.`/`..`, без ведущего `-`, непустое, ограниченной длины,
+    только `[A-Za-z0-9._-]`). Path'ы и glob'ы запрещены.
+  - `SetExtraIgnoreDirs(names)` / `ResetExtraIgnoreDirs()` — процесс-глобальный
+    дополнительный набор; `DefaultIgnoreDirs()` возвращает baseline + extra
+    (baseline неизменяем). Канонический tree hash использует его на ВСЕХ
+    call-site (checks, pipeline, delivery planner/executor) — согласованность
+    digest между check-time и delivery-time гарантирована.
+- **`pkg/config`**:
+  - `TreeHashConfig{IgnoreDirs []string}` в `Config.TreeHash` (yaml `tree_hash`).
+  - Строгая `TreeHashConfig.Validate()`: каждое имя через
+    `checks.ValidIgnoreDirName`, без дубликатов.
+  - `Config.Validate()` включает валидацию `TreeHash`.
+  - `Load()` регистрирует валидированный набор через `checks.SetExtraIgnoreDirs`,
+    поэтому все вычисления digest в процессе используют его.
+
+## Acceptance Criteria
+
+1. Проект может указать `tree_hash.ignore_dirs` простыми именами каталогов;
+   они исключаются из workspace digest.
+2. Пути/glob'ы/небезопасные имена (`..`, `/`, ведущий `-`, пробелы) отвергаются
+   строгой валидацией.
+3. Канонический baseline (`DefaultIgnoreDirs`) никогда не ослабляется.
+4. Digest согласован: check-time и delivery-time используют идентичный ignore-list.
+5. `make specs` 67/67, `go test ./...` зелёные (кроме двух известных e2e baseline-fail).

--- a/openspec/changes/configurable-tree-hash-ignore/specs/configurable-tree-hash-ignore/spec.md
+++ b/openspec/changes/configurable-tree-hash-ignore/specs/configurable-tree-hash-ignore/spec.md
@@ -1,0 +1,39 @@
+# configurable-tree-hash-ignore delta (OPS-2)
+
+## ADDED Requirements
+
+### Requirement: Project-specific tree-hash ignore directories
+
+A project MUST be able to configure additional directory names that are excluded
+from workspace tree hashing, without weakening the canonical baseline ignore set.
+
+#### Scenario: Ignore directories excluded from digest
+
+- **WHEN** a project config declares `tree_hash.ignore_dirs` containing simple
+  directory names (e.g. `coverage`)
+- **THEN** those directories MUST be excluded from the workspace digest
+- **AND** the digest MUST differ from the digest computed without the extra ignore
+- **AND** every digest computation in the process (checks, pipeline, delivery
+  planning and execution) MUST use the same expanded ignore set
+
+#### Scenario: Baseline is never weakened
+
+- **WHEN** a project config declares extra ignore directories
+- **THEN** the canonical baseline entries (`.git`, `.ai-team`, `node_modules`,
+  `vendor`, `dist`, `.venv`, `__pycache__`) MUST remain ignored
+
+### Requirement: Strict validation of ignore directory names
+
+Ignore entries MUST be validated strictly: only simple directory names are
+accepted; paths, glob patterns and unsafe names are rejected.
+
+#### Scenario: Invalid names are rejected
+
+- **WHEN** an ignore entry is empty, `.`, `..`, contains `/` or `\`, starts with
+  `-`, contains whitespace, or is longer than the limit
+- **THEN** configuration validation MUST reject it with an error
+
+#### Scenario: Duplicate entries are rejected
+
+- **WHEN** the same directory name appears more than once in `ignore_dirs`
+- **THEN** configuration validation MUST reject it with an error

--- a/openspec/changes/configurable-tree-hash-ignore/tasks.md
+++ b/openspec/changes/configurable-tree-hash-ignore/tasks.md
@@ -1,0 +1,28 @@
+# Tasks — Configurable tree-hash ignore list (OPS-2)
+
+## T1. pkg/checks: extra ignore set
+
+- [x] `pkg/checks/ignore.go`:
+  - `ValidIgnoreDirName(name)` — строгий шаблон (канонический).
+  - `SetExtraIgnoreDirs` / `ResetExtraIgnoreDirs` — mutex-защищённый
+    процесс-глобальный набор; `DefaultIgnoreDirs()` возвращает baseline + extra.
+- [x] `ignore_test.go`: строгая валидация имён; extra изменяет digest;
+      reset возвращает baseline; baseline неизменяем.
+
+## T2. pkg/config: параметр + строгая валидация
+
+- [x] `Config.TreeHash *TreeHashConfig` (yaml `tree_hash.ignore_dirs`),
+      разобран в `UnmarshalYAML` (в allowlist и rawConfig).
+- [x] `TreeHashConfig.Validate()`: `checks.ValidIgnoreDirName` + анти-дубликат;
+      включён в `Config.Validate`.
+- [x] `Load()` применяет набор через `checks.SetExtraIgnoreDirs` — все digest
+      вычисления процесса используют его.
+- [x] `treehash_config_test.go`: validate-кейсы; load применяет ignore;
+      недопустимый путь отвергается Validate.
+
+## T3. Verification
+
+- [x] `go build ./...`, `gofmt -l` чисто, `go vet ./...`.
+- [x] `go test ./pkg/checks ./pkg/config ./pkg/pipeline ./pkg/delivery`
+      зелёные; полный `go test ./...` — только два известных e2e baseline-fail.
+- [x] `make specs` 67/67.

--- a/pkg/checks/checks.go
+++ b/pkg/checks/checks.go
@@ -571,9 +571,11 @@ func VerifyResultDigest(result Result) bool {
 // DefaultIgnoreDirs is the single canonical ignore list for workspace tree
 // hashing: controller metadata (.git, .ai-team) plus dependency/build
 // directories that are never part of a mutation contract. Directories are
-// matched by name at any depth of the walk.
+// matched by name at any depth of the walk. Project-specific additions from
+// config (OPS-2) are merged in; the canonical baseline is never removable.
 func DefaultIgnoreDirs() map[string]bool {
-	return map[string]bool{
+	extra := loadExtraIgnoreDirs()
+	result := map[string]bool{
 		".git":         true,
 		".ai-team":     true,
 		"node_modules": true,
@@ -582,6 +584,13 @@ func DefaultIgnoreDirs() map[string]bool {
 		".venv":        true,
 		"__pycache__":  true,
 	}
+	for name := range extra {
+		if name == "" {
+			continue
+		}
+		result[name] = true
+	}
+	return result
 }
 
 // WorkspaceFileDigests is the single tree-walking implementation shared by

--- a/pkg/checks/ignore.go
+++ b/pkg/checks/ignore.go
@@ -1,0 +1,73 @@
+package checks
+
+import (
+	"sync"
+)
+
+// Процесс-глобальный дополнительный ignore-набор (OPS-2). Один процесс
+// управляет одним проектом (пользовательский CLI/daemon держит target под
+// workspace lock), поэтому глобальная override на процесс безопасна и, главное,
+// гарантирует, что ВСЕ вычисления workspace digest (checks, pipeline candidate,
+// delivery planner/executor) используют идентичный ignore-набор. Канонический
+// baseline никогда не удаляется — extra только добавляет имена каталогов.
+var (
+	extraMu         sync.RWMutex
+	extraIgnoreDirs = map[string]bool{}
+)
+
+// SetExtraIgnoreDirs задаёт project-specific имена каталогов, добавляемые к
+// baseline DefaultIgnoreDirs при workspace tree hashing. Вызывается однократно
+// при загрузке строго валидированного конфига (см. pkg/config.TreeHash).
+func SetExtraIgnoreDirs(names []string) {
+	extraMu.Lock()
+	defer extraMu.Unlock()
+	extraIgnoreDirs = make(map[string]bool, len(names))
+	for _, name := range names {
+		if name != "" {
+			extraIgnoreDirs[name] = true
+		}
+	}
+}
+
+// ResetExtraIgnoreDirs очищает дополнительный набор (тесты / пере-конфиг).
+func ResetExtraIgnoreDirs() {
+	extraMu.Lock()
+	defer extraMu.Unlock()
+	extraIgnoreDirs = map[string]bool{}
+}
+
+func loadExtraIgnoreDirs() map[string]bool {
+	extraMu.RLock()
+	defer extraMu.RUnlock()
+	// вернуть копию, чтобы вызывающий не мутировал глобальное состояние
+	out := make(map[string]bool, len(extraIgnoreDirs))
+	for name := range extraIgnoreDirs {
+		out[name] = true
+	}
+	return out
+}
+
+// ValidIgnoreDirName — строгий шаблон имени каталога для tree-hash ignore
+// (OPS-2). Только простое имя (матчится по имени компонента на любой глубине):
+// непустое, без '/', не '.'/'..', не начинается с '-', ограниченной длины.
+// Полные пути/glob'ы запрещены — это не ослабляет baseline identity.
+func ValidIgnoreDirName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if len(name) > 128 {
+		return false
+	}
+	if name[0] == '-' || name[0] == '/' {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r == '/', r == '\\', r == 0, r == ' ':
+			return false
+		case r != '_' && r != '-' && r != '.' && (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9'):
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/checks/ignore_test.go
+++ b/pkg/checks/ignore_test.go
@@ -1,0 +1,85 @@
+package checks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidIgnoreDirNameStrict(t *testing.T) {
+	valid := []string{"coverage", ".cache", "target", "build-out", ".next"}
+	for _, name := range valid {
+		if !ValidIgnoreDirName(name) {
+			t.Errorf("ожидали валидное имя %q", name)
+		}
+	}
+	invalid := map[string]bool{
+		"": true, ".": true, "..": true,
+		"a/b": true, "a\\b": true, "/abs": true,
+		"-leading": true, "has space": true, "quo\"te": true,
+		"non\x00ascii": true,
+	}
+	for name := range invalid {
+		if ValidIgnoreDirName(name) {
+			t.Errorf("%q: получили valid, ожидали invalid", name)
+		}
+	}
+	if ValidIgnoreDirName(string(make([]byte, 129))) {
+		t.Error("слишком длинное имя должно быть недопустимо")
+	}
+}
+
+func TestExtraIgnoreDirsMergeAndDigest(t *testing.T) {
+	ResetExtraIgnoreDirs()
+	defer ResetExtraIgnoreDirs()
+
+	dir := t.TempDir()
+	mkdir := func(rel string) {
+		if err := os.MkdirAll(filepath.Join(dir, rel), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mkfile := func(rel string) {
+		if err := os.WriteFile(filepath.Join(dir, rel), []byte(rel), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mkfile("a.txt")
+	mkdir("coverage")
+	mkfile("coverage/x.txt")
+	mkdir("src")
+	mkfile("src/main.go")
+
+	baseDigest, err := WorkspaceDigest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// project-specific ignore: coverage
+	SetExtraIgnoreDirs([]string{"coverage"})
+	withExtra, err := WorkspaceDigest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withExtra == baseDigest {
+		t.Fatal("digest должен измениться при добавлении ignore-имени")
+	}
+
+	// canonical baseline никогда не удаляется: .git остаётся в DefaultIgnoreDirs
+	dd := DefaultIgnoreDirs()
+	if !dd[".git"] || !dd[".ai-team"] {
+		t.Fatal("baseline должен оставаться")
+	}
+	if !dd["coverage"] {
+		t.Fatal("extra ignore должен быть добавлен")
+	}
+
+	ResetExtraIgnoreDirs()
+	afterReset, err := WorkspaceDigest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterReset != baseDigest {
+		t.Fatal("reset должен вернуть baseline digest")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,36 @@ type Config struct {
 	Effort         string             `yaml:"effort,omitempty"`
 	StageTimeout   string             `yaml:"stage_timeout,omitempty"`
 	Containment    *ContainmentConfig `yaml:"containment,omitempty"`
+	TreeHash       *TreeHashConfig    `yaml:"tree_hash,omitempty"`
+}
+
+// TreeHashConfig — project-specific настройки tree hashing (OPS-2).
+// IgnoreDirs добавляет имена каталогов к каноническому baseline без его
+// ослабления. Только простые имена (строгий ValidIgnoreDirName), никаких путей
+// или glob'ов.
+type TreeHashConfig struct {
+	IgnoreDirs []string `yaml:"ignore_dirs,omitempty"`
+}
+
+// ValidIgnoreDirName — строгий шаблон имени каталога для tree-hash ignore
+// (канонический — в pkg/checks, где живёт tree hashing).
+func ValidIgnoreDirName(name string) bool { return checks.ValidIgnoreDirName(name) }
+
+func (tc *TreeHashConfig) Validate() error {
+	if tc == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(tc.IgnoreDirs))
+	for _, name := range tc.IgnoreDirs {
+		if !checks.ValidIgnoreDirName(name) {
+			return fmt.Errorf("tree_hash.ignore_dirs: недопустимое имя каталога %q (допустимо только простое имя: буквы/цифры/-/./_, без '/', не '.'/'..', без ведущего '-')", name)
+		}
+		if seen[name] {
+			return fmt.Errorf("tree_hash.ignore_dirs: дубликат %q", name)
+		}
+		seen[name] = true
+	}
+	return nil
 }
 
 type ContainmentConfig struct {
@@ -85,6 +115,7 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	if err := validateMappingKeys(value, map[string]bool{
 		"schema_version": true, "pipeline": true, "cli": true, "model": true,
 		"effort": true, "stage_timeout": true, "workflow": true, "containment": true,
+		"tree_hash": true,
 	}, "config"); err != nil {
 		return err
 	}
@@ -96,6 +127,7 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 		Effort        string          `yaml:"effort"`
 		StageTimeout  string          `yaml:"stage_timeout"`
 		Workflow      *WorkflowConfig `yaml:"workflow"`
+		TreeHash      *TreeHashConfig `yaml:"tree_hash"`
 	}
 	var raw rawConfig
 	if err := value.Decode(&raw); err != nil {
@@ -111,6 +143,7 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	c.Effort = raw.Effort
 	c.StageTimeout = raw.StageTimeout
 	c.Workflow = raw.Workflow
+	c.TreeHash = raw.TreeHash
 
 	if raw.Pipeline.Kind == 0 {
 		return fmt.Errorf("config: pipeline is required")
@@ -404,6 +437,11 @@ func (c *Config) Validate(reg AgentLookup) error {
 	}
 	if c.Containment != nil {
 		if err := c.Containment.Validate(); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if c.TreeHash != nil {
+		if err := c.TreeHash.Validate(); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/arturpanteleev/ai-team/pkg/checks"
 	"github.com/arturpanteleev/ai-team/pkg/safeio"
 	"gopkg.in/yaml.v3"
 )
@@ -26,6 +27,12 @@ func Load(path string) (*Config, error) {
 			return nil, fmt.Errorf("config: multiple YAML documents are not supported")
 		}
 		return nil, err
+	}
+	// OPS-2: регистрируем project-specific ignore dirs в каноническом tree
+	// hash'е как процесс-глобальный набор — все вычисления workspace digest
+	// (checks, pipeline, delivery) используют идентичный ignore-list.
+	if cfg.TreeHash != nil {
+		checks.SetExtraIgnoreDirs(cfg.TreeHash.IgnoreDirs)
 	}
 	return &cfg, nil
 }

--- a/pkg/config/treehash_config_test.go
+++ b/pkg/config/treehash_config_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arturpanteleev/ai-team/pkg/checks"
+)
+
+func TestTreeHashConfigValidate(t *testing.T) {
+	// валидный
+	valid := &TreeHashConfig{IgnoreDirs: []string{"coverage", ".cache"}}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("ожидали valid: %v", err)
+	}
+	// недопустимые имена
+	for _, name := range []string{"", ".", "..", "a/b", "-x", "a/b/c", "x y"} {
+		tc := &TreeHashConfig{IgnoreDirs: []string{name}}
+		if err := tc.Validate(); err == nil {
+			t.Errorf("name %q должен быть отвергнут", name)
+		}
+	}
+	// дубликаты
+	dup := &TreeHashConfig{IgnoreDirs: []string{"coverage", "coverage"}}
+	if err := dup.Validate(); err == nil {
+		t.Error("дубликат должен быть отвергнут")
+	}
+}
+
+func TestLoadAppliesTreeHashIgnoreDirs(t *testing.T) {
+	checks.ResetExtraIgnoreDirs()
+	defer checks.ResetExtraIgnoreDirs()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := []byte(`
+schema_version: 4
+pipeline: [a]
+tree_hash:
+  ignore_dirs:
+    - build
+    - .scanner
+`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.TreeHash == nil || len(cfg.TreeHash.IgnoreDirs) != 2 {
+		t.Fatalf("tree_hash не загружен: %+v", cfg.TreeHash)
+	}
+	dd := checks.DefaultIgnoreDirs()
+	if !dd["build"] || !dd[".scanner"] {
+		t.Fatal("extra ignore dirs должны быть зарегистрированы в canonical tree hash")
+	}
+	if !dd[".git"] {
+		t.Fatal("baseline не должен быть ослаблен")
+	}
+}
+
+func TestLoadRejectsInvalidTreeHash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := []byte(`
+schema_version: 4
+pipeline: [a]
+tree_hash:
+  ignore_dirs:
+    - foo/bar
+`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Load не валидирует ignore-имена сам, но применяет их только если валидны;
+	// полная строгая валидация — через Config.Validate.
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.Validate(nil); err == nil {
+		t.Error("недопустимый ignore path должен быть отвергнут Validate")
+	}
+}


### PR DESCRIPTION
## What
Project-specific `tree_hash.ignore_dirs` — строгий configurable ignore для workspace tree hashing (OPS-2), без ослабления baseline identity.

- **pkg/checks/ignore.go**: `ValidIgnoreDirName` (строгий шаблон) + `SetExtraIgnoreDirs`/`ResetExtraIgnoreDirs` — процесс-глобальный extra-набор, мёрженный в канонический `DefaultIgnoreDirs`. Baseline (`DefaultIgnoreDirs`) неизменяем.
- **pkg/config**: `Config.TreeHash{IgnoreDirs}` (yaml `tree_hash`), строгая валидация (только простые имена, без дубликатов) в `TreeHashConfig.Validate` + `Config.Validate`; `Load()` регистрирует набор → все digest-вычисления процесса используют идентичный ignore-list (инвариант check-time == delivery-time защищён).
- Тесты: `checks/ignore_test.go`, `config/treehash_config_test.go`.

## Why
Единый источник истины для ignore-list без threading через все call-site digest — устраняет класс ошибок «забыли игнор у одного пути» и защищает целостность binding проверенного digest к delivery.

## Verification
- `go build ./...`, `go vet`, `gofmt -l` чисто
- `go test ./pkg/checks ./pkg/config ./pkg/pipeline ./pkg/delivery` — зелёные
- `go test ./...` — только два известных e2e baseline-fail вне scope
- `make specs` 68/68 (67 + новый delta-спек)

## Stack
base: `ops3-fail-closed-resume` (PR #65)