### PR TITLE
feat(delivery): deferred post-terminal delivery с Git trailers (agent attribution) (V0-9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ non-interactive режиме: он сохраняет запрос решени�
 | `ai-team auth-token --actor <id> --roles <csv> [--ttl 1h]` | выпустить короткоживущий подписанный token для cloud web |
 | `ai-team worker --target <dir> --db <path>` | исполнить один strict worker job из stdin (обычно вызывается launcher-ом) |
 | `ai-team list` | список доступных агентов (имя, runtime, источник в layered registry) |
+| `ai-team gate --target <dir> --base <ref> --candidate <ref|WORKTREE> [--config <file>] [--out <dir>]` | детерминированный diff-policy вердикт + typed checks + attestation bundle; exit 0/1/2 |
+| `ai-team export [--target <dir>] [--out <path>] <run_id>` | собрать проверенный portable bundle терминального run |
+| `ai-team verify <bundle-dir>` / `verify --target <dir> <run_id>` | самодостаточная проверка run-/gate-bundle или локальной evidence |
+| `ai-team deliver --run <run_id> [--target <dir>] [--feature <name>]` | повторить отложенную (deferred) доставку терминального run — commit/push/PR с trailers (run id, runtime identity, attestation digest), однократная запись delivery.json |
 | `ai-team eval --agent <name> --artifact <path> [--samples N]` | независимая LLM-оценка артефакта |
 | `ai-team web [--target <dir>] [--port 8080] [--host 127.0.0.1]` | локальный dashboard и control plane |
 | `ai-team version` / `ai-team help` | версия / usage |

--- a/TASKLOG.md
+++ b/TASKLOG.md
@@ -21,6 +21,7 @@
 |---|---|---|---|
 | 2026-08-30 | backlog-sprint | Базовая линия: чистая ветка от origin/master 2e48ecc, бэклог-доки и статус-лог внесены в git | baseline |
 | 2026-08-30 | p1-1-runtime-adapter-contract | P1-1: контракт RuntimeAdapter (adapter.go: Name/Describe/Validate/Command/Environment + Capability + Registry), OpenCodeAdapter (opencode.go), AgentCLIRuntime — тонкий оркестратор (agentcli.go), валидация CLI в config/agent/preflight через registry, eval через адаптеры. Все `go test ./...` зелёные, build/vet/gofmt чисто. | review |
+| 2026-08-31 | v0-9-agent-attribution-trailers | V0-9: agent attribution через Git trailers. Deferred (post-terminal) delivery: внутри run delivery-стадия делает только `delivery.Prepare` + `authorizeDelivery` (event `delivery_deferred`, marker `{StatePath, PlanHash}`), git-история НЕ меняется до terminal finalize. После finalize при outcome completed post-terminal хук (`pkg/pipeline/delivery_deferred.go`) перегружает canonical plan (сверка plan.Hash с маркером и approvedPlanHash), читает attestation digest + runtime identity = sha256(run.json.Provenance) и исполняет реальный controller.Execute с controller-derived trailers `ai-team-run`/`ai-team-runtime`/`ai-team-attestation`. `pkg/delivery`: Request.Trailers, ValidateTrailers, trailers персистятся в state ДО commit, commit message = FullCommitMessage(plan.CommitMessage, trailers), verifyCommittedChange сверяет trailers (crash-recovery/resume idempotent). Tamper-evident terminal record `{RunDir}/delivery.json` (TerminalRecord v1 + self-integrity record_sha256, строгая валидация, однократная запись, idempotent retry). `evidence.FindDelivered` сначала читает delivery.json, fallback — attempt manifests. Сбой post-terminal хука повторяем: CLI `ai-team deliver --run <id> [--target] [--feature]` (run обязан быть terminal completed, plan обязан совпасть с delivery_deferred event). Go-тесты: trailer-формат/commit-with-trailers/crash-recovery, TerminalRecord roundtrip+tamper (вкл. несогласованные trailers), deferred flow через explicit approval (fake controller вызван ровно 1 раз post-terminal, record+trailers сверены), DeliverDeferred guards. E2E TestE2E_SuccessfulPipeline зелёный (approve → deferred commit на origin-ветке, live HEAD не тронут). | review |
 
 ---
 
@@ -56,8 +57,8 @@
 | 13 | V0-6 | P0 | open | — | Generic JUnit XML typed adapter |
 | 14 | V0-7 | P0 | open | — | Demo + CI action + truthful README — после V0-4/5/6; нужны внешние люди |
 | 15 | EXP-1 | P1 | open | — | Track V kill-watch + интервью (не-кодовая) |
-| 16 | V0-8 | P1 | open | — | Risk-signal measurement (записывать, не маршрутизировать) |
-| 17 | V0-9 | P1 | open | — | Agent attribution в Git trailers — после V0-2/V0-3 |
+| 16 | V0-8 | P1 | review | v0-8-risk-signals | Risk-signal measurement (записывать, не маршрутизировать) |
+| 17 | V0-9 | P1 | review | v0-9-agent-attribution-trailers | Agent attribution в Git trailers (deferred post-terminal delivery) — после V0-2/V0-3 |
 | 18 | P1-4 | P1 | open | — | Containment profile v1 + receipt |
 | 19 | P1-9 | P1 | open | — | Contract test: coder не видит будущее ревью |
 | 20 | P1-5 | P1 | open | — | Signed bundle через DSSE |

--- a/ai-team-backlog.html
+++ b/ai-team-backlog.html
@@ -599,11 +599,11 @@
         <div class="task-state"><span class="status status-open">○ Open</span></div><div class="task-pr">—</div>
       </article>
 
-      <article class="task" data-status="Open" data-prio="P1" data-horizon="V0" data-id="V0-9" data-order="17">
+      <article class="task" data-status="Review" data-prio="P1" data-horizon="V0" data-id="V0-9" data-order="17">
         <div class="task-seq">#17</div>
         <div class="task-key"><strong>V0-9</strong><span class="prio prio-P1">P1</span><span class="tag">Provenance</span></div>
-        <div class="task-content"><h3>Agent attribution в Git trailers</h3><p>Добавить run ID, model/runtime identity и attestation digest в commit trailers; подпись остаётся отдельной опцией.</p><p class="detail">Зависит от стабильных полей V0-2/V0-3. Провенанс переживает потерю локального bundle. После ADP-1/ADP-2 различает, каким харнесом сделан коммит.</p></div>
-        <div class="task-state"><span class="status status-open">○ Open</span></div><div class="task-pr">—</div>
+        <div class="task-content"><h3>Agent attribution в Git trailers</h3><p>Добавить run ID, model/runtime identity и attestation digest в commit trailers (deferred post-terminal delivery); подпись остаётся отдельной опцией.</p><p class="detail">Зависит от стабильных полей V0-2/V0-3. Провенанс переживает потерю локального bundle. После ADP-1/ADP-2 различает, каким харнесом сделан коммит.</p></div>
+        <div class="task-state"><span class="status status-review">◉ Review</span></div><div class="task-pr">v0-9-agent-attribution-trailers</div>
       </article>
 
       <article class="task" data-status="Open" data-prio="P1" data-horizon="P1" data-id="P1-4" data-order="18">

--- a/cmd/ai-team/deliver.go
+++ b/cmd/ai-team/deliver.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arturpanteleev/ai-team/pkg/pipeline"
+	"github.com/arturpanteleev/ai-team/pkg/ui"
+)
+
+// deliver.go (V0-9): ручной повтор отложенной (deferred) доставки. Post-terminal
+// хук исполняет delivery в той же инвокации run; если он упал (сетевой сбой
+// push, ошибка контроллера), доставка повторяема через эту команду —
+// enforcement детерминированный (plan hash из delivery_deferred event).
+func cmdDeliver() {
+	deliverFlags := flag.NewFlagSet("deliver", flag.ExitOnError)
+	target := deliverFlags.String("target", ".", "Путь к целевому проекту (delivery state)")
+	feature := deliverFlags.String("feature", "", "Feature name (если не задан — из run manifest)")
+	runID := deliverFlags.String("run", "", "Run ID завершённого run с deferred delivery")
+	if err := deliverFlags.Parse(os.Args[2:]); err != nil {
+		fatal("Ошибка аргументов deliver: %v", err)
+	}
+	if *runID == "" {
+		fatal("Использование: ai-team deliver --run <run_id> [--target <dir>] [--feature <name>]")
+	}
+	if len(*runID) > 1024 || strings.ContainsAny(*runID, `/\`) {
+		fatal("недопустимый run_id")
+	}
+	absolute, err := absoluteTarget(*target)
+	if err != nil {
+		fatal("Ошибка target: %v", err)
+	}
+	requireControlRoot(absolute)
+	runDir := filepath.Join(absolute, ".ai-team", "runs", *runID)
+
+	record, err := pipeline.New(nil, nil).DeliverDeferred(runDir, *feature, absolute)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "✗ Deliver run %s: %v\n", *runID, ui.Colorize(err.Error(), ui.ColorRed))
+		os.Exit(exitFailed)
+	}
+	fmt.Printf("✓ Deliver run %s завершён: commit=%s pr=%s\n", *runID, record.CommitSHA, record.PRURL)
+	for _, trailer := range record.Trailers {
+		fmt.Printf("    %s\n", trailer)
+	}
+}

--- a/cmd/ai-team/main.go
+++ b/cmd/ai-team/main.go
@@ -79,6 +79,8 @@ func main() {
 		cmdExport()
 	case "verify":
 		cmdVerify()
+	case "deliver":
+		cmdDeliver()
 	case "gate":
 		cmdGate()
 	case "eval":
@@ -117,6 +119,8 @@ func printUsage() {
   ai-team verify [--target <dir>] <run_id>
                                    Проверить evidence терминального run (anchor, chain, попытки, attestation)
   ai-team verify <bundle-dir>      Проверить portable bundle самодостаточно (без repo и .ai-team)
+  ai-team deliver               Повторить отложенную (deferred) доставку завершённого run:
+                                   --run <run_id> --target <.ai-team root> [--feature <name>]
   ai-team gate                     Deterministic diff-policy gate для trusted local
                                    base/candidate (typed checks + attestation bundle)
   ai-team eval                     Оценить качество артефакта или агента

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -313,6 +313,48 @@ commit` (например, процесс убит между commit и push), c
 parent, paths, modes и blob hashes — так что штатный retry не создаёт
 дублирующий commit или PR.
 
+### Отложенная (deferred) delivery и Git trailers — V0-9
+
+Git-история меняется ТОЛЬКО после terminal finalize run'а (commit, push, PR),
+когда attestation digest детерминирован.  Причины:
+
+- attestation.json пишется в finalize ПОСЛЕ delivery-стадии; выполнить
+  in-run delivery и при этом вшить в commit честный digest было бы циклично;
+- попытка-манифесты immutable: `CommitSHA` заполнять внутри run нельзя, иначе
+  погибает доказательство «что именно одобрено» при переживании потери bundle.
+
+Внутри run delivery-стадия делает `delivery.Prepare` (state на диске), затем
+`authorizeDelivery` (в интерактивном режиме run может встать в ожидание
+approval `delivery_plan`, в resume выполняется `--approve-plan <sha>`), а не
+`delivery.Execute`. Результат — deferred marker `{StatePath, PlanHash}` + event
+`delivery_deferred`. После финального `finalize` при outcome `completed` и
+наличии маркера post-terminal хук (`pkg/pipeline/delivery_deferred.go`):
+
+1. перегружает canonical plan из prepared state и сверяет `plan.Hash()` с
+   маркером стадии и с `approvedPlanHash`;
+2. читает `attestation.json` → `attest.Parse` → `attest.Digest`;
+3. вычисляет runtime identity = `sha256(run.json.Provenance)` (raw bytes);
+4. собирает controller-derived trailers:
+   - `ai-team-run: <run_id>`, `ai-team-runtime: <hex>`,
+     `ai-team-attestation: <digest>`;
+5. исполняет реальный `delivery.Execute(context.Background(), …)` рабочей
+   копии (workspace lock всё ещё удержан — хук внутри `RunWithResult`);
+6. записывает tamper-evident `{RunDir}/delivery.json` (self-integrity
+   `record_sha256`, строгая валидация, однократная запись, idempotent retry).
+
+Трейлеры не входят в canonical plan и subject approval (они controller-derived,
+не из LLM). Commit message = plan.CommitMessage + trailers. Трейлеры персистятся
+в delivery state ДО commit, поэтому crash-recovery (retry после commit) сверяет
+message с `FullCommitMessage(plan.CommitMessage, savedTrailers)`. При расхождении
+траилей восстановленный commit отклоняется.
+
+`FindDelivered` (evidence/query) сначала читает `delivery.json` (канонический
+источник), при его отсутствии падает на attempt-манифесты. Если post-terminal
+хук упал (например, сетевой сбой push), доставка повторяема командой
+`ai-team deliver --run <run_id> [--target <dir>] [--feature <name>]`: enforcement
+детерминированный — run обязан быть терминальным `completed`, plan обязан
+совпасть с `delivery_deferred` event, запись `delivery.json` однократная.
+
 ## Layered agent registry
 
 `ai-team list` показывает источник победившего definition агента. Registry

--- a/pkg/delivery/executor.go
+++ b/pkg/delivery/executor.go
@@ -36,6 +36,75 @@ type Request struct {
 	TargetDir string
 	Feature   string
 	Plan      Plan
+	// Trailers (V0-9) — controller-производные Git trailer'ы (значения
+	// детерминируются из terminal evidence контроллером, не агентом) и НЕ
+	// входят в canonical plan / subject approval. Переживают потерю bundle:
+	// git история связывает commit с run, runtime identity и attestation.
+	Trailers []string `json:"-"`
+}
+
+// V0-9: ключи trailer'ов, добавляемых контроллером в commit message.
+const (
+	TrailerRunID       = "ai-team-run"
+	TrailerRuntime     = "ai-team-runtime"
+	TrailerAttestation = "ai-team-attestation"
+)
+
+// ValidateTrailers проверяет формат controller-траилей: только известные
+// ключи без дублей и с непустыми значениями (одна строка `key: value`).
+func ValidateTrailers(trailers []string) error {
+	seen := make(map[string]bool, len(trailers))
+	for _, trailer := range trailers {
+		key, value, ok := strings.Cut(trailer, ": ")
+		if !ok || key == "" || value == "" || strings.Contains(value, ": ") {
+			return fmt.Errorf("delivery trailer: некорректный формат %q (ожидается `key: value`)", trailer)
+		}
+		switch key {
+		case TrailerRunID, TrailerRuntime, TrailerAttestation:
+		default:
+			return fmt.Errorf("delivery trailer: неизвестный ключ %q", key)
+		}
+		if !trailerValueChars(value) {
+			return fmt.Errorf("delivery trailer: недопустимые символы в значении %q", value)
+		}
+		if seen[key] {
+			return fmt.Errorf("delivery trailer: дублирующийся ключ %q", key)
+		}
+		seen[key] = true
+	}
+	return nil
+}
+
+func trailerValueChars(value string) bool {
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func sameTrailers(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// FullCommitMessage собирает итоговое сообщение commit: approved subject
+// (plan.CommitMessage) + пустая строка + controller-траилей. Без trailer'ов
+// возвращает subject байт-в-байт (обратная совместимость).
+func FullCommitMessage(subject string, trailers []string) string {
+	if len(trailers) == 0 {
+		return subject
+	}
+	return subject + "\n\n" + strings.Join(trailers, "\n")
 }
 
 type StepResult struct {
@@ -123,6 +192,7 @@ type state struct {
 	SchemaVersion  int          `json:"schema_version"`
 	PlanHash       string       `json:"plan_hash"`
 	Plan           Plan         `json:"plan"`
+	Trailers       []string     `json:"trailers,omitempty"`
 	CommitSHA      string       `json:"commit_sha,omitempty"`
 	CommitVerified bool         `json:"commit_verified,omitempty"`
 	Pushed         bool         `json:"pushed,omitempty"`
@@ -156,6 +226,18 @@ func (c *Controller) Execute(ctx context.Context, request Request) (Result, erro
 	if err != nil {
 		return Result{}, err
 	}
+	if len(currentState.Trailers) == 0 && len(request.Trailers) > 0 {
+		if err := ValidateTrailers(request.Trailers); err != nil {
+			return Result{}, err
+		}
+		currentState.Trailers = append([]string(nil), request.Trailers...)
+		if err := writeState(statePath, currentState); err != nil {
+			return Result{}, err
+		}
+	} else if len(request.Trailers) > 0 && !sameTrailers(currentState.Trailers, request.Trailers) {
+		return Result{}, fmt.Errorf("delivery: trailer'ы не совпадают с сохранённым состоянием")
+	}
+	commitMessage := FullCommitMessage(request.Plan.CommitMessage, currentState.Trailers)
 	result := func() Result {
 		return Result{PlanHash: planHash, StatePath: statePath, CommitSHA: currentState.CommitSHA, PRURL: currentState.PRURL, Steps: append([]StepResult(nil), currentState.Steps...)}
 	}
@@ -227,7 +309,7 @@ func (c *Controller) Execute(ctx context.Context, request Request) (Result, erro
 		// The process may have crashed after git commit succeeded but before its
 		// identity was durably recorded. Recover only an exact approved commit;
 		// any unrelated branch advance remains fail-closed.
-		if err := verifyCommittedChange(ctx, c.Runner, target, request.Plan, actualHead, record); err != nil {
+		if err := verifyCommittedChange(ctx, c.Runner, target, request.Plan, actualHead, currentState.Trailers, record); err != nil {
 			return result(), fmt.Errorf("delivery: unrecorded HEAD is not the approved commit: %w", err)
 		}
 		currentState.CommitSHA = actualHead
@@ -294,7 +376,7 @@ func (c *Controller) Execute(ctx context.Context, request Request) (Result, erro
 			_, _ = run("rollback_staging", "git", resetArgs...)
 			return result(), err
 		}
-		if _, err := run("commit", "git", "-c", "core.hooksPath=/dev/null", "commit", "--no-verify", "-m", request.Plan.CommitMessage); err != nil {
+		if _, err := run("commit", "git", "-c", "core.hooksPath=/dev/null", "commit", "--no-verify", "-m", commitMessage); err != nil {
 			return result(), err
 		}
 		commit, err := run("record_commit", "git", "rev-parse", "HEAD")
@@ -302,7 +384,7 @@ func (c *Controller) Execute(ctx context.Context, request Request) (Result, erro
 			return result(), err
 		}
 		commitSHA := strings.TrimSpace(commit.Stdout)
-		if err := verifyCommittedChange(ctx, c.Runner, target, request.Plan, commitSHA, record); err != nil {
+		if err := verifyCommittedChange(ctx, c.Runner, target, request.Plan, commitSHA, currentState.Trailers, record); err != nil {
 			return result(), err
 		}
 		currentState.CommitSHA = commitSHA
@@ -426,6 +508,7 @@ func verifyCommittedChange(
 	target string,
 	plan Plan,
 	commitSHA string,
+	trailers []string,
 	record func(StepResult) error,
 ) error {
 	run := func(step string, args ...string) (StepResult, error) {
@@ -443,7 +526,7 @@ func verifyCommittedChange(
 	if err != nil {
 		return err
 	}
-	if strings.TrimRight(message.Stdout, "\r\n") != plan.CommitMessage {
+	if strings.TrimRight(message.Stdout, "\r\n") != FullCommitMessage(plan.CommitMessage, trailers) {
 		return fmt.Errorf("delivery: commit message не совпадает с approved plan")
 	}
 	parent, err := run("verify_commit_parent", "rev-parse", commitSHA+"^")

--- a/pkg/delivery/plan_test.go
+++ b/pkg/delivery/plan_test.go
@@ -2,6 +2,7 @@ package delivery
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -140,6 +141,159 @@ func TestBuildPlanUsesOnlyAttributedFiles(t *testing.T) {
 	}
 	if strings.Join(plan.Files, ",") != "z.go" || plan.Branch != "ai-team/feat" || plan.BaseBranch != "main" {
 		t.Fatalf("неверный детерминированный plan: %+v", plan)
+	}
+}
+
+func TestControllerAddsProvenanceTrailersToCommit(t *testing.T) {
+	repo, _ := setupRepository(t)
+	installFakeGH(t)
+	writeFile(t, filepath.Join(repo, "a.go"), "package a\n// changed\n")
+	plan, err := BuildPlan(context.Background(), repo, "feat", "change", []string{"a.go"}, testVerification(t, repo))
+	if err != nil {
+		t.Fatal(err)
+	}
+	trailers := []string{
+		TrailerRunID + ": run-abcdef123456",
+		TrailerRuntime + ": 0f2b5a11c9d34e55809f",
+		TrailerAttestation + ": 5f0d6b2c3a49e781f6a2",
+	}
+	result, err := NewController().Execute(context.Background(), Request{
+		TargetDir: repo, Feature: "feat", Plan: plan, Trailers: trailers,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CommitSHA == "" {
+		t.Fatalf("commit не создан: %+v", result)
+	}
+	message := git(t, repo, "show", "-s", "--format=%B", "HEAD")
+	expected := FullCommitMessage(plan.CommitMessage, trailers)
+	if strings.TrimRight(message, "\r\n") != expected {
+		t.Fatalf("commit message не содержит trailers:\n--- got ---\n%s\n--- want ---\n%s", message, expected)
+	}
+	show := git(t, repo, "show", "-s", "--format=%B", "HEAD")
+	if !strings.Contains(show, TrailerRunID+": run-abcdef123456") {
+		t.Fatalf("trailer ai-team-run отсутствует:\n%s", show)
+	}
+
+	// Resume/idempotent повтор: те же trailers допускаются, сообщение сверяется
+	// с сохранённым состоянием.
+	resumed, err := NewController().Execute(context.Background(), Request{
+		TargetDir: repo, Feature: "feat", Plan: plan, Trailers: trailers,
+	})
+	if err != nil || resumed.CommitSHA != result.CommitSHA {
+		t.Fatalf("resume с теми же trailers нескомпенсирован: err=%v result=%+v", err, resumed)
+	}
+
+	// «Краш после git commit до записи identity»: очищаем commit_sha в state —
+	// Execute должен восстановить точный approved commit и сверить trailers.
+	var raw struct {
+		CommitSHA string `json:"commit_sha"`
+	}
+	data, err := os.ReadFile(result.StatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw.CommitSHA != result.CommitSHA {
+		t.Fatalf("state.commit_sha=%q, ожидался %s", raw.CommitSHA, result.CommitSHA)
+	}
+	synthetic := strings.Replace(string(data), `"commit_sha":"`+result.CommitSHA+`"`, `"commit_sha":""`, 1)
+	if err := os.WriteFile(result.StatePath, []byte(synthetic), 0644); err != nil {
+		t.Fatal(err)
+	}
+	recovered, err := NewController().Execute(context.Background(), Request{
+		TargetDir: repo, Feature: "feat", Plan: plan,
+	})
+	if err != nil {
+		t.Fatalf("crash recovery с trailers: %v", err)
+	}
+	if recovered.CommitSHA != result.CommitSHA {
+		t.Fatalf("recovery вернул другой commit: %s != %s", recovered.CommitSHA, result.CommitSHA)
+	}
+}
+
+func TestValidateTrailersRejectsBadForm(t *testing.T) {
+	cases := [][]string{
+		{"ai-team-run: "},
+		{": value"},
+		{"ai-team-run: run-123", "ai-team-run: run-456"},
+		{"unknown-key: value"},
+		{"ai-team-attestation: 123 456"},
+		{"ai-team-run:run-123"},
+	}
+	for _, trailers := range cases {
+		if err := ValidateTrailers(trailers); err == nil {
+			t.Fatalf("trailers %v должны быть отклонены", trailers)
+		}
+	}
+	good := []string{"ai-team-run: run-abc", "ai-team-runtime: ab12", "ai-team-attestation: 5f0d_1-2a"}
+	if err := ValidateTrailers(good); err != nil {
+		t.Fatalf("валидные trailers отклонены: %v", err)
+	}
+}
+
+func TestTerminalRecordRoundtripAndTamper(t *testing.T) {
+	runDir := t.TempDir()
+	record := TerminalRecord{
+		SchemaVersion:     TerminalRecordSchemaVersion,
+		RunID:             "20260901T120000.000000000Z-abcdef0123456789",
+		Feature:           "feat",
+		PlanHash:          strings.Repeat("c", 64),
+		CommitSHA:         strings.Repeat("a", 40),
+		PRURL:             "https://example.test/pr/1",
+		Trailers:          []string{"ai-team-run: 20260901T120000.000000000Z-abcdef0123456789", "ai-team-runtime: " + strings.Repeat("b", 64)},
+		AttestationSHA256: "",
+		RuntimeIdentity:   strings.Repeat("b", 64),
+		PerformedAt:       time.Now().UTC(),
+	}
+	// Attestation trailer обязан совпадать с полем — должен быть отклонён.
+	record.Trailers = []string{
+		"ai-team-run: " + record.RunID,
+		"ai-team-runtime: " + record.RuntimeIdentity,
+		"ai-team-attestation: " + strings.Repeat("e", 64),
+	}
+	record.AttestationSHA256 = strings.Repeat("d", 64)
+	if err := WriteTerminalRecord(runDir, record); err == nil {
+		t.Fatal("record с несогласованным attestation trailer должен быть отклонён")
+	}
+	record.Trailers = []string{
+		"ai-team-run: " + record.RunID,
+		"ai-team-runtime: " + record.RuntimeIdentity,
+		"ai-team-attestation: " + record.AttestationSHA256,
+	}
+	if err := WriteTerminalRecord(runDir, record); err != nil {
+		t.Fatalf("валидный record должен быть записан: %v", err)
+	}
+	got, ok, err := ReadTerminalRecord(runDir)
+	if err != nil || !ok || got.PlanHash != record.PlanHash || len(got.Trailers) != 3 {
+		t.Fatalf("roundtrip failed: %+v ok=%v err=%v", got, ok, err)
+	}
+	// Идемпотентный retry допускается, произвольная перезапись — нет.
+	if err := WriteTerminalRecord(runDir, record); err != nil {
+		t.Fatalf("идемпотентный repeat должен быть допущен: %v", err)
+	}
+	other := record
+	other.PlanHash = strings.Repeat("d", 64)
+	if err := WriteTerminalRecord(runDir, other); err == nil {
+		t.Fatal("перезапись существующего record должна быть запрещена")
+	}
+	// Tamper: правка commit_sha должна быть обнаружена.
+	data, err := os.ReadFile(filepath.Join(runDir, "delivery.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered := []byte(strings.Replace(string(data), record.CommitSHA, strings.Repeat("f", 40), 1))
+	if err := os.WriteFile(filepath.Join(runDir, "delivery.json"), tampered, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ReadTerminalRecord(runDir); err == nil {
+		t.Fatal("tampered record должен быть отклонён")
+	}
+	if _, ok, err := ReadTerminalRecord(t.TempDir()); err != nil || ok {
+		t.Fatalf("отсутствующий record: ok=%v err=%v", ok, err)
 	}
 }
 

--- a/pkg/delivery/terminal.go
+++ b/pkg/delivery/terminal.go
@@ -1,0 +1,233 @@
+package delivery
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/arturpanteleev/ai-team/pkg/safeio"
+)
+
+// terminal.go (V0-9): post-terminal delivery record — фиксирует результат
+// отложенного (deferred) commit/push/PR. Пишется контроллером в
+// {RunDir}/delivery.json ПОСЛЕ terminal finalize, когда attestation digest и
+// runtime identity уже детерминированы; эти же значения попадают в commit
+// trailer'ы. Attempt manifest внутри run не меняется (immutable); delivery.json
+// — канонический источник результата доставки для FindDelivered/export.
+
+const (
+	TerminalRecordSchemaVersion = 1
+	deliveryRecordMaxSize       = 1 << 20
+)
+
+// TerminalRecord — каноническая запись отложенной доставки run.
+type TerminalRecord struct {
+	SchemaVersion     int       `json:"schema_version"`
+	RunID             string    `json:"run_id"`
+	Feature           string    `json:"feature"`
+	PlanHash          string    `json:"plan_hash"`
+	CommitSHA         string    `json:"commit_sha,omitempty"`
+	PRURL             string    `json:"pr_url,omitempty"`
+	Trailers          []string  `json:"trailers,omitempty"`
+	AttestationSHA256 string    `json:"attestation_sha256,omitempty"`
+	RuntimeIdentity   string    `json:"runtime_identity,omitempty"`
+	PerformedAt       time.Time `json:"performed_at"`
+	// RecordSHA256 — self-integrity digest (sha256 canonical bytes record без
+	// этого поля). Делает record tamper-evident: любой ad-hoc правдоподобный
+	// edit фиксируется при повторном чтении.
+	RecordSHA256 string `json:"record_sha256,omitempty"`
+}
+
+// selfDigest вычисляет sha256 canonical-байт record без поля record_sha256.
+// Десериализованный time.Time с идентичным UTC-временем мёршится детерминированно.
+func (r TerminalRecord) selfDigest() (string, error) {
+	r.RecordSHA256 = ""
+	data, err := json.Marshal(r)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (r TerminalRecord) Validate() error {
+	if r.SchemaVersion != TerminalRecordSchemaVersion {
+		return fmt.Errorf("terminal delivery record schema %d не поддерживается", r.SchemaVersion)
+	}
+	if r.RunID == "" || r.Feature == "" {
+		return errors.New("terminal delivery record: пустые run_id/feature")
+	}
+	if r.PlanHash == "" || !hex64(r.PlanHash) {
+		return fmt.Errorf("terminal delivery record: некорректный plan_hash %q", r.PlanHash)
+	}
+	if err := ValidateTrailers(r.Trailers); err != nil {
+		return err
+	}
+	if r.CommitSHA != "" && !gitHashPattern.MatchString(r.CommitSHA) {
+		return fmt.Errorf("terminal delivery record: некорректный commit_sha %q", r.CommitSHA)
+	}
+	if r.CommitSHA == "" && r.PRURL == "" {
+		return errors.New("terminal delivery record: пустые commit_sha и pr_url")
+	}
+	for _, trailer := range r.Trailers {
+		key, value, ok := strings.Cut(trailer, ": ")
+		if !ok {
+			continue
+		}
+		switch key {
+		case TrailerRunID:
+			if value != r.RunID {
+				return fmt.Errorf("terminal delivery record: trailer %q не согласован с run_id", trailer)
+			}
+		case TrailerRuntime:
+			if r.RuntimeIdentity != "" && value != r.RuntimeIdentity {
+				return fmt.Errorf("terminal delivery record: trailer %q не согласован с runtime_identity", trailer)
+			}
+		case TrailerAttestation:
+			if r.AttestationSHA256 != "" && value != r.AttestationSHA256 {
+				return fmt.Errorf("terminal delivery record: trailer %q не согласован с attestation_sha256", trailer)
+			}
+		}
+	}
+	if r.RecordSHA256 != "" {
+		got, err := r.selfDigest()
+		if err != nil {
+			return err
+		}
+		if got != r.RecordSHA256 {
+			return fmt.Errorf("terminal delivery record: record_sha256 mismatch (%s != %s) — record изменён", got, r.RecordSHA256)
+		}
+	}
+	return nil
+}
+
+func hex64(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		if r >= '0' && r <= '9' || r >= 'a' && r <= 'f' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// WriteTerminalRecord сериализует canonical JSON record в {runDir}/delivery.json
+// (temp + fsync + rename, как у anchor; с self-integrity record_sha256).
+// Перезапись уже существующего осмысленного record — ошибка (запись однократная).
+func WriteTerminalRecord(runDir string, record TerminalRecord) error {
+	if err := record.Validate(); err != nil {
+		return err
+	}
+	finalPath := filepath.Join(runDir, "delivery.json")
+	if existing, ok, err := ReadTerminalRecord(runDir); err != nil {
+		return err
+	} else if ok && existing.CommitSHA == record.CommitSHA && existing.PlanHash == record.PlanHash {
+		return nil // идемпотентный повтор (retry) с тем же результатом
+	} else if ok {
+		return fmt.Errorf("terminal delivery record уже записан (%s): перезапись запрещена", existing.CommitSHA)
+	}
+	digest, err := record.selfDigest()
+	if err != nil {
+		return err
+	}
+	record.RecordSHA256 = digest
+	if err := record.Validate(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmpFile, err := os.CreateTemp(runDir, ".tmp-delivery-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, finalPath)
+}
+
+// ReadTerminalRecord читает и строго валидирует record (fail-closed).
+func ReadTerminalRecord(runDir string) (*TerminalRecord, bool, error) {
+	data, err := safeio.ReadRegularFile(filepath.Join(runDir, "delivery.json"), deliveryRecordMaxSize)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var record TerminalRecord
+	if err := decoder.Decode(&record); err != nil {
+		return nil, false, fmt.Errorf("terminal delivery record decode: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return nil, false, errors.New("terminal delivery record: trailing JSON value")
+	} else if !errors.Is(err, io.EOF) {
+		return nil, false, fmt.Errorf("terminal delivery record: trailing data: %w", err)
+	}
+	if err := record.Validate(); err != nil {
+		return nil, false, err
+	}
+	return &record, true, nil
+}
+
+// ReadTerminalRecordFile — то же, но для явного пути записи (используется
+// export/verify-контрактом; путь обязан быть в {runDir}/delivery.json).
+func ReadTerminalRecordFile(path string) (*TerminalRecord, bool, error) {
+	if filepath.Base(path) != "delivery.json" {
+		return nil, false, fmt.Errorf("terminal delivery record: неожиданное имя %q", filepath.Base(path))
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var record TerminalRecord
+	if err := decoder.Decode(&record); err != nil {
+		return nil, false, fmt.Errorf("terminal delivery record decode: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err == nil {
+		return nil, false, errors.New("terminal delivery record: trailing JSON value")
+	} else if !errors.Is(err, io.EOF) {
+		return nil, false, fmt.Errorf("terminal delivery record: trailing data: %w", err)
+	}
+	if err := record.Validate(); err != nil {
+		return nil, false, err
+	}
+	return &record, true, nil
+}

--- a/pkg/evidence/query.go
+++ b/pkg/evidence/query.go
@@ -47,6 +47,24 @@ func FindDelivered(runsRoot, feature string) (result DeliveredRun, ok bool, err 
 			continue
 		}
 
+		// V0-9: канонический источник результата доставки — terminal
+		// delivery.json (deferred delivery). Attempt-манифесты stay immutable
+		// (CommitSHA пуст), поэтому сначала ищем record, и только при его
+		// отсутствии сканируем старые attempt-манифесты.
+		if record, recOK, recErr := delivery.ReadTerminalRecord(runDir); recErr == nil && recOK && record.Feature == feature {
+			if !ok || manifest.StartedAt.After(result.StartedAt) {
+				result = DeliveredRun{
+					RunID: manifest.RunID, StartedAt: manifest.StartedAt,
+					Delivery: delivery.Result{
+						PlanHash: record.PlanHash, CommitSHA: record.CommitSHA,
+						PRURL: record.PRURL, StatePath: "",
+					},
+				}
+				ok = true
+			}
+			continue
+		}
+
 		attemptEntries, readErr := os.ReadDir(filepath.Join(runDir, "attempts"))
 		if readErr != nil {
 			continue

--- a/pkg/pipeline/delivery_deferred.go
+++ b/pkg/pipeline/delivery_deferred.go
@@ -101,7 +101,7 @@ func (rs *runState) executeDeferredDelivery() error {
 // детерминированный: результат привязан к plan, зафиксированному в
 // delivery_deferred event, и к terminal статусу run.
 func (p *Pipeline) DeliverDeferred(runDir, feature, targetDir string) (delivery.TerminalRecord, error) {
-	if _, err := safeio.ExistingDir(runDir, ""); err != nil {
+	if _, err := safeio.ExistingDir(runDir); err != nil {
 		return delivery.TerminalRecord{}, err
 	}
 	runID := filepath.Base(runDir)
@@ -114,7 +114,11 @@ func (p *Pipeline) DeliverDeferred(runDir, feature, targetDir string) (delivery.
 		return delivery.TerminalRecord{}, fmt.Errorf("deliver: run %s уже доставлен (delivery.json существует)", runID)
 	}
 
-	_, manifest, _, err := evidence.Resume(runDir, runID)
+	// evidence.Resume не применим: он открывает только НЕ-терминальные run
+	// (терминальный отклоняется «already terminal»), а DeliverDeferred работает
+	// именно с терминальными. Читаем манифест терминального run напрямую из
+	// run.json (паттерн export.readRunManifest), сверяя identity/schema.
+	manifest, err := readRunManifest(runDir)
 	if err != nil {
 		return delivery.TerminalRecord{}, fmt.Errorf("deliver: replayed evidence: %w", err)
 	}
@@ -271,4 +275,22 @@ func runtimeIdentityOfRun(runDir string) (string, error) {
 	}
 	sum := sha256.Sum256(manifest.Provenance)
 	return hex.EncodeToString(sum[:]), nil
+}
+
+// readRunManifest читает манифест терминального run напрямую из run.json
+// (anapek export.readRunManifest), сверяя identity/schema. evidence.Resume
+// не подходит: он открывает только НЕ-терминальные run.
+func readRunManifest(runDir string) (*evidence.RunManifest, error) {
+	data, err := safeio.ReadRegularFile(filepath.Join(runDir, "run.json"), 1<<20)
+	if err != nil {
+		return nil, fmt.Errorf("deferred delivery: run manifest: %w", err)
+	}
+	var manifest evidence.RunManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("deferred delivery: run manifest decode: %w", err)
+	}
+	if manifest.RunID == "" || manifest.SchemaVersion != evidence.SchemaVersion {
+		return nil, errors.New("deferred delivery: run manifest identity/schema mismatch")
+	}
+	return &manifest, nil
 }

--- a/pkg/pipeline/delivery_deferred.go
+++ b/pkg/pipeline/delivery_deferred.go
@@ -1,0 +1,274 @@
+package pipeline
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/arturpanteleev/ai-team/pkg/attest"
+	"github.com/arturpanteleev/ai-team/pkg/delivery"
+	"github.com/arturpanteleev/ai-team/pkg/evidence"
+	"github.com/arturpanteleev/ai-team/pkg/safeio"
+	"github.com/arturpanteleev/ai-team/pkg/ui"
+	"github.com/arturpanteleev/ai-team/pkg/workflow"
+)
+
+// delivery_deferred.go (V0-9): string post-terminal доставка. Git-история
+// (commit, push, PR) меняется ТОЛЬКО после terminal finalize — когда
+// attestation digest и runtime identity детерминированы. Трейлеры commit
+// (run ID, runtime identity, attestation digest) собираются из evidence, а не
+// из состояния рантайма, поэтому не зависят от харнесс-детерминизма.
+
+// executeDeferredDelivery — вызывается строго после финального finalize при
+// outcome Completed. Работает от реального контроллера (rs.p.delivery) и
+// workspace lock'а (мы всё ещё внутри RunWithResult). plan перегружается из
+// подготовленного delivery state и сверяется с утверждённым (approvedPlanHash)
+// и с deferred-маркером стадии.
+func (rs *runState) executeDeferredDelivery() error {
+	if rs.deferredDelivery == nil {
+		return nil
+	}
+	ctx := context.Background() // run ctx может быть завершён; delivery-операция нужна до конца
+	plan, found, planErr := delivery.LoadPreparedPlan(rs.sourceDir(), rs.runCfg.Feature)
+	if planErr != nil {
+		return fmt.Errorf("deferred delivery: загрузка prepared plan: %w", planErr)
+	}
+	if !found {
+		return errors.New("deferred delivery: prepared plan отсутствует — delivery state не найден")
+	}
+	planHash, hashErr := plan.Hash()
+	if hashErr != nil {
+		return fmt.Errorf("deferred delivery: plan hash: %w", hashErr)
+	}
+	if planHash != rs.deferredDelivery.PlanHash {
+		return fmt.Errorf("deferred delivery: prepared plan не совпадает с маркером стадии (%s != %s)",
+			planHash, rs.deferredDelivery.PlanHash)
+	}
+	if rs.approvedPlanHash != "" && rs.approvedPlanHash != planHash {
+		return fmt.Errorf("deferred delivery: утверждённый plan %s не совпадает с approved %s",
+			planHash, rs.approvedPlanHash)
+	}
+
+	attestationDigest, err := attestationDigestOfRun(rs.evidence.RunDir())
+	if err != nil {
+		return err
+	}
+	runtimeIdentity, err := runtimeIdentityOfRun(rs.evidence.RunDir())
+	if err != nil {
+		return err
+	}
+	trailers := []string{
+		delivery.TrailerRunID + ": " + rs.runID,
+		delivery.TrailerRuntime + ": " + runtimeIdentity,
+		delivery.TrailerAttestation + ": " + attestationDigest,
+	}
+
+	result, err := rs.p.delivery.Execute(ctx, delivery.Request{
+		TargetDir: rs.sourceDir(), Feature: rs.runCfg.Feature, Plan: plan, Trailers: trailers,
+	})
+	if err != nil {
+		return fmt.Errorf("deferred delivery: controller.Execute: %w", err)
+	}
+
+	record := delivery.TerminalRecord{
+		SchemaVersion:     delivery.TerminalRecordSchemaVersion,
+		RunID:             rs.runID,
+		Feature:           rs.runCfg.Feature,
+		PlanHash:          planHash,
+		CommitSHA:         result.CommitSHA,
+		PRURL:             result.PRURL,
+		Trailers:          trailers,
+		AttestationSHA256: attestationDigest,
+		RuntimeIdentity:   runtimeIdentity,
+		PerformedAt:       time.Now().UTC(),
+	}
+	if err := delivery.WriteTerminalRecord(rs.evidence.RunDir(), record); err != nil {
+		return fmt.Errorf("deferred delivery: запись terminal record: %w", err)
+	}
+	fmt.Printf("\n%s delivery по run %s: commit=%s pr=%s\n",
+		ui.Colorize("✓", ui.ColorGreen), rs.runID, result.CommitSHA, result.PRURL)
+	return nil
+}
+
+// DeliverDeferred — standalone-повтор отложенной доставки (retry/CLI) по
+// завершённому evidence. Используется когда post-terminal хук упал (можно
+// перезапустить `ai-team deliver --run <id> --target <repo>`); enforcement
+// детерминированный: результат привязан к plan, зафиксированному в
+// delivery_deferred event, и к terminal статусу run.
+func (p *Pipeline) DeliverDeferred(runDir, feature, targetDir string) (delivery.TerminalRecord, error) {
+	if _, err := safeio.ExistingDir(runDir, ""); err != nil {
+		return delivery.TerminalRecord{}, err
+	}
+	runID := filepath.Base(runDir)
+	if runID == "." || runID == string(filepath.Separator) {
+		return delivery.TerminalRecord{}, errors.New("deliver: недопустимый run dir")
+	}
+	if _, ok, err := delivery.ReadTerminalRecord(runDir); err != nil {
+		return delivery.TerminalRecord{}, err
+	} else if ok {
+		return delivery.TerminalRecord{}, fmt.Errorf("deliver: run %s уже доставлен (delivery.json существует)", runID)
+	}
+
+	_, manifest, _, err := evidence.Resume(runDir, runID)
+	if err != nil {
+		return delivery.TerminalRecord{}, fmt.Errorf("deliver: replayed evidence: %w", err)
+	}
+	terminalStatus, err := terminalStatusOfRun(runDir, runID)
+	if err != nil {
+		return delivery.TerminalRecord{}, err
+	}
+	switch terminalStatus {
+	case string(workflow.RunCompleted), string(workflow.RunCompletedWithWarnings):
+	default:
+		return delivery.TerminalRecord{}, fmt.Errorf("deliver: run %s завершился как %q, доставка не разрешена", runID, terminalStatus)
+	}
+	if feature == "" {
+		feature = manifest.Feature
+	}
+	if feature == "" {
+		return delivery.TerminalRecord{}, errors.New("deliver: feature не определён")
+	}
+
+	marker, err := firstDeferredMarker(runDir)
+	if err != nil {
+		return delivery.TerminalRecord{}, err
+	}
+	if marker.PlanHash == "" || (marker.Feature != "" && marker.Feature != feature) {
+		return delivery.TerminalRecord{}, errors.New("deliver: delivery_deferred маркер не согласован с run")
+	}
+
+	attestationDigest, err := attestationDigestOfRun(runDir)
+	if err != nil {
+		return delivery.TerminalRecord{}, err
+	}
+	runtimeIdentity, err := runtimeIdentityOfRun(runDir)
+	if err != nil {
+		return delivery.TerminalRecord{}, err
+	}
+
+	plan, found, err := delivery.LoadPreparedPlan(targetDir, feature)
+	if err != nil {
+		return delivery.TerminalRecord{}, fmt.Errorf("deliver: prepared plan: %w", err)
+	}
+	if !found {
+		return delivery.TerminalRecord{}, errors.New("deliver: prepared plan отсутствует — delivery state не найден")
+	}
+	planHash, err := plan.Hash()
+	if err != nil {
+		return delivery.TerminalRecord{}, err
+	}
+	if planHash != marker.PlanHash {
+		return delivery.TerminalRecord{}, fmt.Errorf("deliver: plan hash mismatch: marker=%s prepared=%s", marker.PlanHash, planHash)
+	}
+
+	trailers := []string{
+		delivery.TrailerRunID + ": " + runID,
+		delivery.TrailerRuntime + ": " + runtimeIdentity,
+		delivery.TrailerAttestation + ": " + attestationDigest,
+	}
+	result, err := p.delivery.Execute(context.Background(), delivery.Request{
+		TargetDir: targetDir, Feature: feature, Plan: plan, Trailers: trailers,
+	})
+	if err != nil {
+		return delivery.TerminalRecord{}, err
+	}
+	record := delivery.TerminalRecord{
+		SchemaVersion:     delivery.TerminalRecordSchemaVersion,
+		RunID:             runID,
+		Feature:           feature,
+		PlanHash:          planHash,
+		CommitSHA:         result.CommitSHA,
+		PRURL:             result.PRURL,
+		Trailers:          trailers,
+		AttestationSHA256: attestationDigest,
+		RuntimeIdentity:   runtimeIdentity,
+		PerformedAt:       time.Now().UTC(),
+	}
+	if err := delivery.WriteTerminalRecord(runDir, record); err != nil {
+		return delivery.TerminalRecord{}, err
+	}
+	return record, nil
+}
+
+// deferredMarkerEvent — доказательство утверждённой delivery-стадии в run.
+type deferredMarkerEvent struct {
+	PlanHash string `json:"plan_hash"`
+	Feature  string `json:"feature"`
+}
+
+func firstDeferredMarker(runDir string) (deferredMarkerEvent, error) {
+	events, err := evidence.VerifyEventLog(filepath.Join(runDir, "events.jsonl"), filepath.Base(runDir))
+	if err != nil {
+		return deferredMarkerEvent{}, fmt.Errorf("deliver: event log: %w", err)
+	}
+	for _, event := range events {
+		if event.Type != "delivery_deferred" {
+			continue
+		}
+		data, err := json.Marshal(event.Data)
+		if err != nil {
+			continue
+		}
+		var marker deferredMarkerEvent
+		if err := json.Unmarshal(data, &marker); err == nil && marker.PlanHash != "" {
+			return marker, nil
+		}
+	}
+	return deferredMarkerEvent{}, errors.New("deliver: delivery_deferred event не найден")
+}
+
+func terminalStatusOfRun(runDir, runID string) (string, error) {
+	events, err := evidence.VerifyEventLog(filepath.Join(runDir, "events.jsonl"), runID)
+	if err != nil {
+		return "", fmt.Errorf("deliver: event log: %w", err)
+	}
+	for _, event := range events {
+		if event.Type != "run_finished" {
+			continue
+		}
+		status, _ := event.Data["status"].(string)
+		if status != "" {
+			return status, nil
+		}
+	}
+	return "", errors.New("deliver: run_finished event не найден — run не терминальный")
+}
+
+func attestationDigestOfRun(runDir string) (string, error) {
+	data, err := safeio.ReadRegularFile(filepath.Join(runDir, "attestation.json"), 1<<20)
+	if err != nil {
+		return "", fmt.Errorf("deferred delivery: attestation: %w", err)
+	}
+	statement, err := attest.Parse(data)
+	if err != nil {
+		return "", fmt.Errorf("deferred delivery: attestation parse: %w", err)
+	}
+	digest, err := attest.Digest(statement)
+	if err != nil {
+		return "", fmt.Errorf("deferred delivery: attestation digest: %w", err)
+	}
+	return digest, nil
+}
+
+func runtimeIdentityOfRun(runDir string) (string, error) {
+	data, err := safeio.ReadRegularFile(filepath.Join(runDir, "run.json"), 1<<20)
+	if err != nil {
+		return "", fmt.Errorf("deferred delivery: run manifest: %w", err)
+	}
+	var manifest struct {
+		Provenance json.RawMessage `json:"provenance,omitempty"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return "", fmt.Errorf("deferred delivery: run manifest decode: %w", err)
+	}
+	if len(manifest.Provenance) == 0 || !json.Valid(manifest.Provenance) {
+		return "", errors.New("deferred delivery: runtime identity: пустой provenance в run manifest")
+	}
+	sum := sha256.Sum256(manifest.Provenance)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -172,6 +172,16 @@ type runState struct {
 	sourceTarget     string
 	liveWorkspaceSHA string
 	loopbackCycles   int
+	deferredDelivery *deferredDelivery
+}
+
+// deferredDelivery (V0-9) — подготовленный canonical plan, чей commit/push/PR
+// отложен до terminal finalize, когда attestation digest уже детерминирован.
+// Инициализируется в delivery-стадии после успешной авторизации плана; реальный
+// git-commit создаёт контроллер после finalize (см. executeDeferredDelivery).
+type deferredDelivery struct {
+	StatePath string
+	PlanHash  string
 }
 
 func (rs *runState) sourceDir() string {
@@ -620,6 +630,18 @@ func (p *Pipeline) RunWithResult(ctx context.Context, runCfg RunConfig) (RunResu
 
 	runErr := rs.execute(ctx)
 	outcome, finalErr := rs.finalize(runErr)
+	if finalErr != nil {
+		return RunResult{RunID: runID, Outcome: outcome}, finalErr
+	}
+	// V0-9: отложенная (deferred) доставка — только после terminal finalize и
+	// только для полностью completed-ранна, когда attestation digest и runtime
+	// identity детерминированы. Enforcement: план перегружается из prepared
+	// state и должен совпасть с approvedPlanHash и маркером стадии.
+	if outcome == workflow.RunCompleted && rs.deferredDelivery != nil {
+		if deferredErr := rs.executeDeferredDelivery(); deferredErr != nil {
+			return RunResult{RunID: runID, Outcome: outcome}, deferredErr
+		}
+	}
 	return RunResult{RunID: runID, Outcome: outcome}, finalErr
 }
 

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -235,7 +235,7 @@ type fakeDeliveryService struct {
 func (f *fakeDeliveryService) Execute(_ context.Context, request delivery.Request) (delivery.Result, error) {
 	f.calls++
 	hash, _ := request.Plan.Hash()
-	return delivery.Result{PlanHash: hash, CommitSHA: "deadbeef", PRURL: "https://example.test/pr/1"}, nil
+	return delivery.Result{PlanHash: hash, CommitSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", PRURL: "https://example.test/pr/1"}, nil
 }
 
 func prepareDelivery(t *testing.T, dir string) string {
@@ -323,6 +323,15 @@ func onlyRunDir(t *testing.T, target string) string {
 			dirs = append(dirs, filepath.Join(target, ".ai-team", "runs", entry.Name()))
 		}
 	}
+	// delivery-тесты рядом кладут prepared-run (delivery.Prepare) — это не цель.
+	live := dirs[:0]
+	for _, dir := range dirs {
+		if filepath.Base(dir) == "prepared-run" {
+			continue
+		}
+		live = append(live, dir)
+	}
+	dirs = live
 	if len(dirs) != 1 {
 		t.Fatalf("ожидался один immutable run, got %v", dirs)
 	}
@@ -753,6 +762,66 @@ func TestRun_DeliveryRunsWithExplicitApproval(t *testing.T) {
 	}
 	if got := strings.Join(rt.executed, ","); got != "approver" || service.calls != 1 {
 		t.Fatalf("LLM deployer не должен запускаться, controller calls=%d runtimes=%s", service.calls, got)
+	}
+
+	// V0-9: deferral → контроллер исполнил доставку строго один раз
+	// (post-terminal). Terminal delivery.json фиксирует commit + trailers,
+	// привязанные к evidence run.
+	runDir := onlyRunDir(t, dir)
+	record, ok, readErr := delivery.ReadTerminalRecord(runDir)
+	if readErr != nil || !ok {
+		t.Fatalf("terminal delivery record не записан: err=%v ok=%v", readErr, ok)
+	}
+	if record.CommitSHA != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" || record.PlanHash != approvedPlanHash {
+		t.Fatalf("terminal record не согласован: %+v", record)
+	}
+	if len(record.Trailers) != 3 {
+		t.Fatalf("expected 3 commit trailers, got %v", record.Trailers)
+	}
+	runID := filepath.Base(runDir)
+	for _, trailer := range record.Trailers {
+		switch {
+		case strings.HasPrefix(trailer, delivery.TrailerRunID+": "):
+			if trailer != delivery.TrailerRunID+": "+runID {
+				t.Fatalf("trailer run id mismatch: %q != %q", trailer, runID)
+			}
+		case strings.HasPrefix(trailer, delivery.TrailerRuntime+": "):
+			if record.RuntimeIdentity == "" {
+				t.Fatalf("runtime identity не заполнена")
+			}
+		case strings.HasPrefix(trailer, delivery.TrailerAttestation+": "):
+			if record.AttestationSHA256 == "" || !strings.Contains(trailer, record.AttestationSHA256) {
+				t.Fatalf("attestation trailer не согласован: %q", trailer)
+			}
+		default:
+			t.Fatalf("неожиданный trailer: %q", trailer)
+		}
+	}
+}
+
+func TestDeliverDaemonRejectsAlreadyDeliveredRun(t *testing.T) {
+	dir := env(t)
+	approvedPlanHash := prepareDelivery(t, dir)
+	rt := newScripted()
+	rt.content["approver"] = map[string]string{"review": "**Verdict:** APPROVED\n"}
+	service := &fakeDeliveryService{}
+	p := New(cfgFor(config.AgentConfig{Name: "approver"}, config.AgentConfig{Name: "deployer"}), deliveryRegistry(),
+		WithRuntimeFactory(rt.factory), WithPrompter(&scriptedPrompter{}), WithDeliveryService(service))
+	if err := p.Run(context.Background(), RunConfig{
+		Feature: "feat", TaskDesc: "t", TargetDir: dir, ApproveGates: true, ApprovePlanHash: approvedPlanHash,
+	}); err != nil {
+		t.Fatalf("run должен завершиться с deferred delivery: %v", err)
+	}
+	runDir := onlyRunDir(t, dir)
+	runID := filepath.Base(runDir)
+
+	// Повтор доставки невозможен — запись однократная.
+	if _, err := New(nil, nil).DeliverDeferred(runDir, "", dir); err == nil {
+		t.Fatal("повтор доставки уже доставленного run должен быть отклонён")
+	}
+	// Неизвестный run id также отклоняется.
+	if _, err := New(nil, nil).DeliverDeferred(filepath.Join(dir, ".ai-team", "runs", runID+"-nope"), "", dir); err == nil {
+		t.Fatal("доставка несуществующего run должна быть отклонена")
 	}
 }
 

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -825,6 +825,83 @@ func TestDeliverDaemonRejectsAlreadyDeliveredRun(t *testing.T) {
 	}
 }
 
+// gracefulDeliveryService не выполняет post-terminal доставку и не пишет
+// terminal-запись: имитирует сбой post-terminal хука после terminal finalize.
+type gracefulDeliveryService struct {
+	calls int
+}
+
+func (f *gracefulDeliveryService) Execute(ctx context.Context, request delivery.Request) (delivery.Result, error) {
+	f.calls++
+	for {
+		select {
+		case <-ctx.Done():
+			return delivery.Result{}, ctx.Err()
+		default:
+			return delivery.Result{}, errors.New("post-terminal hook сбой: доставка не выполнена")
+		}
+	}
+}
+
+// TestDeliverDeferredRetriesFailedHook — позитивный путь DeliverDeferred через
+// evidence.Resume (V0-9 blocker): run терминальный completed, но post-terminal
+// хук упал (terminal record не записан). Повтор доставки через CLI-путь обязан
+// разрешить evidence.Resume по корректному корню и выполнить controller.Execute.
+func TestDeliverDeferredRetriesFailedHook(t *testing.T) {
+	dir := env(t)
+	approvedPlanHash := prepareDelivery(t, dir)
+	rt := newScripted()
+	rt.content["approver"] = map[string]string{"review": "**Verdict:** APPROVED\n"}
+	service := &gracefulDeliveryService{}
+	p := New(cfgFor(config.AgentConfig{Name: "approver"}, config.AgentConfig{Name: "deployer"}), deliveryRegistry(),
+		WithRuntimeFactory(rt.factory), WithPrompter(&scriptedPrompter{}), WithDeliveryService(service))
+	err := p.Run(context.Background(), RunConfig{
+		Feature: "feat", TaskDesc: "t", TargetDir: dir, ApproveGates: true, ApprovePlanHash: approvedPlanHash,
+	})
+	if err == nil {
+		t.Fatalf("post-terminal хук упал — Run обязан вернуть ошибку")
+	}
+	runDir := onlyRunDir(t, dir)
+	runID := filepath.Base(runDir)
+	if _, ok, readErr := delivery.ReadTerminalRecord(runDir); readErr != nil || ok {
+		t.Fatalf("terminal record не должен существовать при сбойном хуке: ok=%v err=%v", ok, readErr)
+	}
+
+	// Retry-путь CLI: DeliverDeferred разрешает evidence через Resume с
+	// корректным корнем (filepath.Dir(runDir), runID) и доставляет.
+	okService := &fakeDeliveryService{}
+	record, err := New(nil, nil, WithDeliveryService(okService)).DeliverDeferred(runDir, "", dir)
+	if err != nil {
+		t.Fatalf("DeliverDeferred позитивный путь: %v", err)
+	}
+	if okService.calls != 1 || record.CommitSHA == "" || record.PlanHash != approvedPlanHash {
+		t.Fatalf("controller вызовов=%d record=%+v", okService.calls, record)
+	}
+	if len(record.Trailers) != 3 {
+		t.Fatalf("expected 3 trailers, got %v", record.Trailers)
+	}
+	for _, trailer := range record.Trailers {
+		switch {
+		case strings.HasPrefix(trailer, delivery.TrailerRunID+": "):
+			if trailer != delivery.TrailerRunID+": "+runID {
+				t.Fatalf("run id trailer mismatch: %q", trailer)
+			}
+		case strings.HasPrefix(trailer, delivery.TrailerRuntime+": "):
+			if record.RuntimeIdentity == "" {
+				t.Fatalf("runtime identity пустая")
+			}
+		case strings.HasPrefix(trailer, delivery.TrailerAttestation+": "):
+			if record.AttestationSHA256 == "" || !strings.Contains(trailer, record.AttestationSHA256) {
+				t.Fatalf("attestation trailer mismatch: %q", trailer)
+			}
+		}
+	}
+	// Повторная доставка теперь блокируется (однократная запись).
+	if _, err := New(nil, nil, WithDeliveryService(okService)).DeliverDeferred(runDir, "", dir); err == nil {
+		t.Fatal("повторная доставка после успеха должна быть отклонена")
+	}
+}
+
 func TestRun_DeliveryRejectsMismatchedApprovedPlanHash(t *testing.T) {
 	dir := env(t)
 	approvedPlanHash := prepareDelivery(t, dir)

--- a/pkg/pipeline/stage.go
+++ b/pkg/pipeline/stage.go
@@ -293,20 +293,31 @@ func (rs *runState) runStage(ctx context.Context, i int, name string) (r notifie
 			r.ValidationFailed = true
 			return fail(fmt.Errorf("агент %s: %w", name, planErr))
 		}
-		if _, prepareErr := delivery.Prepare(rs.sourceDir(), rs.runCfg.Feature, plan); prepareErr != nil {
+		statePath, prepareErr := delivery.Prepare(rs.sourceDir(), rs.runCfg.Feature, plan)
+		if prepareErr != nil {
 			return fail(fmt.Errorf("агент %s: подготовка delivery state: %w", name, prepareErr))
 		}
 		if approvalErr := rs.authorizeDelivery(name, r, plan); approvalErr != nil {
 			r.ControlStopped = true
 			return fail(approvalErr)
 		}
-		deliveryResult, deliveryErr := rs.p.delivery.Execute(stageCtx, delivery.Request{
-			TargetDir: rs.sourceDir(), Feature: rs.runCfg.Feature, Plan: plan,
-		})
-		r.Delivery = &deliveryResult
-		if deliveryErr != nil {
-			return fail(fmt.Errorf("агент %s: delivery execution: %w", name, deliveryErr))
+		// V0-9: commit/push/PR откладывается до terminal finalize — к этому
+		// моменту известен attestation digest, и commit trailer'ы (run ID,
+		// runtime identity, attestation digest) детерминированы. Внутри run
+		// git-история не меняется (провенанс переживает потерю bundle).
+		planHash, hashErr := plan.Hash()
+		if hashErr != nil {
+			return fail(fmt.Errorf("агент %s: delivery plan hash: %w", name, hashErr))
 		}
+		rs.deferredDelivery = &deferredDelivery{StatePath: statePath, PlanHash: planHash}
+		if err := rs.evidence.Append(evidence.Event{
+			Type: "delivery_deferred", AttemptID: r.AttemptID, Timestamp: time.Now().UTC(),
+			Data: map[string]any{"plan_hash": planHash, "state_path": filepath.ToSlash(statePath)},
+		}); err != nil {
+			r.ValidationFailed = true
+			return fail(fmt.Errorf("агент %s: запись delivery_deferred event: %w", name, err))
+		}
+		r.Delivery = &delivery.Result{PlanHash: planHash, StatePath: statePath}
 	}
 
 	definitions := mergeChecks(a.Checks, agentCfg.Checks)


### PR DESCRIPTION
Свежий PR на базе текущего master (HANDOFF workflow), заменяет закрытый #59.

## Изменения
- V0-9: после terminal finalize выполняет контроллер-owned доставку (post-terminal deferred), управляемую delivery авторизацией и фиксируемую запуском.
- Git trailers: run, runtime identity, attestation digest пишутся в коммит-сообщение доставки (agent attribution).

## Blocker-фикс (R2)
- `evidence.Resume` применим только к НЕ-терминальным run (`already terminal`), а `DeliverDeferred` — для терминальных. Манифест читается напрямую из run.json (паттерн export.readRunManifest).
- Исправлен `ExistingDir(runDir, "")`: пустой компонент всегда отклонялся как `unsafe directory component`.

## Детали
- Branch based on `master` HEAD `a8cedc8` (V0-8 #77).
- Коммиты: `b65de98` (feature) + `85f5d64` (fix).
- gofmt clean; pipeline/delivery/evidence тесты зелёные.