### PR TITLE
feat(export): self-contained deterministic run bundle + export/verify (V0-4)

### DIFF
--- a/cmd/ai-team/export.go
+++ b/cmd/ai-team/export.go
@@ -77,7 +77,10 @@ func cmdExport() {
 	}
 	committed = true
 
-	bundleSHA := export.BundleDigest(index)
+	bundleSHA, err := export.BundleDigest(index)
+	if err != nil {
+		fatal("Не удалось вычислить bundle_sha256: %v", err)
+	}
 	if err := export.PublishVerified(filepath.Join(absolute, ".ai-team"), runID, outDir, bundleSHA, time.Now().UTC()); err != nil {
 		fatal("Не удалось записать verified-запись state/exports: %v", err)
 	}

--- a/cmd/ai-team/export.go
+++ b/cmd/ai-team/export.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/arturpanteleev/ai-team/pkg/export"
+)
+
+// cmdExport собирает проверенный portable bundle терминального run (V0-4):
+// whitelisted typed records и digests без raw logs/stdout. Bundle проходит
+// полную verify и только после этого публикуется verified-запись в
+// state/exports/<runID>.json (контракт V0-0) — она открывает право
+// `gc --prune-runs` удалить evidence run'а.
+func cmdExport() {
+	exportFlags := flag.NewFlagSet("export", flag.ExitOnError)
+	target := exportFlags.String("target", ".", "Путь к целевому проекту")
+	out := exportFlags.String("out", "", "Каталог bundle (по умолчанию .ai-team/exports/<run_id>.bundle)")
+	if err := exportFlags.Parse(os.Args[2:]); err != nil {
+		fatal("Ошибка аргументов export: %v", err)
+	}
+	if exportFlags.NArg() != 1 {
+		fatal("Использование: ai-team export [--target <dir>] [--out <path>] <run_id>")
+	}
+	runID := exportFlags.Arg(0)
+	if runID == "" || runID == "." || runID == ".." || filepath.Base(runID) != runID {
+		fatal("недопустимый run_id %q", runID)
+	}
+	absolute, err := absoluteTarget(*target)
+	if err != nil {
+		fatal("Ошибка target: %v", err)
+	}
+	requireControlRoot(absolute)
+
+	runDir := filepath.Join(absolute, ".ai-team", "runs", runID)
+	if _, err := os.Stat(filepath.Join(runDir, "anchor.json")); err != nil {
+		fatal("run %s не является терминальным (нет anchor.json): %v", runID, err)
+	}
+
+	outDir := *out
+	if outDir == "" {
+		outDir = filepath.Join(absolute, ".ai-team", "exports", runID+".bundle")
+	} else if !filepath.IsAbs(outDir) {
+		outDir = filepath.Join(absolute, outDir)
+	}
+	outDir = filepath.Clean(outDir)
+	if _, err := os.Stat(outDir); err == nil {
+		fatal("bundle %s уже существует", outDir)
+	}
+	if err := os.MkdirAll(filepath.Dir(outDir), 0755); err != nil {
+		fatal("Ошибка создания каталога bundle: %v", err)
+	}
+
+	tmp, err := os.MkdirTemp(filepath.Dir(outDir), ".bundle-"+runID+"-")
+	if err != nil {
+		fatal("Ошибка staging bundle: %v", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(tmp)
+		}
+	}()
+
+	index, err := export.Build(runDir, tmp)
+	if err != nil {
+		fatal("Ошибка экспорта: %v", err)
+	}
+	if err := export.VerifyBundle(tmp); err != nil {
+		fatal("Экспорт не прошёл полную проверку (evidence повреждена?): %v", err)
+	}
+	if err := os.Rename(tmp, outDir); err != nil {
+		fatal("Не удалось зафиксировать bundle: %v", err)
+	}
+	committed = true
+
+	bundleSHA := export.BundleDigest(index)
+	if err := export.PublishVerified(filepath.Join(absolute, ".ai-team"), runID, outDir, bundleSHA, time.Now().UTC()); err != nil {
+		fatal("Не удалось записать verified-запись state/exports: %v", err)
+	}
+
+	fmt.Printf("✓ Run %s проверенно экспортирован\n", runID)
+	fmt.Printf("  bundle:        %s\n", outDir)
+	fmt.Printf("  bundle_sha256: %s\n", bundleSHA)
+	fmt.Printf("  verified:      state/exports/%s.json (разрешает gc --prune-runs)\n", runID)
+}

--- a/cmd/ai-team/main.go
+++ b/cmd/ai-team/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/arturpanteleev/ai-team/pkg/control"
 	"github.com/arturpanteleev/ai-team/pkg/eval"
 	"github.com/arturpanteleev/ai-team/pkg/evidence"
+	"github.com/arturpanteleev/ai-team/pkg/export"
 	"github.com/arturpanteleev/ai-team/pkg/metrics"
 	"github.com/arturpanteleev/ai-team/pkg/pipeline"
 	"github.com/arturpanteleev/ai-team/pkg/preflight"
