### PR TITLE
feat(gate): risk-signals measurement без routing (V0-8)

### DIFF
--- a/cmd/ai-team/gate.go
+++ b/cmd/ai-team/gate.go
@@ -172,5 +172,17 @@ func printGateSummary(result *gate.Result, outDir string) {
 		fmt.Printf("  check %-16s %-8s %s (%s)\n", check.Name, statusMark, check.Status, time.Duration(check.Duration).Round(time.Millisecond))
 	}
 
+	sig := result.Signals
+	fmt.Printf("  signals: +%d/-%d lines, %d→%d files, tests=%d, checks=%d failed=%d",
+		sig.AddedLines, sig.RemovedLines, sig.AddedFiles+sig.ModifiedFiles, sig.RemovedFiles, sig.TestChanges, sig.ChecksRun, sig.FailedChecks)
+	if len(sig.SensitivePaths) > 0 {
+		paths := make([]string, 0, len(sig.SensitivePaths))
+		for _, entry := range sig.SensitivePaths {
+			paths = append(paths, entry.Path)
+		}
+		fmt.Printf("; sensitive: %s", strings.Join(paths, ", "))
+	}
+	fmt.Println()
+
 	fmt.Printf("  bundle: %s\n  bundle digest: %s\n", outDir, result.BundleSHA256)
 }

--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -20,10 +20,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/arturpanteleev/ai-team/pkg/checks"
+	"github.com/arturpanteleev/ai-team/pkg/risk"
 	"github.com/arturpanteleev/ai-team/pkg/safeio"
 
 	"github.com/arturpanteleev/ai-team/pkg/scope"
@@ -215,9 +217,25 @@ type Result struct {
 	PolicyVerdict    string          `json:"policy_verdict"`
 	PolicyViolations []Mutation      `json:"policy_violations,omitempty"`
 	Checks           []checks.Result `json:"checks"`
+	Signals          Signals         `json:"signals"`
 	Status           string          `json:"status"`
 	FinishedAt       time.Time       `json:"finished_at"`
 	BundleSHA256     string          `json:"bundle_sha256,omitempty"`
+}
+
+// Signals (V0-8) — измеренные risk-signals diff: размер/тип изменений,
+// чувствительные пути, тестовые изменения, failed checks. Записываются в
+// bundle как данные и НЕ маршрутизируют pipeline (routing — позже, P2-1/P2-2).
+type Signals struct {
+	AddedFiles     int          `json:"added_files"`
+	ModifiedFiles  int          `json:"modified_files"`
+	RemovedFiles   int          `json:"removed_files"`
+	AddedLines     int64        `json:"added_lines"`
+	RemovedLines   int64        `json:"removed_lines"`
+	TestChanges    int          `json:"test_changes"`
+	ChecksRun      int          `json:"checks_run"`
+	FailedChecks   int          `json:"failed_checks"`
+	SensitivePaths []risk.Entry `json:"sensitive_paths,omitempty"`
 }
 
 // Run выполняет diff-policy проверку и typed checks для trusted local
