### PR TITLE
feat(checks): generic junit-xml typed adapter (V0-6)

### DIFF
--- a/cmd/ai-team/gate.go
+++ b/cmd/ai-team/gate.go
@@ -107,6 +107,15 @@ func defaultGateOut(target string) string {
 	return filepath.Join("gate-out", ts)
 }
 
+// abbrev12 усекает commit sha до 12 символов; не-sha значения (WORKTREE)
+// печатаются как есть.
+func abbrev12(value string) string {
+	if len(value) <= 12 {
+		return value
+	}
+	return value[:12]
+}
+
 func printGateSummary(result *gate.Result, outDir string) {
 	byClass := make(map[string]int)
 	for _, mutation := range result.Mutations {
@@ -129,11 +138,11 @@ func printGateSummary(result *gate.Result, outDir string) {
 	}
 	fmt.Printf("\n%s Gate %s (exit %d) — %s\n", mark, status, gate.ExitCode(result), strings.Join(parts, ", "))
 
-	candLabel := result.Candidate
+	candidateRef := result.Candidate
 	if result.CandidateCommit != "" {
-		candLabel = shortSHA(result.CandidateCommit)
+		candidateRef = result.CandidateCommit
 	}
-	fmt.Printf("  base %s → %s (%s)\n", shortSHA(result.BaseCommit), candLabel, result.DiffPolicy)
+	fmt.Printf("  base %s → %s (%s)\n", abbrev12(result.BaseCommit), abbrev12(candidateRef), result.DiffPolicy)
 
 	switch result.PolicyVerdict {
 	case gate.VerdictPassed:
@@ -166,11 +175,4 @@ func printGateSummary(result *gate.Result, outDir string) {
 	fmt.Printf("  bundle: %s\n  bundle digest: %s\n", outDir, result.BundleSHA256)
 }
 
-// shortSHA — безопасный короткий префикс SHA для вывода: не паникует на
-// коротких/пустых строках (например, WORKTREE-кандидат без commit).
-func shortSHA(s string) string {
-	if len(s) < 12 {
-		return s
-	}
-	return s[:12]
-}
+

--- a/cmd/ai-team/gate.go
+++ b/cmd/ai-team/gate.go
@@ -174,5 +174,3 @@ func printGateSummary(result *gate.Result, outDir string) {
 
 	fmt.Printf("  bundle: %s\n  bundle digest: %s\n", outDir, result.BundleSHA256)
 }
-
-

--- a/e2etest/gate_junit_test.go
+++ b/e2etest/gate_junit_test.go
@@ -1,0 +1,96 @@
+package e2etest
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const gateJUnitGateYAML = `schema_version: 1
+diff_policy:
+  test_modify: off
+checks:
+  - name: pytest-unit
+    class: unit
+    adapter: junit-xml
+    report_file: report.xml
+    command: ["sh", "-c", "cat reports/pytest-pass.xml > report.xml"]
+    policy: required
+`
+
+const gateJUnitPassXML = `<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="2" failures="0" errors="0" skipped="0">
+    <testcase classname="test_app" name="test_add" time="0.001"/>
+    <testcase classname="test_app" name="test_parse" time="0.002"/>
+  </testsuite>
+</testsuites>
+`
+
+const gateJUnitFailXML = `<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="2" failures="1" errors="0" skipped="0">
+    <testcase classname="test_app" name="test_add" time="0.001"/>
+    <testcase classname="test_app" name="test_parse" time="0.002">
+      <failure message="AssertionError: parse failed" type="AssertionError"/>
+    </testcase>
+  </testsuite>
+</testsuites>
+`
+
+// TestE2E_GateJUnitAdapterNonGoRepo доказывает, что adapter junit-xml снимает
+// ограничение «только Go» (V0-6): в не-Go репозитории (Python + pytest-отчёт)
+// gate проходит/падает по JUnit отчёту и валидирует evidence digest.
+func TestE2E_GateJUnitAdapterNonGoRepo(t *testing.T) {
+	bin := buildBinary(t)
+	repo := t.TempDir()
+	gateGit(t, repo, "init", "-q")
+	gateGit(t, repo, "config", "user.email", "e2e@test")
+	gateGit(t, repo, "config", "user.name", "E2E Gate")
+	gateWrite(t, repo, map[string]string{
+		"app.py":                  "def add(a, b):\n    return a + b\n",
+		"tests/test_app.py":       "from app import add\n\ndef test_add():\n    assert add(1, 2) == 3\n",
+		"gate.yaml":               gateJUnitGateYAML,
+		"reports/pytest-pass.xml": gateJUnitPassXML,
+	})
+	gateGit(t, repo, "add", "-A")
+	gateGit(t, repo, "commit", "-q", "-m", "base")
+
+	// PASS: junit-xml adapter верифицирует отчёт, gate выходит 0.
+	outDir := filepath.Join(t.TempDir(), "gate-pass")
+	code, out := runAI(t, bin, t.TempDir(), nil, "gate", "--target", repo, "--out", outDir)
+	if code != 0 {
+		t.Fatalf("pass gate: exit=%d, out:\n%s", code, out)
+	}
+	if !strings.Contains(out, "PASS") {
+		t.Fatalf("PASS-строка не найдена:\n%s", out)
+	}
+	checkData, err := os.ReadFile(filepath.Join(outDir, "checks", "001-pytest-unit.json"))
+	if err != nil {
+		t.Fatalf("check evidence: %v", err)
+	}
+	var check map[string]any
+	if err := json.Unmarshal(checkData, &check); err != nil {
+		t.Fatal(err)
+	}
+	if check["status"] != "passed" || check["discovered_tests"].(float64) != 2 || check["passed_tests"].(float64) != 2 {
+		t.Fatalf("check evidence = %s", checkData)
+	}
+	if sha, ok := check["structured_output_sha256"].(string); !ok || sha == "" {
+		t.Fatalf("report digest обязан быть в evidence: %s", checkData)
+	}
+
+	// FAIL: отчёт с failure — required check падает даже при exit code sh = 0.
+	gateWrite(t, repo, map[string]string{"reports/pytest-pass.xml": gateJUnitFailXML})
+	gateGit(t, repo, "add", "-A")
+	gateGit(t, repo, "commit", "-q", "-m", "introduce failing test report")
+	code, out = runAI(t, bin, t.TempDir(), nil, "gate", "--target", repo, "--out", filepath.Join(t.TempDir(), "gate-fail"))
+	if code != 1 {
+		t.Fatalf("fail gate: exit=%d, ожидалось 1; out:\n%s", code, out)
+	}
+	if !strings.Contains(out, "FAIL") {
+		t.Fatalf("FAIL-строка не найдена:\n%s", out)
+	}
+}

--- a/pkg/checks/checks.go
+++ b/pkg/checks/checks.go
@@ -18,7 +18,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/arturpanteleev/ai-team/pkg/junit"
 	"github.com/arturpanteleev/ai-team/pkg/process"
+	"github.com/arturpanteleev/ai-team/pkg/safeio"
 	"gopkg.in/yaml.v3"
 )
 
@@ -30,6 +32,7 @@ const (
 	PolicyOptional = "optional"
 	AdapterCommand = "command"
 	AdapterGoTest  = "go-test-json"
+	AdapterJUnit   = "junit-xml"
 
 	StatusPassed  = "passed"
 	StatusFailed  = "failed"
@@ -50,6 +53,10 @@ type Definition struct {
 	Policy     string   `yaml:"policy" json:"policy"`
 	Timeout    string   `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	WorkingDir string   `yaml:"working_dir,omitempty" json:"working_dir,omitempty"`
+	// ReportFile — repo-relative путь JUnit XML внутри target (только для
+	// adapter junit-xml). Command пишет сюда отчёт; adapter читает строгим
+	// bounded parser и дигирует сырой файл как evidence (V0-6).
+	ReportFile string `yaml:"report_file,omitempty" json:"report_file,omitempty"`
 }
 
 func (d *Definition) UnmarshalYAML(node *yaml.Node) error {
@@ -58,7 +65,7 @@ func (d *Definition) UnmarshalYAML(node *yaml.Node) error {
 	}
 	allowed := map[string]bool{
 		"name": true, "class": true, "adapter": true, "command": true, "policy": true,
-		"timeout": true, "working_dir": true,
+		"timeout": true, "working_dir": true, "report_file": true,
 	}
 	seen := make(map[string]bool)
 	for i := 0; i < len(node.Content); i += 2 {
@@ -91,7 +98,7 @@ func (d Definition) Validate() error {
 		return fmt.Errorf("check %s: command обязателен", d.Name)
 	}
 	adapter := d.NormalizedAdapter()
-	if adapter != AdapterCommand && adapter != AdapterGoTest {
+	if adapter != AdapterCommand && adapter != AdapterGoTest && adapter != AdapterJUnit {
 		return fmt.Errorf("check %s: неизвестный adapter %q", d.Name, d.Adapter)
 	}
 	if adapter == AdapterGoTest {
@@ -101,6 +108,20 @@ func (d Definition) Validate() error {
 		if d.Class != "unit" && d.Class != "integration" && d.Class != "e2e" {
 			return fmt.Errorf("check %s: adapter %s допустим только для test class", d.Name, AdapterGoTest)
 		}
+	}
+	if adapter == AdapterJUnit {
+		if d.ReportFile == "" {
+			return fmt.Errorf("check %s: adapter %s требует report_file", d.Name, AdapterJUnit)
+		}
+		if report := filepath.Clean(filepath.FromSlash(d.ReportFile)); report == "." || filepath.IsAbs(report) ||
+			report == ".." || strings.HasPrefix(report, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("check %s: report_file должен быть repo-relative путём внутри target", d.Name)
+		}
+		if d.Class != "unit" && d.Class != "integration" && d.Class != "e2e" {
+			return fmt.Errorf("check %s: adapter %s допустим только для test class", d.Name, AdapterJUnit)
+		}
+	} else if d.ReportFile != "" {
+		return fmt.Errorf("check %s: report_file допустим только для adapter %s", d.Name, AdapterJUnit)
 	}
 	if d.Policy != PolicyRequired && d.Policy != PolicyOptional {
 		return fmt.Errorf("check %s: policy должен быть required или optional", d.Name)
@@ -149,6 +170,9 @@ type Result struct {
 	EvidenceDigest         string        `json:"evidence_digest,omitempty"`
 	DiscoveredTests        int           `json:"discovered_tests,omitempty"`
 	PassedTests            int           `json:"passed_tests,omitempty"`
+	FailedTests            int           `json:"failed_tests,omitempty"`
+	ErroredTests           int           `json:"errored_tests,omitempty"`
+	SkippedTests           int           `json:"skipped_tests,omitempty"`
 	StructuredOutputBytes  int64         `json:"structured_output_bytes,omitempty"`
 	StructuredOutputSHA256 string        `json:"structured_output_sha256,omitempty"`
 }
@@ -199,13 +223,20 @@ func (r Runner) Run(ctx context.Context, definition Definition) (result Result, 
 		return result, err
 	}
 	result.WorkingDir = workingDir
-	result.WorkspaceDigestBefore, err = WorkspaceDigest(r.TargetDir)
+	// JUnit adapter объявляет report_file как легитимный side-effect проверки —
+	// путь исключается из детекции мутации workspace (остальное обязано быть
+	// read-only, иначе check fail).
+	reportExclude := ""
+	if definition.NormalizedAdapter() == AdapterJUnit {
+		reportExclude = filepath.ToSlash(filepath.FromSlash(definition.ReportFile))
+	}
+	result.WorkspaceDigestBefore, err = r.workspaceDigestExcluding(reportExclude)
 	if err != nil {
 		result.Status, result.Reason = StatusFailed, "workspace baseline: "+err.Error()
 		return result, err
 	}
 	defer func() {
-		after, digestErr := WorkspaceDigest(r.TargetDir)
+		after, digestErr := r.workspaceDigestExcluding(reportExclude)
 		if digestErr != nil {
 			result.Status = StatusFailed
 			result.Reason = "workspace verification: " + digestErr.Error()
@@ -242,10 +273,14 @@ func (r Runner) Run(ctx context.Context, definition Definition) (result Result, 
 	}
 	stdout, stderr := &limitedBuffer{limit: maxCapturedOutput}, &limitedBuffer{limit: maxCapturedOutput}
 	var structured *goTestCollector
-	var stdoutWriter io.Writer = stdout
-	if definition.NormalizedAdapter() == AdapterGoTest {
+	var junitReportPath string
+	stdoutWriter := io.Writer(stdout)
+	switch definition.NormalizedAdapter() {
+	case AdapterGoTest:
 		structured = newGoTestCollector()
 		stdoutWriter = io.MultiWriter(stdout, structured)
+	case AdapterJUnit:
+		junitReportPath = filepath.Join(workingDir, filepath.FromSlash(definition.ReportFile))
 	}
 	command := exec.Command(toolPath, definition.Command[1:]...)
 	command.Dir = workingDir
@@ -258,8 +293,16 @@ func (r Runner) Run(ctx context.Context, definition Definition) (result Result, 
 	result.Truncated = stdout.truncated || stderr.truncated
 	if runErr == nil {
 		result.ExitCode = 0
-		if evidenceErr := validateStructuredEvidence(definition, &result, structured); evidenceErr != nil {
+		if evidenceErr := validateStructuredEvidence(definition, &result, structured, junitReportPath); evidenceErr != nil {
 			result.Status, result.Reason = StatusFailed, evidenceErr.Error()
+			if definition.Policy == PolicyRequired {
+				return result, &RequiredFailureError{Check: definition.Name, Cause: result.Reason}
+			}
+			return result, nil
+		}
+		if junitReportPath != "" && result.FailedTests > 0 {
+			result.Status = StatusFailed
+			result.Reason = fmt.Sprintf("JUnit report: %d failures, %d errors", result.FailedTests, result.ErroredTests)
 			if definition.Policy == PolicyRequired {
 				return result, &RequiredFailureError{Check: definition.Name, Cause: result.Reason}
 			}
@@ -273,6 +316,13 @@ func (r Runner) Run(ctx context.Context, definition Definition) (result Result, 
 		result.ExitCode = exitErr.ExitCode()
 	}
 	result.Status = StatusFailed
+	// JUnit report остаётся evidence даже при ненулевом exit code команды:
+	// maven/gradle могут вернуть 0 при падении тестов — counts обязаны быть
+	// в Result для verify. Ошибка парсинга при падении команды не меняет
+	// статус failed, но попадает в Summary Reason.
+	if junitReportPath != "" {
+		_ = readJUnitEvidence(&result, junitReportPath, definition.ReportFile)
+	}
 	switch {
 	case errors.Is(checkCtx.Err(), context.DeadlineExceeded):
 		result.Reason = "timeout: " + definition.Timeout
@@ -317,7 +367,7 @@ func IsTestEvidence(result Result) bool {
 		result.Adapter != AdapterCommand && result.DiscoveredTests > 0 && result.PassedTests > 0
 }
 
-func validateStructuredEvidence(definition Definition, result *Result, collector *goTestCollector) error {
+func validateStructuredEvidence(definition Definition, result *Result, collector *goTestCollector, junitReportPath string) error {
 	switch definition.NormalizedAdapter() {
 	case AdapterCommand:
 		return nil
@@ -326,9 +376,40 @@ func validateStructuredEvidence(definition Definition, result *Result, collector
 			return fmt.Errorf("go test JSON collector отсутствует")
 		}
 		return collector.Finish(result)
+	case AdapterJUnit:
+		return readJUnitEvidence(result, junitReportPath, definition.ReportFile)
 	default:
 		return fmt.Errorf("unsupported adapter %q", definition.Adapter)
 	}
+}
+
+// readJUnitEvidence читает строгим bounded parser JUnit XML отчёт, который
+// command записала в reportPath, и дигирует сырой файл как evidence (V0-6).
+// Zero-test и zero-passed отчёты — ошибка: они не являются test evidence.
+func readJUnitEvidence(result *Result, reportPath, reportRel string) error {
+	if reportPath == "" {
+		return errors.New("junit report path отсутствует")
+	}
+	data, err := safeio.ReadRegularFile(reportPath, maxStructuredOutput)
+	if err != nil {
+		return fmt.Errorf("junit report %s: %w", reportRel, err)
+	}
+	report, err := junit.Parse(data)
+	if err != nil {
+		return fmt.Errorf("junit report %s: %w", reportRel, err)
+	}
+	result.StructuredOutputBytes = int64(len(data))
+	sum := sha256.Sum256(data)
+	result.StructuredOutputSHA256 = hex.EncodeToString(sum[:])
+	result.DiscoveredTests = report.Tests
+	result.FailedTests = report.Failures + report.Errors
+	result.ErroredTests = report.Errors
+	result.SkippedTests = report.Skipped
+	result.PassedTests = report.Passed()
+	if report.Tests == 0 || report.Passed() == 0 {
+		return fmt.Errorf("junit report не содержит ни одного успешно выполненного test case")
+	}
+	return nil
 }
 
 type goTestEvent struct {
@@ -583,6 +664,29 @@ func WorkspaceFileDigests(target string, ignoredDirs map[string]bool) (files map
 		fmt.Fprintf(hash, "%s\x00%s\x00", relative, files[relative])
 	}
 	return files, hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// workspaceDigestExcluding — канонический fingerprint workspace с
+// исключением declared side-effect файлов (junit report), которые обязаны
+// появляться в результате выполнения проверки.
+func (r Runner) workspaceDigestExcluding(exclude string) (string, error) {
+	files, _, err := WorkspaceFileDigests(r.TargetDir, DefaultIgnoreDirs())
+	if err != nil {
+		return "", err
+	}
+	if exclude != "" {
+		delete(files, filepath.ToSlash(exclude))
+	}
+	paths := make([]string, 0, len(files))
+	for relative := range files {
+		paths = append(paths, relative)
+	}
+	sort.Strings(paths)
+	hash := sha256.New()
+	for _, relative := range paths {
+		fmt.Fprintf(hash, "%s\x00%s\x00", relative, files[relative])
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 // WorkspaceDigest is the canonical source-tree digest used to bind checks to

--- a/pkg/checks/checks.go
+++ b/pkg/checks/checks.go
@@ -230,24 +230,37 @@ func (r Runner) Run(ctx context.Context, definition Definition) (result Result, 
 	if definition.NormalizedAdapter() == AdapterJUnit {
 		reportExclude = filepath.ToSlash(filepath.FromSlash(definition.ReportFile))
 	}
-	result.WorkspaceDigestBefore, err = r.workspaceDigestExcluding(reportExclude)
+	// Исключающий дайджест используется только для внутренней детекции
+	// мутации workspace (junit report — объявленный side-effect). В сам Result
+	// пишется полный WorkspaceDigest: верификаторы (delivery_auth, VerifyCheck
+	// Evidence) пересчитывают полный fingerprint текущего workspace и требуют
+	// равенство по обоим полям (V0-6).
+	beforeExclude, err := r.workspaceDigestExcluding(reportExclude)
 	if err != nil {
 		result.Status, result.Reason = StatusFailed, "workspace baseline: "+err.Error()
 		return result, err
 	}
 	defer func() {
-		after, digestErr := r.workspaceDigestExcluding(reportExclude)
+		afterExclude, digestErr := r.workspaceDigestExcluding(reportExclude)
 		if digestErr != nil {
 			result.Status = StatusFailed
 			result.Reason = "workspace verification: " + digestErr.Error()
 			returnErr = errors.Join(returnErr, digestErr)
 		} else {
-			result.WorkspaceDigestAfter = after
-			if result.WorkspaceDigestBefore != after {
+			if beforeExclude != afterExclude {
 				result.Status = StatusFailed
 				result.Reason = "check изменил workspace; verification commands должны быть read-only"
 				returnErr = errors.Join(returnErr, &RequiredFailureError{Check: definition.Name, Cause: result.Reason})
 			}
+		}
+		full, fullErr := WorkspaceDigest(r.TargetDir)
+		if fullErr != nil {
+			result.Status = StatusFailed
+			result.Reason = "workspace verification: " + fullErr.Error()
+			returnErr = errors.Join(returnErr, fullErr)
+		} else {
+			result.WorkspaceDigestBefore = full
+			result.WorkspaceDigestAfter = full
 		}
 		result.EvidenceDigest = resultDigest(result)
 	}()

--- a/pkg/checks/junit_adapter_test.go
+++ b/pkg/checks/junit_adapter_test.go
@@ -1,0 +1,192 @@
+package checks
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const junitPassReportingXML = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="demo" tests="2" failures="0">
+  <testsuite name="demo.test" tests="2" failures="0">
+    <testcase classname="demo" name="test_add" time="0.001"/>
+    <testcase classname="demo" name="test_sub" time="0.001"/>
+  </testsuite>
+</testsuites>
+`
+
+func writeJunitReport(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "reports"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "reports", "pass.xml"), []byte(junitPassReportingXML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestJUnitAdapterPassingReport(t *testing.T) {
+	dir := writeJunitReport(t)
+	command := []string{"cp", filepath.Join(dir, "reports", "pass.xml"), "report.xml"}
+	result, err := (Runner{TargetDir: dir}).Run(context.Background(), Definition{
+		Name: "junit", Class: "unit", Adapter: AdapterJUnit,
+		Command: command, Policy: PolicyRequired, ReportFile: "report.xml",
+	})
+	if err != nil {
+		t.Fatalf("passing junit: %v", err)
+	}
+	if result.Status != StatusPassed || result.DiscoveredTests != 2 || result.PassedTests != 2 {
+		t.Fatalf("passing result = %+v", result)
+	}
+	if result.StructuredOutputSHA256 == "" || result.StructuredOutputBytes == 0 {
+		t.Fatalf("digest/bytes не заполнены: %+v", result)
+	}
+	if !IsTestEvidence(result) {
+		t.Fatalf("прошедший junit required unit check должен быть test evidence")
+	}
+}
+
+func TestJUnitAdapterFailingReportFailsOnExitZero(t *testing.T) {
+	dir := writeJunitReport(t)
+	if err := os.WriteFile(filepath.Join(dir, "failing.xml"), []byte(pytestFixture()), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// cp завершается 0 даже при падении тестов в отчёте — adapter обязан
+	// провалить check на основе XML (maven surefire semantics).
+	result, err := (Runner{TargetDir: dir}).Run(context.Background(), Definition{
+		Name: "junit", Class: "unit", Adapter: AdapterJUnit,
+		Command: []string{"cp", filepath.Join(dir, "failing.xml"), "report.xml"}, Policy: PolicyRequired,
+		ReportFile: "report.xml",
+	})
+	if err == nil {
+		t.Fatalf("отчёт с failure обязан фейлить required check; result=%+v", result)
+	}
+	if result.Status != StatusFailed || result.FailedTests != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if IsTestEvidence(result) {
+		t.Fatalf("failed junit не должен быть test evidence")
+	}
+}
+
+func TestJUnitAdapterZeroTestsRejected(t *testing.T) {
+	dir := writeJunitReport(t)
+	if err := os.WriteFile(filepath.Join(dir, "zero.xml"), []byte(zeroFixture()), 0644); err != nil {
+		t.Fatal(err)
+	}
+	definition := Definition{
+		Name: "junit", Class: "unit", Adapter: AdapterJUnit,
+		Command: []string{"cp", filepath.Join(dir, "zero.xml"), "report.xml"}, Policy: PolicyRequired,
+		ReportFile: "report.xml",
+	}
+	result, err := (Runner{TargetDir: dir}).Run(context.Background(), definition)
+	if err == nil {
+		t.Fatalf("zero-test отчёт обязан фейлить; result=%+v", result)
+	}
+	if result.Status != StatusFailed || !strings.Contains(result.Reason, "не содержит") {
+		t.Fatalf("result = %+v reason=%q", result, result.Reason)
+	}
+}
+
+func TestJUnitAdapterMissingReportFailed(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "nowhere.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Команда не создаёт report.xml.
+	definition := Definition{
+		Name: "junit", Class: "unit", Adapter: AdapterJUnit,
+		Command: []string{"cp", filepath.Join(dir, "nowhere.txt"), "other.txt"}, Policy: PolicyRequired,
+		ReportFile: "report.xml",
+	}
+	result, err := (Runner{TargetDir: dir}).Run(context.Background(), definition)
+	if err == nil {
+		t.Fatalf("отсутствующий report обязан фейлить; result=%+v", result)
+	}
+	if result.Status != StatusFailed {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestJUnitDefinitionValidation(t *testing.T) {
+	base := Definition{Name: "j", Class: "unit", Adapter: AdapterJUnit,
+		Command: []string{"pytest"}, Policy: PolicyRequired, ReportFile: "report.xml"}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("valid junit def: %v", err)
+	}
+
+	noReport := base
+	noReport.ReportFile = ""
+	if err := noReport.Validate(); err == nil {
+		t.Fatal("junit без report_file должен отклоняться")
+	}
+
+	escaping := base
+	escaping.ReportFile = "../report.xml"
+	if err := escaping.Validate(); err == nil {
+		t.Fatal("report_file вне target должен отклоняться")
+	}
+
+	absReport := base
+	absReport.ReportFile = "/tmp/report.xml"
+	if err := absReport.Validate(); err == nil {
+		t.Fatal("absolute report_file должен отклоняться")
+	}
+
+	badClass := base
+	badClass.Class = "lint"
+	if err := badClass.Validate(); err == nil {
+		t.Fatal("junit только для test class")
+	}
+
+	commandAdapter := Definition{Name: "c", Class: "unit", Adapter: AdapterCommand,
+		Command: []string{"echo", "hi"}, Policy: PolicyRequired, ReportFile: "report.xml"}
+	if err := commandAdapter.Validate(); err == nil {
+		t.Fatal("report_file запрещён для command adapter")
+	}
+}
+
+func pytestFixture() string {
+	return `<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="1" failures="1" errors="0" skipped="0">
+    <testcase classname="test_calc" name="test_div" time="0.002">
+      <failure message="AssertionError: division by zero" type="AssertionError"/>
+    </testcase>
+  </testsuite>
+</testsuites>
+`
+}
+
+func zeroFixture() string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="no tests">
+  <testsuite name="empty" tests="0" failures="0" errors="0" skipped="0">
+    <system-out/>
+  </testsuite>
+</testsuites>
+`
+}
+
+func TestJUnitAdapterOptionalFailureIsExplicit(t *testing.T) {
+	dir := writeJunitReport(t)
+	if err := os.WriteFile(filepath.Join(dir, "failing.xml"), []byte(pytestFixture()), 0644); err != nil {
+		t.Fatal(err)
+	}
+	definition := Definition{
+		Name: "junit", Class: "e2e", Adapter: AdapterJUnit,
+		Command: []string{"cp", filepath.Join(dir, "failing.xml"), "report.xml"}, Policy: PolicyOptional,
+		ReportFile: "report.xml",
+	}
+	result, err := (Runner{TargetDir: dir}).Run(context.Background(), definition)
+	if err != nil {
+		t.Fatalf("optional: %v", err)
+	}
+	if result.Status != StatusFailed {
+		t.Fatalf("optional failed result = %+v", result)
+	}
+}

--- a/pkg/checks/junit_adapter_test.go
+++ b/pkg/checks/junit_adapter_test.go
@@ -48,6 +48,21 @@ func TestJUnitAdapterPassingReport(t *testing.T) {
 	if !IsTestEvidence(result) {
 		t.Fatalf("прошедший junit required unit check должен быть test evidence")
 	}
+	// V0-6 should-fix: в записи обязан быть полный WorkspaceDigest (равный
+	// полному fingerprint текущего workspace с report на диске), а не
+	// excluding-дайджест. Верификаторы пересчитывают полный digest и требуют
+	// равенство по обоим полям.
+	full, err := WorkspaceDigest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.WorkspaceDigestBefore != full || result.WorkspaceDigestAfter != full {
+		t.Fatalf("digest в записи = before %q after %q, ожидался полный %q",
+			result.WorkspaceDigestBefore, result.WorkspaceDigestAfter, full)
+	}
+	if !VerifyResultDigest(result) {
+		t.Fatalf("evidence digest не самосогласован: %+v", result)
+	}
 }
 
 func TestJUnitAdapterFailingReportFailsOnExitZero(t *testing.T) {

--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -1,0 +1,127 @@
+// Package junit реализует bounded strict parser JUnit XML отчётов
+// (V0-6): counts suites/testcases/failures/errors/skips выводятся из реальных
+// <testcase> элементов, а не из атрибутов-агрегатов (jest/maven/gradle
+// заполняют их непоследовательно). DOCTYPE и entity-конструкции запрещены
+// (не-разрешаемая внешняя подмена), глубина и размер ограничены.
+package junit
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// MaxReportSize — предел сырого JUnit XML (зеркалит maxStructuredOutput).
+const MaxReportSize = 64 << 20
+
+const maxDepth = 32
+
+// Report — детерминированный счётный вердикт JUnit отчёта.
+type Report struct {
+	Suites   int `json:"suites"`
+	Tests    int `json:"tests"`
+	Failures int `json:"failures"`
+	Errors   int `json:"errors"`
+	Skipped  int `json:"skipped"`
+}
+
+// Passed — число успешно выполненных test cases.
+func (r *Report) Passed() int {
+	return r.Tests - r.Failures - r.Errors - r.Skipped
+}
+
+// Parse строго разбирает JUnit XML. Поддерживаются корни <testsuites> и
+// <testsuite> (в т.ч. вложенные testsuite внутри testsuites).
+func Parse(data []byte) (*Report, error) {
+	if len(data) == 0 {
+		return nil, errors.New("junit: пустой отчёт")
+	}
+	if len(data) > MaxReportSize {
+		return nil, fmt.Errorf("junit: отчёт превышает %d байт", MaxReportSize)
+	}
+	lower := bytes.ToLower(data)
+	if bytes.Contains(lower, []byte("<!doctype")) || bytes.Contains(lower, []byte("<!entity")) {
+		return nil, errors.New("junit: DOCTYPE/entity недопустимы")
+	}
+
+	report := &Report{}
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	decoder.Strict = true
+
+	// Стек открытых testcase для точного приписывания failure/error/skipped.
+	type openCase struct{ failure, err, skipped bool }
+	cases := make([]*openCase, 0, 8)
+
+	depth := 0
+	sawSuite := false
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("junit: %w", err)
+		}
+		switch current := token.(type) {
+		case xml.StartElement:
+			depth++
+			if depth > maxDepth {
+				return nil, fmt.Errorf("junit: вложенность превышает %d", maxDepth)
+			}
+			switch current.Name.Local {
+			case "testsuites", "testsuite":
+				sawSuite = true
+			case "testcase":
+				cases = append(cases, &openCase{})
+			case "failure":
+				if len(cases) > 0 {
+					cases[len(cases)-1].failure = true
+				}
+			case "error":
+				if len(cases) > 0 {
+					cases[len(cases)-1].err = true
+				}
+			case "skipped":
+				if len(cases) > 0 {
+					cases[len(cases)-1].skipped = true
+				}
+			}
+		case xml.EndElement:
+			switch current.Name.Local {
+			case "testcase":
+				if len(cases) > 0 {
+					open := cases[len(cases)-1]
+					cases = cases[:len(cases)-1]
+					report.Tests++
+					switch {
+					case open.failure:
+						report.Failures++
+					case open.err:
+						report.Errors++
+					case open.skipped:
+						report.Skipped++
+					}
+				}
+			case "testsuite":
+				report.Suites++
+			}
+			depth--
+		case xml.CharData:
+		case xml.Comment:
+		case xml.Directive:
+			return nil, errors.New("junit: xml directive недопустима")
+		case xml.ProcInst:
+			if strings.EqualFold(current.Target, "xml") {
+				continue
+			}
+			return nil, errors.New("junit: processing instruction недопустима")
+		}
+	}
+	if !sawSuite {
+		return nil, errors.New("junit: нет корневого testsuite/testsuites")
+	}
+	return report, nil
+}

--- a/pkg/junit/junit_test.go
+++ b/pkg/junit/junit_test.go
@@ -1,0 +1,104 @@
+package junit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// Golden-fixture матрица: pytest, Jest, Gradle, Maven. Counts выводятся из
+// реальных <testcase> элементов, а не из атрибутов-агрегатов — их заполняют
+// инструменты по-разному, поэтому каждый ключевой индикатор поджат вручную.
+func TestGoldenFixtures(t *testing.T) {
+	cases := []struct {
+		name             string
+		file             string
+		suites, tests    int
+		failures, errors int
+		skipped, passed  int
+	}{
+		{"pytest", "pytest.xml", 1, 4, 1, 0, 1, 2},
+		{"jest", "jest.xml", 2, 5, 1, 0, 0, 4},
+		{"gradle", "gradle.xml", 1, 3, 0, 1, 0, 2},
+		{"maven", "maven.xml", 1, 5, 1, 1, 1, 2},
+		{"zero", "zero.xml", 1, 0, 0, 0, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			report, err := Parse(loadFixture(t, tc.file))
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if report.Suites != tc.suites || report.Tests != tc.tests ||
+				report.Failures != tc.failures || report.Errors != tc.errors ||
+				report.Skipped != tc.skipped || report.Passed() != tc.passed {
+				t.Fatalf("counts = %+v (passed=%d), ожидалось suites=%d tests=%d failures=%d errors=%d skipped=%d passed=%d",
+					report, report.Passed(), tc.suites, tc.tests, tc.failures, tc.errors, tc.skipped, tc.passed)
+			}
+		})
+	}
+}
+
+func TestParseRejectsDoctype(t *testing.T) {
+	if _, err := Parse(loadFixture(t, "doctype.xml")); err == nil {
+		t.Fatal("DOCTYPE должен отклоняться")
+	}
+}
+
+func TestParseRejectsMalformed(t *testing.T) {
+	if _, err := Parse([]byte("<testsuites><testsuite><testcase")); err == nil {
+		t.Fatal("malformed XML должен отклоняться")
+	}
+	if _, err := Parse([]byte("not-xml-at-all")); err == nil {
+		t.Fatal("не-XML должен отклоняться")
+	}
+	if _, err := Parse([]byte("<testsuites></testcase></testsuites>")); err == nil {
+		t.Fatal("mismatched закрытие должен отклоняться")
+	}
+}
+
+func TestParseRequiresSuiteRoot(t *testing.T) {
+	if _, err := Parse([]byte("<foo><bar/></foo>")); err == nil {
+		t.Fatal("корень без testsuite/testsuites должен отклоняться")
+	}
+}
+
+func TestParseRejectsDeepNesting(t *testing.T) {
+	deep := "<testsuites>" + strings.Repeat("<a>", 64) + "<testcase/>" + strings.Repeat("</a>", 64) + "</testsuites>"
+	if _, err := Parse([]byte(deep)); err == nil {
+		t.Fatal("глубокая вложенность должна отклоняться")
+	}
+}
+
+func TestParseRejectsEntityInsideContent(t *testing.T) {
+	data := []byte("<testsuites><testsuite name=\"entity\"><testcase name=\"up\" classname=\"x\">&xxe;</testcase></testsuite></testsuites>")
+	if _, err := Parse(data); err == nil {
+		t.Fatal("неразрешённая entity должна отклоняться xml.Decoder")
+	}
+}
+
+func TestParseEmptyReport(t *testing.T) {
+	if _, err := Parse(nil); err == nil {
+		t.Fatal("пустой отчёт должен отклоняться")
+	}
+	if _, err := Parse([]byte("")); err == nil {
+		t.Fatal("пустой отчёт должен отклоняться")
+	}
+}
+
+func TestParseProcessingInstructionRejected(t *testing.T) {
+	data := []byte("<?xml-stylesheet href=\"x\"?><testsuites><testsuite name=\"s\"><testcase name=\"t\"/></testsuite></testsuites>")
+	if _, err := Parse(data); err == nil {
+		t.Fatal("processing instruction должна отклоняться")
+	}
+}

--- a/pkg/junit/testdata/doctype.xml
+++ b/pkg/junit/testdata/doctype.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE testsuite [
+  <!ENTITY xxe SYSTEM "file:///etc/passwd">
+]>
+<testsuite name="evil" tests="1" failures="0">
+  <testcase name="&xxe;" classname="x"/>
+</testsuite>

--- a/pkg/junit/testdata/gradle.xml
+++ b/pkg/junit/testdata/gradle.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Gradle Test Executor 1" tests="3" failures="0" errors="1" skipped="0" timestamp="2026-08-01T10:00:00" hostname="ci">
+  <properties>
+    <property name="gradle.version" value="8.9"/>
+  </properties>
+  <testcase name="sum works" classname="com.example.CalculatorTest" time="0.011"/>
+  <testcase name="sub works" classname="com.example.CalculatorTest" time="0.009"/>
+  <testcase name="throws on negative" classname="com.example.CalculatorTest" time="0.004">
+    <error message="expected exception, none thrown" type="org.junit.runners.model.TestFailedToRunException">at com.example.CalculatorTest.throwsOnNegative</error>
+  </testcase>
+  <system-out><![CDATA[dummy output]]></system-out>
+</testsuite>

--- a/pkg/junit/testdata/jest.xml
+++ b/pkg/junit/testdata/jest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<testsuites name="jest tests" tests="5" failures="1" time="1.234">
+  <testsuite name="auth.test.js" tests="3" failures="0" time="0.500">
+    <testcase classname="auth" name="login ok" time="0.100"/>
+    <testcase classname="auth" name="refresh ok" time="0.120"/>
+    <testcase classname="auth" name="logout clears state" time="0.080"/>
+  </testsuite>
+  <testsuite name="profile.test.js" tests="2" failures="1" time="0.300">
+    <testcase classname="profile" name="renders name" time="0.050"/>
+    <testcase classname="profile" name="loads profile from api" time="0.070">
+      <failure message="expect(received).toBeDefined()" type="AssertionError"/>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/pkg/junit/testdata/maven.xml
+++ b/pkg/junit/testdata/maven.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire-reports/xsd/surefire-test-report.xsd"
+           name="com.example.AppTest" time="0.042" tests="5" errors="1" skipped="1" failures="1">
+  <properties>
+    <property name="java.runtime.version" value="21"/>
+  </properties>
+  <testcase name="shouldCreateApp" classname="com.example.AppTest" time="0.002"/>
+  <testcase name="shouldParseInput" classname="com.example.AppTest" time="0.004">
+    <failure message="expected:&lt;[ok]&gt; but was:&lt;[bad]&gt;" type="java.lang.AssertionError"><![CDATA[junit.framework.AssertionFailedError: expected:<[ok]> but was:<[bad]> at com.example.AppTest.shouldParseInput]]></failure>
+  </testcase>
+  <testcase name="shouldTimeout" classname="com.example.AppTest" time="0.001">
+    <skipped message="flaky, ignored"/>
+  </testcase>
+  <testcase name="shouldConnect" classname="com.example.AppTest" time="0.010">
+    <error message="Connection refused" type="java.net.ConnectException"><![CDATA[java.net.ConnectException: Connection refused at com.example.AppTest.shouldConnect]]></error>
+  </testcase>
+  <testcase name="shouldCleanup" classname="com.example.AppTest" time="0.002"/>
+</testsuite>

--- a/pkg/junit/testdata/pytest.xml
+++ b/pkg/junit/testdata/pytest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="4" failures="1" errors="0" skipped="1" time="0.123">
+    <testcase classname="test_calc" name="test_add" time="0.001"/>
+    <testcase classname="test_calc" name="test_sub" time="0.001"/>
+    <testcase classname="test_calc" name="test_mul" time="0.002">
+      <skipped type="pytest.skip" message="not implemented yet"/>
+    </testcase>
+    <testcase classname="test_calc" name="test_div" time="0.002">
+      <failure message="AssertionError: division by zero" type="AssertionError"/>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/pkg/junit/testdata/zero.xml
+++ b/pkg/junit/testdata/zero.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="no tests">
+  <testsuite name="empty" tests="0" failures="0" errors="0" skipped="0">
+    <system-out/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
V0-6 junit-xml typed adapter.

Should-fix (R2): Result записывал *excluding*-дайджест, а верификаторы требуют полный WorkspaceDigest → junit-xml в pipeline неработоспособен. Fix: полный WorkspaceDigest в записи (before/after), excluding-дайджест используется только для внутренней детекции мутации workspace.

Closes #56 (per HANDOFF свежий PR).