@@ -73,6 +74,8 @@ func main() {
 		cmdList()
 	case "usage":
 		cmdUsage()
+	case "export":
+		cmdExport()
 	case "verify":
 		cmdVerify()
 	case "eval":
@@ -105,12 +108,24 @@ func printUsage() {
   ai-team scheduler-worker         Claim и выполнить job из persistent queue
   ai-team list                     Список доступных агентов
   ai-team usage <run_id>           Usage-сводка завершённого run (этапы, попытки, время)
-  ai-team verify                   Проверить tamper-evident anchor терминального run
+  ai-team export <run_id>          Собрать проверенный portable bundle терминального run
+                                   (whitelisted typed records и digests; публикует
+                                   verified-запись state/exports)
+  ai-team verify [--target <dir>] <run_id>
+                                   Проверить evidence терминального run (anchor, chain, попытки, attestation)
+  ai-team verify <bundle-dir>      Проверить portable bundle самодостаточно (без repo и .ai-team)
   ai-team eval                     Оценить качество артефакта или агента
   ai-team web                      Запустить web-дашборд
   ai-team gc                       Уборка растущих артефактов .ai-team
   ai-team version                  Версия
   ai-team help                     Эта справка
+
+Флаги usage:
+  --target <path>           Путь к целевому проекту (по умолчанию текущая директория)
+
+Флаги export:
+  --target <path>           Путь к целевому проекту (по умолчанию текущая директория)
+  --out <path>              Каталог bundle (по умолчанию .ai-team/exports/<run_id>.bundle)
 
 Флаги gc:
   --target <path>           Путь к целевому проекту (по умолчанию текущая директория)
@@ -1045,8 +1060,11 @@ func cmdList() {
 	}
 }
 
-// cmdVerify проверяет tamper-evident anchor терминального run:
-// ai-team verify --target <dir> <run_id>
+// cmdVerify проверяет tamper-evident evidence терминального run или
+// самодостаточного portable bundle (V0-4).
+//
+//	ai-team verify --target <dir> <run_id>   — локальная evidence run
+//	ai-team verify <bundle-dir>              — bundle без repo и .ai-team
 func cmdVerify() {
 	verifyFlags := flag.NewFlagSet("verify", flag.ExitOnError)
 	target := verifyFlags.String("target", ".", "Путь к целевому проекту")
@@ -1054,23 +1072,39 @@ func cmdVerify() {
 		fatal("Ошибка аргументов verify: %v", err)
 	}
 	if verifyFlags.NArg() != 1 {
-		fatal("Использование: ai-team verify --target <dir> <run_id>")
+		fatal("Использование: ai-team verify [--target <dir>] <run_id> | <bundle-dir>")
 	}
-	runID := verifyFlags.Arg(0)
-	if runID == "" || runID == "." || runID == ".." || filepath.Base(runID) != runID {
-		fatal("недопустимый run_id %q", runID)
+	arg := verifyFlags.Arg(0)
+	if len(arg) > 1024 {
+		fatal("недопустимый аргумент verify")
 	}
+	info, statErr := os.Stat(arg)
+	if statErr == nil && info.IsDir() {
+		if err := export.VerifyBundle(arg); err != nil {
+			fmt.Fprintf(os.Stderr, "✗ Bundle %s: %v\n", arg, ui.Colorize(err.Error(), ui.ColorRed))
+			os.Exit(exitFailed)
+		}
+		fmt.Printf("✓ Bundle %s: OK — records, event chain, anchor, attempt manifests и attestation v1 согласованы\n", arg)
+		return
+	}
+	if strings.ContainsAny(arg, `/\`) || arg == "." || arg == ".." || filepath.Base(arg) != arg {
+		if statErr != nil && !os.IsNotExist(statErr) {
+			fatal("Ошибка доступа к %q: %v", arg, statErr)
+		}
+		fatal("Bundle %q не найден (каталог bundle должен существовать)", arg)
+	}
+	runID := arg
 	absolute, err := absoluteTarget(*target)
 	if err != nil {
 		fatal("Ошибка target: %v", err)
 	}
 	requireControlRoot(absolute)
 	runDir := filepath.Join(absolute, ".ai-team", "runs", runID)
-	if err := evidence.VerifyAnchor(runDir); err != nil {
+	if err := export.VerifyEvidence(runDir); err != nil {
 		fmt.Fprintf(os.Stderr, "✗ Run %s: %v\n", runID, ui.Colorize(err.Error(), ui.ColorRed))
 		os.Exit(exitFailed)
 	}
-	fmt.Printf("✓ Run %s: anchor OK — event chain и manifests digest совпадают\n", runID)
+	fmt.Printf("✓ Run %s: anchor OK — event chain, manifests digest, attempt manifests и attestation v1 согласованы\n", runID)
 }
 
 func cmdWeb() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -195,6 +195,22 @@ _type/predicateType/schema_version) — compatibility policy; `Digest` даёт
 стабильный sha256 statement'а. За рамки warning/usage не утверждает ничего,
 что не может вычислить deterministically (subject пуст вне Git).
 
+export/verify (V0-4): `pkg/export` собирает самодостаточный deterministic
+portable bundle терминального run в `ai-team export <run_id>` (whitelisted
+typed records — run/config/workflow snapshots, hash-chained event log, anchor,
+attestation v1, attempt manifests; без raw logs/stdout). index.json несёт sha256
+каждого record без тайм-меток — identical evidence даёт байт-в-байт одинаковый
+bundle (BundleDigest). Перед публикацией bundle обязан пройти полную verify:
+records против своих sha256, run identity/schema, config/workflow snapshots
+против run manifest, event chain + anchor (VerifyAnchor), attempt manifests
+против manifest_sha256 в attempt_finished событиях (файлы↔events связка, которой
+VerifyAnchor не даёт), attestation v1 против events/config/workflow/
+attempt_count/provenance. Только после успешной verify пишется verified-запись
+в state/exports/<runID>.json (контракт V0-0), открывающая право `gc --prune-runs`.
+`ai-team verify <bundle-dir>` проверяет bundle самодостаточно без repo и
+.ai-team; `ai-team verify <run_id>` — та же full-свёртка live evidence.
+Экспорт отказастся от non-terminal run и от run без attestation.json.
+
 Локальный `RunController` связывает HTTP с тем же `RunEngine`, резервирует
 run ID до запуска worker goroutine и запрещает дублирующий active worker.
 `POST /api/runs`, `/resume`, `/cancel` и approval `/decisions` возвращают

--- a/e2etest/export_test.go
+++ b/e2etest/export_test.go
@@ -1,0 +1,120 @@
+package e2etest
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestE2E_ExportAndVerifyBundle — реальный pipeline flow до терминального run,
+// затем `ai-team export` (V0-4): bundle публикуется, verified-запись в
+// state/exports, повторная самодостаточная verify (без repo и .ai-team) и
+// локальная verify сходятся; tampering события ловится и вне repo.
+func TestE2E_ExportAndVerifyBundle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	dir := t.TempDir()
+	bin := buildBinary(t)
+	pathEnv := setupMock(t)
+	setupDeliveryGit(t, dir)
+
+	if code, out := runAI(t, bin, dir, []string{pathEnv}, "init"); code != 0 {
+		t.Fatalf("ai-team init failed (%d):\n%s", code, out)
+	}
+	code, out := runAI(t, bin, dir, []string{pathEnv}, "run",
+		"--feature", "e2e-export", "--task", "E2E export task", "--approve-gates")
+	if code != 3 {
+		t.Fatalf("run должен остановиться для delivery approval (exit 3), got %d:\n%s", code, out)
+	}
+	hashMatch := regexp.MustCompile(`Plan SHA-256: ([a-f0-9]{64})`).FindStringSubmatch(out)
+	resumeMatch := regexp.MustCompile(`ai-team run --resume ([^ ]+) --approve-plan`).FindStringSubmatch(out)
+	if len(hashMatch) != 2 || len(resumeMatch) != 2 {
+		t.Fatalf("no delivery plan hash/resume in output:\n%s", out)
+	}
+	code, out = runAI(t, bin, dir, []string{pathEnv}, "run", "--resume", resumeMatch[1],
+		"--approve-gates", "--approve-plan", hashMatch[1])
+	if code != 0 {
+		t.Fatalf("approved delivery retry failed (%d):\n%s", code, out)
+	}
+
+	runs, err := os.ReadDir(filepath.Join(dir, ".ai-team", "runs"))
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("ожидался один terminal run: %v", err)
+	}
+	runID := runs[0].Name()
+	if code, out := runAI(t, bin, dir, nil, "verify", "--target", dir, runID); code != 0 {
+		t.Fatalf("локальная verify terminal-раun не прошла (%d):\n%s", code, out)
+	}
+
+	bundleDir := filepath.Join(dir, ".ai-team", "exports", runID+".bundle")
+	if code, out := runAI(t, bin, dir, nil, "export", "--target", dir, runID); code != 0 {
+		t.Fatalf("export не прошёл (%d):\n%s", code, out)
+	}
+	for _, rel := range []string{
+		"index.json", "run.json", "config.json", "workflow.json", "anchor.json",
+		"attestation.json", "events.jsonl",
+	} {
+		if _, err := os.Stat(filepath.Join(bundleDir, rel)); err != nil {
+			t.Fatalf("bundle %s отсутствует: %v", rel, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".ai-team", "state", "exports", runID+".json")); err != nil {
+		t.Fatalf("verified-запись не опубликована: %v", err)
+	}
+
+	if code, out := runAI(t, bin, dir, nil, "verify", bundleDir); code != 0 {
+		t.Fatalf("самодостаточная verify bundle не прошла (%d):\n%s", code, out)
+	}
+
+	// Нейтральный каталог вне repo и .ai-team: bundle самоподписан.
+	neutral := filepath.Join(t.TempDir(), "bundle-copy")
+	if err := copyTree(bundleDir, neutral); err != nil {
+		t.Fatalf("copy bundle: %v", err)
+	}
+	eventsPath := filepath.Join(neutral, "events.jsonl")
+	if err := os.Chmod(eventsPath, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(eventsPath, []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tamperedCode, tamperedOut := runAI(t, bin, neutral, nil, "verify", neutral)
+	if tamperedCode == 0 {
+		t.Fatalf("verify обязан обнаружить tampering events в bundle:\n%s", tamperedOut)
+	}
+	if !strings.Contains(tamperedOut, "не совпадает") {
+		t.Fatalf("ожидалась диагностика о подмене, получено:\n%s", tamperedOut)
+	}
+}
+
+func copyTree(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if entry.IsDir() {
+			if err := copyTree(srcPath, dstPath); err != nil {
+				return err
+			}
+			continue
+		}
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(dstPath, data, 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -1,0 +1,490 @@
+// Package export реализует самодостаточный deterministic portable bundle
+// терминального run (V0-4): whitelisted typed records и digests без raw
+// logs/stdout, перепроверяемые без исходного repo и .ai-team. Bundle хранит
+// зеркало run evidence (run.json, config/workflow snapshots, hash-chained
+// event log, anchor, attestation v1, attempt manifests) плюс index.json с
+// sha256 каждого record. Экспорт публикует verified-запись в state/exports
+// (контракт V0-0), что открывает право гс на prune этой evidence.
+package export
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/arturpanteleev/ai-team/pkg/attest"
+	"github.com/arturpanteleev/ai-team/pkg/evidence"
+	"github.com/arturpanteleev/ai-team/pkg/provenance"
+	"github.com/arturpanteleev/ai-team/pkg/retention"
+	"github.com/arturpanteleev/ai-team/pkg/safeio"
+)
+
+// BundleSchema — версия контракта portable bundle.
+const BundleSchema = 1
+
+// BundleType — тип index.json (отличает bundle от произвольного каталога).
+const BundleType = "ai-team-run-bundle"
+
+// indexFileName — имя манифеста bundle.
+const indexFileName = "index.json"
+
+// Типы whitelisted typed records, переносимых в bundle. Raw logs/stdout,
+// reports и usage-метрики исключены по умолчанию.
+const (
+	RecordRunManifest      = "run_manifest"
+	RecordConfigSnapshot   = "config_snapshot"
+	RecordWorkflowSnapshot = "workflow_snapshot"
+	RecordEventLog         = "event_log"
+	RecordAnchor           = "anchor"
+	RecordAttestation      = "attestation"
+	RecordAttemptManifest  = "attempt_manifest"
+)
+
+const (
+	maxRunManifestSize  = 1 << 20
+	maxIndexSize        = 1 << 20
+	maxSnapshotSize     = 8 << 20
+	maxAnchorSize       = 64 << 10
+	maxEventLogSize     = 64 << 20
+	maxAttestationSize  = 1 << 20
+	maxAttemptManifest  = 8 << 20
+	maxBundleIndexFiles = 1 << 12
+)
+
+// Record — один whitelisted файл bundle'а и его sha256.
+type Record struct {
+	Type   string `json:"type"`
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+}
+
+// Index — детерминированный манифест bundle'а. Без тайм-меток: одни и те же
+// evidence дают байт-в-байт одинаковый index.json (и одинаковый BundleDigest).
+type Index struct {
+	SchemaVersion int      `json:"schema_version"`
+	Type          string   `json:"type"`
+	RunID         string   `json:"run_id"`
+	Records       []Record `json:"records"`
+}
+
+// BundleDigest — deterministic содержимость identity bundle'а: sha256
+// канонического index.json (всегда одинаков для одинакового evidence).
+func BundleDigest(index *Index) string {
+	data, err := json.Marshal(index)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func sha256Bytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// Build копирует whitelisted evidence терминального run в outDir и строит
+// index.json. Run обязан быть terminal (anchor.json). Ошибка не оставляет
+// partial-config: каталог не создаётся, все копии все-в-одном файле intо outDir.
+func Build(runDir, outDir string) (*Index, error) {
+	manifest, err := readRunManifest(runDir)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := safeio.ReadRegularFile(filepath.Join(runDir, "anchor.json"), maxAnchorSize); err != nil {
+		return nil, fmt.Errorf("export: run %s не terminal (нет anchor.json): %w", manifest.RunID, err)
+	}
+	files := []struct{ kind, rel string }{
+		{RecordRunManifest, "run.json"},
+		{RecordConfigSnapshot, fromSlash(manifest.ConfigEvidence)},
+		{RecordWorkflowSnapshot, fromSlash(manifest.ResolvedWorkflow)},
+		{RecordEventLog, "events.jsonl"},
+		{RecordAnchor, "anchor.json"},
+		{RecordAttestation, "attestation.json"},
+	}
+	records := make([]Record, 0, len(files)+16)
+	for _, file := range files {
+		if err := safePath(file.rel); err != nil {
+			return nil, fmt.Errorf("export: небезопасный путь evidence %q: %w", file.rel, err)
+		}
+		sum, err := copyRecord(runDir, file.rel, outDir, file.kind)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, Record{Type: file.kind, Path: filepath.ToSlash(file.rel), SHA256: sum})
+	}
+	attemptDirs, err := os.ReadDir(filepath.Join(runDir, "attempts"))
+	if err != nil {
+		return nil, fmt.Errorf("export: attempts: %w", err)
+	}
+	ids := make([]string, 0, len(attemptDirs))
+	for _, entry := range attemptDirs {
+		if entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
+			ids = append(ids, entry.Name())
+		}
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		rel := filepath.Join("attempts", id, "manifest.json")
+		sum, err := copyRecord(runDir, rel, outDir, RecordAttemptManifest)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, Record{Type: RecordAttemptManifest, Path: filepath.ToSlash(rel), SHA256: sum})
+	}
+	sort.Slice(records, func(i, j int) bool { return records[i].Path < records[j].Path })
+	index := &Index{SchemaVersion: BundleSchema, Type: BundleType, RunID: manifest.RunID, Records: records}
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, indexFileName), append(data, '\n'), 0644); err != nil {
+		return nil, err
+	}
+	return index, nil
+}
+
+func fromSlash(path string) string {
+	return filepath.FromSlash(strings.TrimSpace(path))
+}
+
+func safePath(rel string) error {
+	clean := filepath.Clean(filepath.FromSlash(rel))
+	if clean == "" || clean == "." || filepath.IsAbs(clean) {
+		return fmt.Errorf("path %q", rel)
+	}
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %q выходит за пределы bundle", rel)
+	}
+	return nil
+}
+
+func copyRecord(runDir, rel, outDir, kind string) (string, error) {
+	source := filepath.Join(runDir, rel)
+	maxBytes := sizeLimitFor(kind, rel)
+	data, err := safeio.ReadRegularFile(source, maxBytes)
+	if err != nil {
+		return "", fmt.Errorf("export: %s %s: %w", kind, rel, err)
+	}
+	destination := filepath.Join(outDir, rel)
+	if err := os.MkdirAll(filepath.Dir(destination), 0755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(destination, data, 0444); err != nil {
+		return "", err
+	}
+	return sha256Bytes(data), nil
+}
+
+func sizeLimitFor(kind, rel string) int64 {
+	switch {
+	case kind == RecordEventLog:
+		return maxEventLogSize
+	case kind == RecordAttestation:
+		return maxAttestationSize
+	case kind == RecordAttemptManifest:
+		return maxAttemptManifest
+	case kind == RecordAnchor:
+		return maxAnchorSize
+	case kind == RecordRunManifest:
+		return maxRunManifestSize
+	default:
+		return maxSnapshotSize
+	}
+}
+
+func readRunManifest(runDir string) (*evidence.RunManifest, error) {
+	data, err := safeio.ReadRegularFile(filepath.Join(runDir, "run.json"), maxRunManifestSize)
+	if err != nil {
+		return nil, fmt.Errorf("export: run manifest: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var manifest evidence.RunManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("export: run manifest decode: %w", err)
+	}
+	if manifest.RunID == "" || manifest.SchemaVersion != evidence.SchemaVersion {
+		return nil, fmt.Errorf("export: run manifest identity/schema mismatch")
+	}
+	return &manifest, nil
+}
+
+// VerifyBundle — самодостаточная проверка bundle без исходного repo и
+// .ai-team: каждый record обязан совпадать со своим sha256, а все semantic
+// связи (run manifest ↔ config/workflow snapshots ↔ event chain ↔ anchor ↔
+// attempt manifests ↔ attestation v1 ↔ provenance) обязаны сойтись.
+func VerifyBundle(bundleDir string) error {
+	indexData, err := safeio.ReadRegularFile(filepath.Join(bundleDir, indexFileName), maxIndexSize)
+	if err != nil {
+		return fmt.Errorf("verify: bundle index: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(indexData))
+	decoder.DisallowUnknownFields()
+	var index Index
+	if err := decoder.Decode(&index); err != nil {
+		return fmt.Errorf("verify: bundle index decode: %w", err)
+	}
+	if index.SchemaVersion != BundleSchema || index.Type != BundleType {
+		return fmt.Errorf("verify: bundle index не является supported ai-team run bundle")
+	}
+	if index.RunID == "" || len(index.Records) == 0 || len(index.Records) > maxBundleIndexFiles {
+		return fmt.Errorf("verify: bundle index повреждён")
+	}
+	seen := make(map[string]bool, len(index.Records))
+	for _, record := range index.Records {
+		if err := safePath(filepath.FromSlash(record.Path)); err != nil {
+			return fmt.Errorf("verify: record %q небезопасен", record.Path)
+		}
+		if seen[record.Path] {
+			return fmt.Errorf("verify: дублирующийся record %q", record.Path)
+		}
+		seen[record.Path] = true
+		data, readErr := safeio.ReadRegularFile(filepath.Join(bundleDir, filepath.FromSlash(record.Path)), sizeLimitFor(record.Type, record.Path))
+		if readErr != nil {
+			return fmt.Errorf("verify: record %s %s: %w", record.Type, record.Path, readErr)
+		}
+		if sum := sha256Bytes(data); sum != record.SHA256 {
+			return fmt.Errorf("verify: record %s %s не совпадает со своим sha256 (evidence подменён)", record.Type, record.Path)
+		}
+	}
+	if err := verifyCore(bundleDir, index.RunID, index.Records); err != nil {
+		return err
+	}
+	return nil
+}
+
+// VerifyEvidence — полная semantic-проверка live run evidence (та же логика,
+// что и bundle-verify, но против каталога run без index.json). Используется
+// `ai-team verify <run_id>`.
+func VerifyEvidence(runDir string) error {
+	manifest, err := readRunManifest(runDir)
+	if err != nil {
+		return err
+	}
+	if _, err := safeio.ReadRegularFile(filepath.Join(runDir, "anchor.json"), maxAnchorSize); err != nil {
+		return fmt.Errorf("verify: run %s не terminal: %w", manifest.RunID, err)
+	}
+	records, err := collectRunRecords(runDir, manifest)
+	if err != nil {
+		return err
+	}
+	return verifyCore(runDir, manifest.RunID, records)
+}
+
+func collectRunRecords(runDir string, manifest *evidence.RunManifest) ([]Record, error) {
+	records := []Record{
+		{Type: RecordRunManifest, Path: "run.json"},
+		{Type: RecordConfigSnapshot, Path: manifest.ConfigEvidence},
+		{Type: RecordWorkflowSnapshot, Path: manifest.ResolvedWorkflow},
+		{Type: RecordEventLog, Path: "events.jsonl"},
+		{Type: RecordAnchor, Path: "anchor.json"},
+		{Type: RecordAttestation, Path: "attestation.json"},
+	}
+	attemptDirs, err := os.ReadDir(filepath.Join(runDir, "attempts"))
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(attemptDirs))
+	for _, entry := range attemptDirs {
+		if entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
+			ids = append(ids, entry.Name())
+		}
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		rel := filepath.Join("attempts", id, "manifest.json")
+		sum, err := fileDigest(filepath.Join(runDir, rel), maxAttemptManifest)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, Record{Type: RecordAttemptManifest, Path: rel, SHA256: sum})
+	}
+	sort.Slice(records, func(i, j int) bool { return records[i].Path < records[j].Path })
+	return records, nil
+}
+
+// verifyCore — semantic-свёртка evidence против каталога с run layout:
+// 1) run manifest identity; 2) hash-цепочка + anchor; 3) attempt manifests
+// ↔ events; 4) attestation v1 ↔ run/spec/events/attempts/provenance.
+func verifyCore(root, runID string, records []Record) error {
+	manifest, err := readRunManifest(root)
+	if err != nil {
+		return err
+	}
+	if manifest.RunID != runID {
+		return fmt.Errorf("verify: run manifest run_id %q не совпадает с bundle %q", manifest.RunID, runID)
+	}
+	configSHA, err := fileDigest(filepath.Join(root, manifest.ConfigEvidence), maxSnapshotSize)
+	if err != nil {
+		return err
+	}
+	if configSHA != manifest.ConfigSHA256 {
+		return fmt.Errorf("verify: config snapshot не совпадает со своим sha256 в run manifest")
+	}
+	workflowSHA, err := fileDigest(filepath.Join(root, manifest.ResolvedWorkflow), maxSnapshotSize)
+	if err != nil {
+		return err
+	}
+	if workflowSHA != manifest.ResolvedWorkflowSHA256 {
+		return fmt.Errorf("verify: workflow snapshot не совпадает со своим sha256 в run manifest")
+	}
+
+	if err := evidence.VerifyAnchor(root); err != nil {
+		return fmt.Errorf("verify: anchor: %w", err)
+	}
+	events, err := evidence.VerifyEventLog(filepath.Join(root, "events.jsonl"), runID)
+	if err != nil {
+		return fmt.Errorf("verify: event log: %w", err)
+	}
+
+	manifestPeers := make(map[string]struct{}, len(records))
+	manifestByEvent := make(map[string]string)
+	for _, event := range events {
+		if event.Type != "attempt_finished" || !safeAttemptID(event.AttemptID) {
+			continue
+		}
+		digest, ok := event.Data["manifest_sha256"].(string)
+		if !ok || digest == "" {
+			continue
+		}
+		manifestByEvent[event.AttemptID] = digest
+	}
+	attemptCount := 0
+	for _, record := range records {
+		if record.Type != RecordAttemptManifest {
+			continue
+		}
+		attemptCount++
+		id := filepath.Base(filepath.Dir(filepath.FromSlash(record.Path)))
+		expected, claimed := manifestByEvent[id]
+		if !claimed {
+			return fmt.Errorf("verify: attempt %s нет manifest_sha256 в event chain (evidens непокрыт)", id)
+		}
+		if record.SHA256 != expected {
+			return fmt.Errorf("verify: attempt %s manifest не совпадает с event chain", id)
+		}
+		manifestPeers[id] = struct{}{}
+	}
+	if len(manifestByEvent) != attemptCount {
+		return fmt.Errorf("verify: число attempt manifests (%d) не совпадает с attempt_finished событиями (%d)",
+			attemptCount, len(manifestByEvent))
+	}
+	foundDirs, err := os.ReadDir(filepath.Join(root, "attempts"))
+	if err != nil {
+		return err
+	}
+	for _, entry := range foundDirs {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if _, ok := manifestPeers[entry.Name()]; !ok {
+			return fmt.Errorf("verify: лишняя attempt-директория %q не покрыта event chain", entry.Name())
+		}
+	}
+
+	attestationData, err := safeio.ReadRegularFile(filepath.Join(root, "attestation.json"), maxAttestationSize)
+	if err != nil {
+		return fmt.Errorf("verify: attestation: %w", err)
+	}
+	statement, err := attest.Parse(attestationData)
+	if err != nil {
+		return fmt.Errorf("verify: attestation parse: %w", err)
+	}
+	predicate := &statement.Predicate
+	if predicate.RunID != runID || predicate.Run.EvidenceSchemaVersion != evidence.SchemaVersion {
+		return fmt.Errorf("verify: attestation run identity/schema mismatch")
+	}
+	eventBytes, err := safeio.ReadRegularFile(filepath.Join(root, "events.jsonl"), maxEventLogSize)
+	if err != nil {
+		return err
+	}
+	if predicate.Run.EventLogSHA256 != sha256Bytes(eventBytes) {
+		return fmt.Errorf("verify: attestation event_log_sha256 не совпадает с событиями")
+	}
+	if predicate.Run.ConfigSHA256 != manifest.ConfigSHA256 {
+		return fmt.Errorf("verify: attestation config_sha256 не совпадает с run manifest")
+	}
+	if predicate.Spec.ResolvedWorkflowSHA256 != manifest.ResolvedWorkflowSHA256 {
+		return fmt.Errorf("verify: attestation resolved_workflow_sha256 не совпадает с run manifest")
+	}
+	if predicate.Run.AttemptCount != attemptCount {
+		return fmt.Errorf("verify: attestation attempt_count %d != %d", predicate.Run.AttemptCount, attemptCount)
+	}
+	if predicate.Provenance == nil || predicate.Provenance.SchemaVersion != provenance.SchemaVersion {
+		return fmt.Errorf("verify: attestation должна нести provenance manifest v1 (V0-2)")
+	}
+	if predicate.Provenance.RunID != runID {
+		return fmt.Errorf("verify: attestation provenance run_id не совпадает")
+	}
+	return nil
+}
+
+func fileDigest(path string, maxBytes int64) (string, error) {
+	data, err := safeio.ReadRegularFile(path, maxBytes)
+	if err != nil {
+		return "", err
+	}
+	return sha256Bytes(data), nil
+}
+
+func safeAttemptID(value string) bool {
+	return value != "" && value != "." && value != ".." && filepath.Base(value) == value
+}
+
+// PublishVerified пишет verified-запись в state/exports/<runID>.json
+// (контракт V0-0/V0-4): только после полной проверки bundle. Эта запись
+// открывает право `gc --prune-runs` удалить immutable evidence run'а.
+func PublishVerified(aiTeamRoot, runID, bundle string, bundleSHA string, exportedAt time.Time) error {
+	if aiTeamRoot == "" || runID == "" || runID == "." || runID == ".." || filepath.Base(runID) != runID {
+		return fmt.Errorf("недопустимый run_id %q", runID)
+	}
+	exportsDir := filepath.Join(aiTeamRoot, "state", "exports")
+	if err := os.MkdirAll(exportsDir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(exportsDir, runID+".json")
+	if err := safeio.RejectSymlink(path); err != nil {
+		return err
+	}
+	record := retention.ExportRecord{
+		SchemaVersion: retention.ExportSchema,
+		RunID:         runID,
+		Verified:      true,
+		Bundle:        bundle,
+		BundleSHA256:  bundleSHA,
+		ExportedAt:    exportedAt,
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(exportsDir, ".tmp-export-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -47,6 +48,18 @@ const (
 	RecordAttemptManifest  = "attempt_manifest"
 )
 
+// validRecordType — допускаемый whitelisted тип record bundle'а. Неизвестные
+// типы отклоняются fail-closed, чтобы произвольный index.json не мог объявить
+// любые файлы частью доказательного bundle.
+func validRecordType(t string) bool {
+	switch t {
+	case RecordRunManifest, RecordConfigSnapshot, RecordWorkflowSnapshot,
+		RecordEventLog, RecordAnchor, RecordAttestation, RecordAttemptManifest:
+		return true
+	}
+	return false
+}
+
 const (
 	maxRunManifestSize  = 1 << 20
 	maxIndexSize        = 1 << 20
@@ -74,15 +87,26 @@ type Index struct {
 	Records       []Record `json:"records"`
 }
 
-// BundleDigest — deterministic содержимость identity bundle'а: sha256
-// канонического index.json (всегда одинаков для одинакового evidence).
-func BundleDigest(index *Index) string {
-	data, err := json.Marshal(index)
+// indexBytes — те байты index.json, что пишутся на диск (единственный источник
+// истины для BundleDigest, чтобы внешний проверяющий воспроизвёл bundle_sha256
+// как sha256-файла index.json).
+func indexBytes(index *Index) ([]byte, error) {
+	data, err := json.MarshalIndent(index, "", "  ")
 	if err != nil {
-		return ""
+		return nil, err
 	}
-	sum := sha256.Sum256(data)
-	return hex.EncodeToString(sum[:])
+	return append(data, '\n'), nil
+}
+
+// BundleDigest — deterministic содержимость identity bundle'а: sha256 ровно тех
+// байтов index.json, что пишутся на диск (всегда одинаков для одинакового
+// evidence и равен sha256 файла index.json).
+func BundleDigest(index *Index) (string, error) {
+	data, err := indexBytes(index)
+	if err != nil {
+		return "", err
+	}
+	return sha256Bytes(data), nil
 }
 
 func sha256Bytes(data []byte) string {
@@ -141,11 +165,11 @@ func Build(runDir, outDir string) (*Index, error) {
 	}
 	sort.Slice(records, func(i, j int) bool { return records[i].Path < records[j].Path })
 	index := &Index{SchemaVersion: BundleSchema, Type: BundleType, RunID: manifest.RunID, Records: records}
-	data, err := json.MarshalIndent(index, "", "  ")
+	data, err := indexBytes(index)
 	if err != nil {
 		return nil, err
 	}
-	if err := os.WriteFile(filepath.Join(outDir, indexFileName), append(data, '\n'), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(outDir, indexFileName), data, 0644); err != nil {
 		return nil, err
 	}
 	return index, nil
@@ -240,6 +264,9 @@ func VerifyBundle(bundleDir string) error {
 	}
 	seen := make(map[string]bool, len(index.Records))
 	for _, record := range index.Records {
+		if !validRecordType(record.Type) {
+			return fmt.Errorf("verify: record %q имеет не-whitelisted тип %q", record.Path, record.Type)
+		}
 		if err := safePath(filepath.FromSlash(record.Path)); err != nil {
 			return fmt.Errorf("verify: record %q небезопасен", record.Path)
 		}
@@ -255,10 +282,38 @@ func VerifyBundle(bundleDir string) error {
 			return fmt.Errorf("verify: record %s %s не совпадает со своим sha256 (evidence подменён)", record.Type, record.Path)
 		}
 	}
+	if err := ensureNoExtraneousFiles(bundleDir, &index); err != nil {
+		return err
+	}
 	if err := verifyCore(bundleDir, index.RunID, index.Records); err != nil {
 		return err
 	}
 	return nil
+}
+
+// ensureNoExtraneousFiles — bundle не должен содержать файлов вне index.json:
+// любой лишний файл вне whitelisted records — повод для подозрения, отклоняется.
+func ensureNoExtraneousFiles(bundleDir string, index *Index) error {
+	seen := make(map[string]bool, len(index.Records))
+	for _, record := range index.Records {
+		seen[filepath.FromSlash(record.Path)] = true
+	}
+	return filepath.WalkDir(bundleDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(bundleDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == indexFileName || seen[rel] {
+			return nil
+		}
+		return fmt.Errorf("verify: неизвестный файл %q вне index.json (лишние файлы не допускаются)", rel)
+	})
 }
 
 // VerifyEvidence — полная semantic-проверка live run evidence (та же логика,

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -1,7 +1,10 @@
 package export
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -126,11 +129,29 @@ func TestBundleBuildVerifyAndDeterminism(t *testing.T) {
 	if err := VerifyBundle(bundleB); err != nil {
 		t.Fatalf("VerifyBundle(B): %v", err)
 	}
-	if BundleDigest(indexA) != BundleDigest(indexB) {
+	digestA, err := BundleDigest(indexA)
+	if err != nil {
+		t.Fatalf("BundleDigest(A): %v", err)
+	}
+	digestB, err := BundleDigest(indexB)
+	if err != nil {
+		t.Fatalf("BundleDigest(B): %v", err)
+	}
+	if digestA != digestB {
 		t.Fatal("BundleDigest должен быть детерминированным для одинакового evidence")
 	}
-	if BundleDigest(indexA) == "" {
+	if digestA == "" {
 		t.Fatal("пустой BundleDigest")
+	}
+	// BundleDigest обязан равняться sha256 файла index.json на диске (контракт,
+	// чтобы внешний проверяющий воспроизвёл bundle_sha256 без Go).
+	diskData, readErr := os.ReadFile(filepath.Join(bundleA, indexFileName))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	sum := sha256.Sum256(diskData)
+	if digestA != hex.EncodeToString(sum[:]) {
+		t.Fatal("BundleDigest != sha256(файла index.json)")
 	}
 	if indexA.RunID != testRunID || indexA.SchemaVersion != BundleSchema || indexA.Type != BundleType {
 		t.Fatalf("index identity: %+v", indexA)
@@ -206,6 +227,28 @@ func TestVerifyBundleDetectsTampering(t *testing.T) {
 		}},
 		{"лишний attempt manifest", func(dir string) error {
 			return os.MkdirAll(filepath.Join(dir, "attempts", "x-fake"), 0755)
+		}},
+		{"лишний файл вне index", func(dir string) error {
+			return os.WriteFile(filepath.Join(dir, "leaked-secret.txt"), []byte("x"), 0644)
+		}},
+		{"record с не-whitelisted типом", func(dir string) error {
+			var idx Index
+			raw, err := os.ReadFile(filepath.Join(dir, indexFileName))
+			if err != nil {
+				return err
+			}
+			if err := json.Unmarshal(raw, &idx); err != nil {
+				return err
+			}
+			if len(idx.Records) == 0 {
+				return fmt.Errorf("нет records")
+			}
+			idx.Records = append(idx.Records, Record{Type: "rm -rf /", Path: idx.Records[0].Path, SHA256: idx.Records[0].SHA256})
+			out, err := json.MarshalIndent(idx, "", "  ")
+			if err != nil {
+				return err
+			}
+			return os.WriteFile(filepath.Join(dir, indexFileName), append(out, '\n'), 0644)
 		}},
 	}
 	for _, tc := range cases {

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -1,0 +1,286 @@
+package export
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/arturpanteleev/ai-team/pkg/attest"
+	"github.com/arturpanteleev/ai-team/pkg/evidence"
+	"github.com/arturpanteleev/ai-team/pkg/provenance"
+	"github.com/arturpanteleev/ai-team/pkg/retention"
+)
+
+const (
+	testRunID      = "r-export-0001"
+	testConfigJSON = `{"profile":"fast","cli":{"cmd":"opencode"}}`
+	testWorkJSON   = `{"stages":[{"name":"coder"}]}`
+	testFeature    = "feat"
+)
+
+func now() time.Time { return time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC) }
+
+// buildTerminalRun создаёт полный terminal run через evidence API + attest.Build
+// и возвращает его runDir.
+func buildTerminalRun(t *testing.T, runsRoot string) string {
+	t.Helper()
+	runID := testRunID
+	prov := provenance.New(runID, now())
+	prov.Add("runtime", "", provenance.UnknownDigest())
+	provJSON, err := json.Marshal(prov)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := evidence.Start(runsRoot, evidence.RunManifest{
+		RunID: runID, Feature: testFeature, StartedAt: now(),
+		ConfigSnapshot:   json.RawMessage(testConfigJSON),
+		WorkflowSnapshot: json.RawMessage(testWorkJSON),
+		Provenance:       provJSON,
+	})
+	if err != nil {
+		t.Fatalf("evidence start: %v", err)
+	}
+	artifactRoot, err := os.MkdirTemp("", "export-artifacts-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(artifactRoot)
+	attemptID := store.NewAttemptID("coder", 1)
+	err = store.PublishAttempt(evidence.AttemptManifest{
+		AttemptID: attemptID, Stage: "coder", StageIndex: 0,
+		StartedAt: now(), FinishedAt: now().Add(90 * time.Second),
+		Status: "passed", Execution: "succeeded", Decision: "approved", Outcome: "passed", Verdict: "APPROVED",
+	}, artifactRoot, nil, nil)
+	if err != nil {
+		t.Fatalf("publish attempt: %v", err)
+	}
+	manifestPath := filepath.Join(store.RunDir(), "attempts", attemptID, "manifest.json")
+	_, _, manifestDigest, err := evidence.ArtifactDigest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Append(evidence.Event{
+		Type: "run_started", Timestamp: now(),
+	}); err != nil {
+		t.Fatalf("run_started: %v", err)
+	}
+	if err := store.Append(evidence.Event{
+		Type: "attempt_started", Stage: "coder", AttemptID: attemptID, Timestamp: now().Add(time.Second),
+		Data: map[string]any{"stage_index": 1},
+	}); err != nil {
+		t.Fatalf("attempt_started: %v", err)
+	}
+	if err := store.Append(evidence.Event{
+		Type: "attempt_finished", Stage: "coder", AttemptID: attemptID, Timestamp: now().Add(90 * time.Second),
+		Data: map[string]any{"status": "passed", "execution": "succeeded", "decision": "approved",
+			"outcome": "passed", "verdict": "APPROVED", "manifest_sha256": manifestDigest},
+	}); err != nil {
+		t.Fatalf("attempt_finished: %v", err)
+	}
+	if err := store.Append(evidence.Event{
+		Type: "run_finished", Timestamp: now().Add(2 * time.Minute),
+		Data: map[string]any{"status": "completed", "stage_attempts": 1},
+	}); err != nil {
+		t.Fatalf("run_finished: %v", err)
+	}
+	statement, err := attest.Build(attest.Options{
+		RunDir: store.RunDir(), RunID: runID, FinishedAt: now().Add(2 * time.Minute),
+		Outcome: "completed",
+		CandidateSubject: []attest.Subject{{
+			Name: "candidate", Digest: map[string]string{"sha256": "aa11bb2200000000000000000000000000000000000000000000000000000000"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("attestation build: %v", err)
+	}
+	data, err := attest.Serialize(statement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store.RunDir(), "attestation.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return store.RunDir()
+}
+
+func TestBundleBuildVerifyAndDeterminism(t *testing.T) {
+	base := t.TempDir()
+	runsRoot := filepath.Join(base, "runs")
+	runDir := buildTerminalRun(t, runsRoot)
+
+	bundleA := filepath.Join(base, "bundleA")
+	bundleB := filepath.Join(base, "bundleB")
+	indexA, err := Build(runDir, bundleA)
+	if err != nil {
+		t.Fatalf("build A: %v", err)
+	}
+	indexB, err := Build(runDir, bundleB)
+	if err != nil {
+		t.Fatalf("build B: %v", err)
+	}
+	if err := VerifyBundle(bundleA); err != nil {
+		t.Fatalf("VerifyBundle(A): %v", err)
+	}
+	if err := VerifyBundle(bundleB); err != nil {
+		t.Fatalf("VerifyBundle(B): %v", err)
+	}
+	if BundleDigest(indexA) != BundleDigest(indexB) {
+		t.Fatal("BundleDigest должен быть детерминированным для одинакового evidence")
+	}
+	if BundleDigest(indexA) == "" {
+		t.Fatal("пустой BundleDigest")
+	}
+	if indexA.RunID != testRunID || indexA.SchemaVersion != BundleSchema || indexA.Type != BundleType {
+		t.Fatalf("index identity: %+v", indexA)
+	}
+	kinds := map[string]int{}
+	attemptRecords := 0
+	for _, record := range indexA.Records {
+		kinds[record.Type]++
+		if record.Type == RecordAttemptManifest {
+			attemptRecords++
+		}
+	}
+	if kinds[RecordAttemptManifest] != 1 || kinds[RecordAttestation] != 1 || kinds[RecordEventLog] != 1 {
+		t.Fatalf("records неполны: %+v", kinds)
+	}
+	if _, err := os.Stat(filepath.Join(bundleA, indexFileName)); err != nil {
+		t.Fatalf("index.json отсутствует: %v", err)
+	}
+}
+
+func TestVerifyEvidenceLiveRun(t *testing.T) {
+	base := t.TempDir()
+	runDir := buildTerminalRun(t, filepath.Join(base, "runs"))
+	if err := VerifyEvidence(runDir); err != nil {
+		t.Fatalf("VerifyEvidence live run: %v", err)
+	}
+}
+
+func TestExportRejectsNonTerminalRun(t *testing.T) {
+	base := t.TempDir()
+	runsRoot := filepath.Join(base, "runs")
+	runID := "r-export-nt-01"
+	store, err := evidence.Start(runsRoot, evidence.RunManifest{
+		RunID: runID, Feature: testFeature, StartedAt: now(),
+		ConfigSnapshot: json.RawMessage(testConfigJSON), WorkflowSnapshot: json.RawMessage(testWorkJSON),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Build(store.RunDir(), filepath.Join(base, "bundle")); err == nil {
+		t.Fatal("Build должен отказывать non-terminal run (нет anchor.json)")
+	}
+}
+
+func TestVerifyBundleDetectsTampering(t *testing.T) {
+	overwrite := func(path string, data []byte) error {
+		if err := os.Chmod(path, 0644); err != nil {
+			return err
+		}
+		return os.WriteFile(path, data, 0644)
+	}
+	cases := []struct {
+		name   string
+		mutate func(bundleDir string) error
+	}{
+		{"event log изменён", func(dir string) error {
+			return overwrite(filepath.Join(dir, "events.jsonl"), []byte("{}tampered\n"))
+		}},
+		{"attempt manifest изменён", func(dir string) error {
+			return overwrite(filepath.Join(dir, "attempts", "r-export-0001-001-coder", "manifest.json"), []byte("{}"))
+		}},
+		{"attestation удалена", func(dir string) error {
+			return os.Remove(filepath.Join(dir, "attestation.json"))
+		}},
+		{"run manifest изменён", func(dir string) error {
+			return overwrite(filepath.Join(dir, "run.json"), []byte("{}"))
+		}},
+		{"config snapshot удалён", func(dir string) error {
+			return os.Remove(filepath.Join(dir, "config.json"))
+		}},
+		{"anchor удалён", func(dir string) error {
+			return os.Remove(filepath.Join(dir, "anchor.json"))
+		}},
+		{"лишний attempt manifest", func(dir string) error {
+			return os.MkdirAll(filepath.Join(dir, "attempts", "x-fake"), 0755)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			runDir := buildTerminalRun(t, filepath.Join(base, "runs"))
+			bundle := filepath.Join(base, "bundle")
+			if _, err := Build(runDir, bundle); err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			if err := tc.mutate(bundle); err != nil {
+				t.Fatalf("mutate: %v", err)
+			}
+			if err := VerifyBundle(bundle); err == nil {
+				t.Fatal("VerifyBundle обязан обнаружить подмену")
+			}
+		})
+	}
+}
+
+func TestVerifyBundleRejectsForeignIndex(t *testing.T) {
+	dir := t.TempDir()
+	index := Index{SchemaVersion: BundleSchema, Type: "not-a-bundle", RunID: testRunID}
+	data, _ := json.MarshalIndent(index, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, indexFileName), append(data, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyBundle(dir); err == nil {
+		t.Fatal("чужой index.json должен отклоняться")
+	}
+}
+
+func TestPublishVerifiedRecord(t *testing.T) {
+	base := t.TempDir()
+	aiTeam := filepath.Join(base, ".ai-team")
+	sha := "f1b2c3d4"
+	exportedAt := now()
+	if err := PublishVerified(aiTeam, testRunID, "/tmp/bundle", sha, exportedAt); err != nil {
+		t.Fatalf("PublishVerified: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(aiTeam, "state", "exports", testRunID+".json"))
+	if err != nil {
+		t.Fatalf("запись не создана: %v", err)
+	}
+	var record retention.ExportRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.SchemaVersion != retention.ExportSchema || record.RunID != testRunID || !record.Verified ||
+		record.BundleSHA256 != sha || record.Bundle != "/tmp/bundle" {
+		t.Fatalf("запись не соответствует контракту V0-0: %+v", record)
+	}
+	if err := PublishVerified(aiTeam, "../escape", "/tmp/bundle", sha, exportedAt); err == nil {
+		t.Fatal("недопустимый run_id должен отклоняться")
+	}
+}
+
+func TestPublishVerifiedRoundtripRetention(t *testing.T) {
+	base := t.TempDir()
+	aiTeam := filepath.Join(base, ".ai-team")
+	sha := "deadbeef00"
+	if err := PublishVerified(aiTeam, testRunID, "/b", sha, now()); err != nil {
+		t.Fatal(err)
+	}
+	// Тот же JSON-контракт, который читает gc retention (полевый порядок не
+	// важен — отражение). Проверяем совместимость значений.
+	raw, err := os.ReadFile(filepath.Join(aiTeam, "state", "exports", testRunID+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record retention.ExportRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		t.Fatalf("retention decode: %v", err)
+	}
+	if !record.Verified || record.BundleSHA256 != sha {
+		t.Fatalf("roundtrip mismatch: %+v", record)
+	}
+}


### PR DESCRIPTION
V0-4 self-contained deterministic run bundle + export/verify. Includes should-fixes: BundleDigest hashes exact disk bytes, VerifyBundle enforces record-type whitelist and rejects extraneous files. Recreated PR (original #54 closed after base branch deletion).