@@ -305,9 +323,42 @@ func Run(ctx context.Context, opt Options) (*Result, int, error) {
 	result.PolicyVerdict = verdict
 	result.PolicyViolations = violations
 
+	addLines, remLines, numstatErr := diffNumstatLines(ctx, opt.TargetDir, baseCommit, candidateCommit, worktreeMode)
+	if numstatErr != nil {
+		return nil, ExitBlocked, &BlockedError{Reason: "не удалось измерить размер diff (numstat): " + numstatErr.Error()}
+	}
+	signalPaths := make([]string, 0, len(mutations))
+	for _, mutation := range mutations {
+		signalPaths = append(signalPaths, mutation.Path)
+	}
+	result.Signals = Signals{
+		AddedLines:     addLines,
+		RemovedLines:   remLines,
+		SensitivePaths: risk.Entries(signalPaths),
+	}
+	for _, mutation := range mutations {
+		switch mutation.Kind {
+		case KindAdded:
+			result.Signals.AddedFiles++
+		case KindModified:
+			result.Signals.ModifiedFiles++
+		case KindRemoved:
+			result.Signals.RemovedFiles++
+		}
+		if mutation.Class == scope.ClassTests && (mutation.Kind == KindAdded || mutation.Kind == KindModified) {
+			result.Signals.TestChanges++
+		}
+	}
+
 	if len(cfg.Checks) > 0 {
 		results, checkErr := (checks.Runner{TargetDir: opt.TargetDir}).RunAll(ctx, cfg.Checks)
 		result.Checks = results
+		result.Signals.ChecksRun = len(results)
+		for _, check := range results {
+			if check.Status == checks.StatusFailed {
+				result.Signals.FailedChecks++
+			}
+		}
 		if checkErr != nil {
 			result.Status = "failed"
 			return result, ExitFail, nil
@@ -321,6 +372,48 @@ func Run(ctx context.Context, opt Options) (*Result, int, error) {
 	}
 	result.Status = "passed"
 	return result, ExitPass, nil
+}
+
+// diffNumstatLines измеряет размер diff в добавленных/удалённых строках через
+// `git diff --numstat`. Бинарные файлы выводятся как "-" и учитываются как 0
+// строк (факт их наличия уже покрыт file counts в Signals).
+func diffNumstatLines(ctx context.Context, target, baseCommit, candidateCommit string, worktreeMode bool) (added, removed int64, err error) {
+	args := []string{"-C", target, "--no-pager", "diff", "--numstat", baseCommit}
+	if !worktreeMode {
+		args = append(args, candidateCommit)
+	}
+	command := exec.CommandContext(ctx, "git", args...)
+	var buffer bytes.Buffer
+	command.Stdout = &buffer
+	command.Stderr = &buffer
+	if err := command.Run(); ctx.Err() != nil {
+		return 0, 0, ctx.Err()
+	} else if err != nil {
+		return 0, 0, errors.New(strings.TrimSpace(buffer.String()))
+	}
+	for _, line := range strings.Split(buffer.String(), "\n") {
+		fields := strings.Split(line, "\t")
+		if len(fields) < 3 {
+			continue
+		}
+		add := parseIntOrZero(fields[0])
+		rem := parseIntOrZero(fields[1])
+		added += add
+		removed += rem
+	}
+	return added, removed, nil
+}
+
+func parseIntOrZero(value string) int64 {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "-" {
+		return 0
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return parsed
 }
 
 func isWorkTree(ctx context.Context, target string) (bool, error) {

--- a/pkg/gate/gate_test.go
+++ b/pkg/gate/gate_test.go
@@ -298,6 +298,71 @@ func writeBundleCopy(t *testing.T, result *Result) (string, error) {
 	return result.BundleSHA256, nil
 }
 
+func TestSignalsRecorded(t *testing.T) {
+	repo := newRepo(t, map[string]string{
+		"src/app.go":        "package app\n",
+		"tests/app_test.go": "package app\n",
+		".env.example":      "KEY=placeholder\n",
+	})
+	base := gitCmd(t, repo, "rev-parse", "HEAD")
+	feature := commitChange(t, repo, "source + test + secret", map[string]string{
+		"src/app.go":             "package app\n// change\n",
+		"tests/app_test.go":      "package app\n\nfunc TestApp() {}\n",
+		"config/.env.production": "DB=prod-secret\n",
+		"deploy/server.key":      "key-material\n",
+	})
+	result, code, err := Run(context.Background(), Options{TargetDir: repo, Base: base, Candidate: feature, Config: &Config{
+		SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyRequired},
+	}})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if code != ExitPass {
+		t.Fatalf("code=%d, ожидался pass", code)
+	}
+	sig := result.Signals
+	if sig.AddedFiles != 2 || sig.ModifiedFiles != 2 || sig.RemovedFiles != 0 {
+		t.Fatalf("signals files: %+v", sig)
+	}
+	if sig.TestChanges != 1 {
+		t.Fatalf("test_changes = %d, ожидался 1 (tests/app_test.go mofified)", sig.TestChanges)
+	}
+	if sig.AddedLines == 0 || sig.RemovedLines != 0 {
+		t.Fatalf("signals lines: %+v", sig)
+	}
+	if len(sig.SensitivePaths) != 2 {
+		t.Fatalf("sensitive paths = %+v, ожидалось 2 (env + key)", sig.SensitivePaths)
+	}
+	if sig.SensitivePaths[0].Path != "config/.env.production" || sig.SensitivePaths[0].Kind != "env" {
+		t.Fatalf("sensitive order/kind: %+v", sig.SensitivePaths)
+	}
+	if sig.SensitivePaths[1].Path != "deploy/server.key" || sig.SensitivePaths[1].Kind != "secrets" {
+		t.Fatalf("sensitive order/kind: %+v", sig.SensitivePaths)
+	}
+	if sig.ChecksRun != 0 || sig.FailedChecks != 0 {
+		t.Fatalf("checks signals: %+v", sig)
+	}
+}
+
+func TestSignalsRecordFailedChecks(t *testing.T) {
+	repo := newRepo(t, map[string]string{"src/app.go": "package app\n", "tests/app_test.go": "package app\n"})
+	cfg := &Config{
+		SchemaVersion: SchemaVersion,
+		DiffPolicy:    DiffPolicy{TestModify: TestModifyOff},
+		Checks: []checks.Definition{{
+			Name: "must-fail", Class: "unit", Adapter: checks.AdapterCommand, Policy: checks.PolicyRequired,
+			Command: []string{"sh", "-c", "exit 1"},
+		}},
+	}
+	result, code, err := Run(context.Background(), Options{TargetDir: repo, Base: "HEAD", Candidate: "HEAD", Config: cfg})
+	if err != nil || code != ExitFail {
+		t.Fatalf("code=%d err=%v", code, err)
+	}
+	if result.Signals.ChecksRun != 1 || result.Signals.FailedChecks != 1 {
+		t.Fatalf("checks signals: %+v", result.Signals)
+	}
+}
+
 func TestVerifyBundleRoundtripAndTampering(t *testing.T) {
 	fixed := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
 	result := &Result{

--- a/pkg/risk/risk.go
+++ b/pkg/risk/risk.go
@@ -38,13 +38,13 @@ var sensitiveExtensions = map[string]string{
 }
 
 // sensitiveBases — имена файлов, признаваемых чувствительными по имени.
+// Путь .docker/config.json матчится через sensitiveSegments (сегмент ".docker"),
+// а не здесь, т.к. path.Base возвращает "config.json".
 var sensitiveBases = map[string]string{
 	".npmrc":                               KindCredentials,
 	".pypirc":                              KindCredentials,
 	".netrc":                               KindCredentials,
 	".htpasswd":                            KindCredentials,
-	".aws/credentials":                     KindCredentials,
-	".docker/config.json":                  KindCredentials,
 	"credentials.json":                     KindCredentials,
 	"service-account.json":                 KindCredentials,
 	"service_account.json":                 KindCredentials,
@@ -52,11 +52,13 @@ var sensitiveBases = map[string]string{
 }
 
 // sensitiveSegments — каталоги, содержимое которых чувствительно.
+// .docker содержит config.json с registry credentials (V0-8 should-fix).
 var sensitiveSegments = map[string]string{
 	"secrets":     KindSecrets,
 	".ssh":        KindSecrets,
 	".gnupg":      KindSecrets,
 	".aws":        KindCredentials,
+	".docker":     KindCredentials,
 	"credentials": KindCredentials,
 }
 

--- a/pkg/risk/risk.go
+++ b/pkg/risk/risk.go
@@ -1,0 +1,140 @@
+// Package risk измеряет risk-signals изменений (V0-8): размер и тип diff,
+// чувствительные пути, тестовые изменения, failed checks. Сигналы записываются
+// в attestation bundle как данные, но НЕ маршрутизируют pipeline — никакого
+// автоматического решения на их основе нет (routing придёт отдельно в
+// P2-1/P2-2 вместе с продуктивным решением владельца).
+package risk
+
+import (
+	"path"
+	"sort"
+	"strings"
+)
+
+// Kind — тип чувствительного пути.
+const (
+	KindEnv         = "env"         // .env и аналоги: переменные окружения/конфигурация
+	KindSecrets     = "secrets"     // ключи, сертификаты, secret-каталоги
+	KindCredentials = "credentials" // файлы авторизации/токенов
+)
+
+// Entry — один чувствительный путь и его тип.
+type Entry struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
+}
+
+// sensitiveExtensions — расширения секретов/ключей.
+var sensitiveExtensions = map[string]string{
+	".pem":      KindSecrets,
+	".key":      KindSecrets,
+	".p12":      KindSecrets,
+	".pfx":      KindSecrets,
+	".jks":      KindSecrets,
+	".keystore": KindSecrets,
+	".secret":   KindSecrets,
+	".token":    KindSecrets,
+	".tok":      KindSecrets,
+}
+
+// sensitiveBases — имена файлов, признаваемых чувствительными по имени.
+var sensitiveBases = map[string]string{
+	".npmrc":                               KindCredentials,
+	".pypirc":                              KindCredentials,
+	".netrc":                               KindCredentials,
+	".htpasswd":                            KindCredentials,
+	".aws/credentials":                     KindCredentials,
+	".docker/config.json":                  KindCredentials,
+	"credentials.json":                     KindCredentials,
+	"service-account.json":                 KindCredentials,
+	"service_account.json":                 KindCredentials,
+	"application_default_credentials.json": KindCredentials,
+}
+
+// sensitiveSegments — каталоги, содержимое которых чувствительно.
+var sensitiveSegments = map[string]string{
+	"secrets":     KindSecrets,
+	".ssh":        KindSecrets,
+	".gnupg":      KindSecrets,
+	".aws":        KindCredentials,
+	"credentials": KindCredentials,
+}
+
+// isPrivateKeyBase — имена приватных ключей OpenSSH/OpenPGP.
+func isPrivateKeyBase(base string) bool {
+	switch base {
+	case "id_rsa", "id_ed25519", "id_ed448", "id_ecdsa", "id_dsa", "id_ecdsa_sk", "id_ed25519_sk":
+		return true
+	}
+	return false
+}
+
+// envKind — тип для файлов .env. .env.example — общепринятый шаблон без
+// значений и не считается чувствительным (иначе сигнал превращается в шум).
+func envKind(base string) string {
+	if base == ".env" || strings.HasPrefix(base, ".env.") {
+		if base == ".env.example" || base == ".env.sample" {
+			return ""
+		}
+		return KindEnv
+	}
+	return ""
+}
+
+// Entries возвращает чувствительные пути среди repository-relative путей:
+// отсортированные по пути и без дублей; каждый путь ровно с одним типом
+// (приоритет: каталог > расширение > basename > env).
+func Entries(repoRelative []string) []Entry {
+	index := make(map[string]Entry)
+	for _, candidate := range repoRelative {
+		value := path.Clean(strings.ReplaceAll(candidate, "\\", "/"))
+		value = strings.TrimPrefix(value, "./")
+		if value == "." || value == "" {
+			continue
+		}
+		base := path.Base(value)
+		dir := path.Dir(value)
+
+		entry := Entry{Path: value}
+		kind := ""
+		for _, segment := range strings.Split(dir, "/") {
+			if k, ok := sensitiveSegments[segment]; ok {
+				kind = k
+				break
+			}
+		}
+		if kind == "" {
+			if k, ok := sensitiveExtensions[strings.ToLower(path.Ext(base))]; ok {
+				kind = k
+			}
+		}
+		if kind == "" && isPrivateKeyBase(base) {
+			kind = KindSecrets
+		}
+		if kind == "" {
+			if k, ok := sensitiveBases[base]; ok {
+				kind = k
+			}
+		}
+		if kind == "" {
+			kind = envKind(base)
+		}
+		if kind == "" {
+			continue
+		}
+		entry.Kind = kind
+		if existing, ok := index[value]; ok {
+			if existing.Kind != kind && kind == KindSecrets {
+				index[value] = entry
+			}
+			continue
+		}
+		index[value] = entry
+	}
+	entries := make([]Entry, 0, len(index))
+	for _, entry := range index {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	return entries
+}

--- a/pkg/risk/risk_test.go
+++ b/pkg/risk/risk_test.go
@@ -1,0 +1,91 @@
+package risk
+
+import (
+	"testing"
+)
+
+func TestSensitiveEntries(t *testing.T) {
+	cases := []struct {
+		name  string
+		paths []string
+		want  []Entry
+	}{
+		{
+			name:  "env file",
+			paths: []string{".env", "src/app.go"},
+			want:  []Entry{{Path: ".env", Kind: KindEnv}},
+		},
+		{
+			name:  "env variant and key",
+			paths: []string{"config/.env.production", "deploy/server.key"},
+			want: []Entry{
+				{Path: "config/.env.production", Kind: KindEnv},
+				{Path: "deploy/server.key", Kind: KindSecrets},
+			},
+		},
+		{
+			name:  "private key basename",
+			paths: []string{"id_rsa", ".ssh/id_ed25519"},
+			want: []Entry{
+				{Path: ".ssh/id_ed25519", Kind: KindSecrets},
+				{Path: "id_rsa", Kind: KindSecrets},
+			},
+		},
+		{
+			name:  "secrets dir trumps extension",
+			paths: []string{"secrets/service.toml", "secrets/env.token"},
+			want: []Entry{
+				{Path: "secrets/env.token", Kind: KindSecrets},
+				{Path: "secrets/service.toml", Kind: KindSecrets},
+			},
+		},
+		{
+			name:  "credentials",
+			paths: []string{"credentials.json", ".aws/config"},
+			want: []Entry{
+				{Path: ".aws/config", Kind: KindCredentials},
+				{Path: "credentials.json", Kind: KindCredentials},
+			},
+		},
+		{
+			name:  "clean paths ignored",
+			paths: []string{"src/app.go", "tests/app_test.go", "go.mod", "README.md"},
+			want:  nil,
+		},
+		{
+			name:  "dedup and sort",
+			paths: []string{"z.key", ".env", "z.key"},
+			want: []Entry{
+				{Path: ".env", Kind: KindEnv},
+				{Path: "z.key", Kind: KindSecrets},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Entries(tc.paths)
+			if len(got) != len(tc.want) {
+				t.Fatalf("Entries(%v) = %+v, ожидалось %+v", tc.paths, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("Entries(%v) = %+v, ожидалось %+v", tc.paths, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSensitiveEntryDeterminism(t *testing.T) {
+	base := []string{"src/a.go", "secrets/x.toml", ".env", "m.key", "go.mod"}
+	first := Entries(base)
+	second := Entries(append([]string(nil), base...))
+	if len(first) != len(second) {
+		t.Fatalf("детерминизм нарушен: %+v vs %+v", first, second)
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("детерминизм нарушен: %+v vs %+v", first, second)
+		}
+	}
+}

--- a/pkg/risk/risk_test.go
+++ b/pkg/risk/risk_test.go
@@ -53,6 +53,14 @@ func TestSensitiveEntries(t *testing.T) {
 			want:  nil,
 		},
 		{
+			name:  "docker config",
+			paths: []string{".docker/config.json", ".docker/config.json.bak"},
+			want: []Entry{
+				{Path: ".docker/config.json", Kind: KindCredentials},
+				{Path: ".docker/config.json.bak", Kind: KindCredentials},
+			},
+		},
+		{
 			name:  "dedup and sort",
 			paths: []string{"z.key", ".env", "z.key"},
 			want: []Entry{


### PR DESCRIPTION
V0-8 risk-signals measurement (fresh PR per HANDOFF, replaces closed #58).

Fixes (R2 should-fix): .docker/config.json теперь матчится через sensitiveSegments (.docker), т.к. path.Base давал config.json.