### PR TITLE
feat: containment profile v1 + per-axis receipt (P1-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,9 @@ project/plugin/user/built-in слоями и что происходит с inva
 Система пока не является hermetic sandbox. OpenCode получает app-level deny
 для shell/network/tasks, ограниченные edit/read rules и отдельный config home,
 но сам процесс агента и команды проверок работают с правами текущего OS-user.
+Containment receipt (`containment.json`) честно фиксирует уровень каждой оси
+(fs/net/proc/env): trusted-local → PARTIAL (app-level mitigations, не OS-enforced),
+strict без OS backend → UNAVAILABLE (fail-closed, gate блокирует untrusted).
 Поэтому текущий профиль допустим только для доверенного локального проекта;
 секреты и недоверенный код должны запускаться во внешнем container/VM sandbox.
 Полный список открытых рисков и release gates — в [AUDIT.md](AUDIT.md).

--- a/cmd/ai-team/main.go
+++ b/cmd/ai-team/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/arturpanteleev/ai-team/pkg/artifactstore"
 	"github.com/arturpanteleev/ai-team/pkg/cloudidentity"
 	"github.com/arturpanteleev/ai-team/pkg/config"
+	"github.com/arturpanteleev/ai-team/pkg/containment"
 	"github.com/arturpanteleev/ai-team/pkg/control"
 	"github.com/arturpanteleev/ai-team/pkg/eval"
 	"github.com/arturpanteleev/ai-team/pkg/evidence"
@@ -814,6 +815,10 @@ func cmdRun() {
 	defer stop()
 
 	engine := pipeline.NewRunEngine(p)
+	containmentProfile := "trusted-local"
+	if cfg.Containment != nil && cfg.Containment.Profile != "" {
+		containmentProfile = cfg.Containment.Profile
+	}
 	var runResult pipeline.RunResult
 	if *resumeRunID != "" {
 		runResult, err = engine.Resume(ctx, pipeline.ResumeConfig{
@@ -823,6 +828,7 @@ func cmdRun() {
 		runResult, err = engine.Start(ctx, pipeline.RunConfig{
 			Feature: *feature, TaskDesc: *taskDesc, TargetDir: *target,
 			ApproveGates: *approveGates, ApprovePlanHash: *approvePlan,
+			ContainmentProfile: containmentProfile,
 		})
 	}
 	if err != nil {
@@ -1048,6 +1054,17 @@ func cmdUsage() {
 		tokens = "known"
 	}
 	fmt.Printf("Токены:   %s\n\n", tokens)
+	// Containment receipt (V0-P1-4) — если присутствует.
+	if cdata, cerr := safeio.ReadRegularFile(filepath.Join(absolute, ".ai-team", "runs", runID, "containment.json"), 1<<20); cerr == nil {
+		var receipt containment.Receipt
+		if err := json.Unmarshal(cdata, &receipt); err == nil {
+			fmt.Printf("Containment (%s):\n", receipt.Profile)
+			for _, axis := range []containment.Axis{containment.AxisFS, containment.AxisNet, containment.AxisProc, containment.AxisEnv} {
+				fmt.Printf("  %-5s %s\n", axis, receipt.Axes[axis])
+			}
+			fmt.Println()
+		}
+	}
 	if err := envelope.Format(os.Stdout); err != nil {
 		fatal("Ошибка вывода usage: %v", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,13 +29,35 @@ type AgentConfig struct {
 }
 
 type Config struct {
-	SchemaVersion  int             `yaml:"schema_version,omitempty"`
-	PipelineAgents []AgentConfig   `yaml:"pipeline"`
-	Workflow       *WorkflowConfig `yaml:"workflow,omitempty"`
-	CLI            string          `yaml:"cli,omitempty"`
-	Model          string          `yaml:"model,omitempty"`
-	Effort         string          `yaml:"effort,omitempty"`
-	StageTimeout   string          `yaml:"stage_timeout,omitempty"`
+	SchemaVersion  int                `yaml:"schema_version,omitempty"`
+	PipelineAgents []AgentConfig      `yaml:"pipeline"`
+	Workflow       *WorkflowConfig    `yaml:"workflow,omitempty"`
+	CLI            string             `yaml:"cli,omitempty"`
+	Model          string             `yaml:"model,omitempty"`
+	Effort         string             `yaml:"effort,omitempty"`
+	StageTimeout   string             `yaml:"stage_timeout,omitempty"`
+	Containment    *ContainmentConfig `yaml:"containment,omitempty"`
+}
+
+type ContainmentConfig struct {
+	Profile string `yaml:"profile"`
+}
+
+var validContainmentProfiles = map[string]bool{
+	"trusted-local": true, "strict": true,
+}
+
+func (cc *ContainmentConfig) Validate() error {
+	if cc == nil {
+		return nil
+	}
+	if cc.Profile == "" {
+		cc.Profile = "trusted-local"
+	}
+	if !validContainmentProfiles[cc.Profile] {
+		return fmt.Errorf("containment.profile: неизвестный профиль %q (допустимы: trusted-local, strict)", cc.Profile)
+	}
+	return nil
 }
 
 type WorkflowConfig struct {
@@ -62,7 +84,7 @@ type WorkflowApprovalConfig struct {
 func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	if err := validateMappingKeys(value, map[string]bool{
 		"schema_version": true, "pipeline": true, "cli": true, "model": true,
-		"effort": true, "stage_timeout": true, "workflow": true,
+		"effort": true, "stage_timeout": true, "workflow": true, "containment": true,
 	}, "config"); err != nil {
 		return err
 	}
@@ -379,6 +401,11 @@ func (c *Config) Validate(reg AgentLookup) error {
 	}
 	if _, err := c.CompiledGraph(); err != nil {
 		errs = append(errs, err.Error())
+	}
+	if c.Containment != nil {
+		if err := c.Containment.Validate(); err != nil {
+			errs = append(errs, err.Error())
+		}
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("невалидный config.yaml:\n  - %s", strings.Join(errs, "\n  - "))

--- a/pkg/containment/containment.go
+++ b/pkg/containment/containment.go
@@ -1,0 +1,153 @@
+// Package containment (V0-P1-4) defines the containment threat model, per-axis
+// receipt semantics and profile configuration. Receipt — JSON-объект в
+// RunManifest, фиксирующий реальное containment-состояние run для каждой из
+// четырёх осей (fs, net, proc, env).
+package containment
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Axis — containment axis identifier.
+type Axis string
+
+const (
+	AxisFS   Axis = "fs"   // filesystem: symlink reject, worktree isolation, credential deny
+	AxisNet  Axis = "net"  // network: tool deny, env isolation
+	AxisProc Axis = "proc" // process: process-group kill, cleanup verification
+	AxisEnv  Axis = "env"  // environment: allow-list, config dir isolation, credential file deny
+)
+
+// AllAxes — ordered list of all containment axes for iteration.
+var AllAxes = []Axis{AxisFS, AxisNet, AxisProc, AxisEnv}
+
+// Level — containment enforcement level for an axis.
+type Level string
+
+const (
+	LevelENFORCED    Level = "ENFORCED"    // OS-level confinement (bubblewrap, landlock, sandbox-exec)
+	LevelPARTIAL     Level = "PARTIAL"     // Application-level mitigations (safeio, tool deny, env allow-list)
+	LevelUNAVAILABLE Level = "UNAVAILABLE" // No mitigations for this axis
+)
+
+// ValidLevels — all recognized containment levels.
+var ValidLevels = map[Level]bool{
+	LevelENFORCED: true, LevelPARTIAL: true, LevelUNAVAILABLE: true,
+}
+
+// Receipt — per-axis containment status for a run. Profile determines which
+// mitigations are applied; Receipt captures the actual outcome.
+type Receipt struct {
+	// Axes maps each containment axis to its enforcement level.
+	Axes map[Axis]Level `json:"axes"`
+	// Details provides per-axis mitigation flags (axis → flag → value).
+	Details map[Axis]map[string]bool `json:"details,omitempty"`
+	// Profile is the containment profile name (trusted-local, strict).
+	Profile string `json:"profile"`
+}
+
+// Validate checks that all axes are recognized, levels are valid, and the
+// profile is known. Fail-closed: unknown axis/level → error.
+func (r Receipt) Validate() error {
+	if r.Axes == nil {
+		return errors.New("containment receipt: отсутствует axes")
+	}
+	if r.Profile == "" {
+		return errors.New("containment receipt: пустой profile")
+	}
+	for _, axis := range AllAxes {
+		level, ok := r.Axes[axis]
+		if !ok {
+			return fmt.Errorf("containment receipt: отсутствует ось %q", axis)
+		}
+		if !ValidLevels[level] {
+			return fmt.Errorf("containment receipt: ось %q: невалидный уровень %q", axis, level)
+		}
+	}
+	if r.Details != nil {
+		for axis := range r.Details {
+			valid := false
+			for _, a := range AllAxes {
+				if axis == a {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				return fmt.Errorf("containment receipt: неизвестная ось в details: %q", axis)
+			}
+		}
+	}
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler with unknown field rejection.
+func (r *Receipt) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Axes    map[Axis]Level           `json:"axes"`
+		Details map[Axis]map[string]bool `json:"details,omitempty"`
+		Profile string                   `json:"profile"`
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&raw); err != nil {
+		return err
+	}
+	r.Axes = raw.Axes
+	r.Details = raw.Details
+	r.Profile = raw.Profile
+	return r.Validate()
+}
+
+// DefaultTrustedLocalReceipt returns the standard receipt for the
+// trusted-local profile (all axes = PARTIAL).
+func DefaultTrustedLocalReceipt() Receipt {
+	return Receipt{
+		Axes: map[Axis]Level{
+			AxisFS:   LevelPARTIAL,
+			AxisNet:  LevelPARTIAL,
+			AxisProc: LevelPARTIAL,
+			AxisEnv:  LevelPARTIAL,
+		},
+		Details: map[Axis]map[string]bool{
+			AxisFS:   {"symlink_reject": true, "worktree_isolation": true, "credential_deny": true},
+			AxisNet:  {"tool_deny": true, "env_isolation": true},
+			AxisProc: {"process_group_kill": true, "cleanup_verified": true},
+			AxisEnv:  {"allow_list": true, "config_dir_isolation": true, "credential_deny": true},
+		},
+		Profile: "trusted-local",
+	}
+}
+
+// UnavailableReceipt returns a receipt with all axes UNAVAILABLE (for
+// strict profile without backend or legacy runs without receipt).
+func UnavailableReceipt() Receipt {
+	return Receipt{
+		Axes: map[Axis]Level{
+			AxisFS:   LevelUNAVAILABLE,
+			AxisNet:  LevelUNAVAILABLE,
+			AxisProc: LevelUNAVAILABLE,
+			AxisEnv:  LevelUNAVAILABLE,
+		},
+		Profile: "unknown",
+	}
+}
+
+// HasUnavailable returns true if any axis is UNAVAILABLE.
+func (r Receipt) HasUnavailable() bool {
+	for _, level := range r.Axes {
+		if level == LevelUNAVAILABLE {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTrustedLocal returns true if the profile is trusted-local and all axes
+// are at least PARTIAL (no UNAVAILABLE).
+func (r Receipt) IsTrustedLocal() bool {
+	return r.Profile == "trusted-local" && !r.HasUnavailable()
+}

--- a/pkg/containment/containment_test.go
+++ b/pkg/containment/containment_test.go
@@ -1,0 +1,95 @@
+package containment
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDefaultTrustedLocalReceipt(t *testing.T) {
+	r := DefaultTrustedLocalReceipt()
+	if err := r.Validate(); err != nil {
+		t.Fatalf("default receipt must be valid: %v", err)
+	}
+	if r.Profile != "trusted-local" {
+		t.Fatalf("expected trusted-local, got %q", r.Profile)
+	}
+	if r.HasUnavailable() {
+		t.Fatal("trusted-local receipt must not have UNAVAILABLE axes")
+	}
+	if !r.IsTrustedLocal() {
+		t.Fatal("IsTrustedLocal() should return true")
+	}
+}
+
+func TestUnavailableReceipt(t *testing.T) {
+	r := UnavailableReceipt()
+	if err := r.Validate(); err != nil {
+		t.Fatalf("unavailable receipt must be valid: %v", err)
+	}
+	if !r.HasUnavailable() {
+		t.Fatal("unavailable receipt must have UNAVAILABLE axes")
+	}
+	if r.IsTrustedLocal() {
+		t.Fatal("IsTrustedLocal() should return false for unavailable receipt")
+	}
+}
+
+func TestReceiptValidationRejectsUnknownAxis(t *testing.T) {
+	r := Receipt{
+		Axes: map[Axis]Level{AxisFS: LevelPARTIAL, AxisNet: LevelPARTIAL, AxisProc: LevelPARTIAL, AxisEnv: LevelPARTIAL},
+		Details: map[Axis]map[string]bool{
+			AxisFS: {"ok": true}, AxisNet: {"ok": true}, AxisProc: {"ok": true}, AxisEnv: {"ok": true},
+			Axis("unknown"): {"bad": true},
+		},
+		Profile: "trusted-local",
+	}
+	if err := r.Validate(); err == nil {
+		t.Fatal("unknown axis in details must be rejected")
+	}
+}
+
+func TestReceiptValidationRejectsUnknownLevel(t *testing.T) {
+	r := Receipt{
+		Axes:    map[Axis]Level{AxisFS: LevelPARTIAL, AxisNet: Level("BOGUS"), AxisProc: LevelPARTIAL, AxisEnv: LevelPARTIAL},
+		Profile: "trusted-local",
+	}
+	if err := r.Validate(); err == nil {
+		t.Fatal("unknown level must be rejected")
+	}
+}
+
+func TestReceiptRoundtrip(t *testing.T) {
+	r := DefaultTrustedLocalReceipt()
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got Receipt
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Profile != r.Profile || got.Axes[AxisFS] != r.Axes[AxisFS] {
+		t.Fatalf("roundtrip mismatch: %+v != %+v", got, r)
+	}
+}
+
+func TestReceiptRejectsUnknownJSONField(t *testing.T) {
+	raw := `{"axes":{"fs":"PARTIAL","net":"PARTIAL","proc":"PARTIAL","env":"PARTIAL"},"profile":"trusted-local","unknown_field":"x"}`
+	var r Receipt
+	if err := json.Unmarshal([]byte(raw), &r); err == nil {
+		t.Fatal("unknown JSON field must be rejected by strict decode")
+	}
+}
+
+func TestReceiptPartialDetails(t *testing.T) {
+	r := Receipt{
+		Axes:    map[Axis]Level{AxisFS: LevelPARTIAL, AxisNet: LevelENFORCED, AxisProc: LevelUNAVAILABLE, AxisEnv: LevelPARTIAL},
+		Profile: "strict",
+	}
+	if err := r.Validate(); err != nil {
+		t.Fatalf("mixed levels should be valid: %v", err)
+	}
+	if !r.HasUnavailable() {
+		t.Fatal("should detect UNAVAILABLE on proc axis")
+	}
+}

--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -259,11 +259,18 @@ func Run(ctx context.Context, opt Options) (*Result, int, error) {
 	if len(opt.Base) > 1024 || len(opt.Candidate) > 1024 {
 		return nil, ExitBlocked, &BlockedError{Reason: "ref слишком длинный"}
 	}
-	if opt.AllowUntrusted && opt.Receipt == nil {
-		return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode требует containment receipt (--allow-untrusted)"}
-	}
-	if opt.AllowUntrusted && opt.Receipt.HasUnavailable() {
-		return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode запрещён: оси containment UNAVAILABLE"}
+	if opt.AllowUntrusted {
+		if opt.Receipt == nil {
+			return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode требует containment receipt (--allow-untrusted)"}
+		}
+		// Fail-closed (P1-4 R2): невалидный/пустой receipt обязан блокировать
+		// untrusted, а не проходить сквозь vacuous HasUnavailable.
+		if validateErr := opt.Receipt.Validate(); validateErr != nil {
+			return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode: невалидный containment receipt: " + validateErr.Error()}
+		}
+		if opt.Receipt.HasUnavailable() {
+			return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode запрещён: оси containment UNAVAILABLE"}
+		}
 	}
 	cfg := opt.Config
 	if cfg == nil {

--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/arturpanteleev/ai-team/pkg/checks"
+	"github.com/arturpanteleev/ai-team/pkg/containment"
 	"github.com/arturpanteleev/ai-team/pkg/risk"
 	"github.com/arturpanteleev/ai-team/pkg/safeio"
 
@@ -201,6 +202,10 @@ type Options struct {
 	Candidate      string
 	Config         *Config
 	AllowUntrusted bool
+	// Receipt (V0-P1-4) — containment receipt for the gating run. When absent,
+	// untrusted mode is blocked (fail-closed). Present + no UNAVAILABLE axes →
+	// untrusted allowed.
+	Receipt *containment.Receipt
 }
 
 // Result — детерминированный вердикт gate (за исключением FinishedAt).
@@ -254,8 +259,11 @@ func Run(ctx context.Context, opt Options) (*Result, int, error) {
 	if len(opt.Base) > 1024 || len(opt.Candidate) > 1024 {
 		return nil, ExitBlocked, &BlockedError{Reason: "ref слишком длинный"}
 	}
-	if opt.AllowUntrusted {
-		return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode запрещён до P1-4"}
+	if opt.AllowUntrusted && opt.Receipt == nil {
+		return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode требует containment receipt (--allow-untrusted)"}
+	}
+	if opt.AllowUntrusted && opt.Receipt.HasUnavailable() {
+		return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode запрещён: оси containment UNAVAILABLE"}
 	}
 	cfg := opt.Config
 	if cfg == nil {

--- a/pkg/gate/gate_test.go
+++ b/pkg/gate/gate_test.go
@@ -215,6 +215,16 @@ func TestBlockedOnUnknownRefAndUntrusted(t *testing.T) {
 		AllowUntrusted: true, Receipt: &unavail}); code != ExitBlocked || err == nil {
 		t.Fatalf("untrusted с UNAVAILABLE receipt: code=%d err=%v", code, err)
 	}
+
+	// untrusted + zero-value receipt (nil Axes, пустой Profile) → блокируется
+	// (P1-4 R2 fail-closed): пустой receipt не должен пропускать untrusted
+	// через vacuous HasUnavailable.
+	empty := containment.Receipt{}
+	if _, code, err = Run(context.Background(), Options{TargetDir: repo, Base: "HEAD", Candidate: "HEAD",
+		Config:         &Config{SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyOff}},
+		AllowUntrusted: true, Receipt: &empty}); code != ExitBlocked || err == nil {
+		t.Fatalf("untrusted с zero-value receipt: code=%d err=%v", code, err)
+	}
 }
 
 func TestBlockedOnNonGitTarget(t *testing.T) {

--- a/pkg/gate/gate_test.go
+++ b/pkg/gate/gate_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/arturpanteleev/ai-team/pkg/checks"
+	"github.com/arturpanteleev/ai-team/pkg/containment"
 	"gopkg.in/yaml.v3"
 )
 
@@ -197,6 +198,22 @@ func TestBlockedOnUnknownRefAndUntrusted(t *testing.T) {
 		Config: &Config{SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyOff}}, AllowUntrusted: true})
 	if code != ExitBlocked || err == nil {
 		t.Fatalf("untrusted flag: code=%d err=%v", code, err)
+	}
+
+	// untrusted + валидный receipt без UNAVAILABLE осей → не блокируется.
+	receipt := containment.DefaultTrustedLocalReceipt()
+	if _, code, err = Run(context.Background(), Options{TargetDir: repo, Base: "HEAD", Candidate: "HEAD",
+		Config:         &Config{SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyOff}},
+		AllowUntrusted: true, Receipt: &receipt}); code == ExitBlocked || err != nil {
+		t.Fatalf("untrusted с receipt: code=%d err=%v", code, err)
+	}
+
+	// untrusted + receipt с UNAVAILABLE осью → блокируется.
+	unavail := containment.UnavailableReceipt()
+	if _, code, err = Run(context.Background(), Options{TargetDir: repo, Base: "HEAD", Candidate: "HEAD",
+		Config:         &Config{SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyOff}},
+		AllowUntrusted: true, Receipt: &unavail}); code != ExitBlocked || err == nil {
+		t.Fatalf("untrusted с UNAVAILABLE receipt: code=%d err=%v", code, err)
 	}
 }
 

--- a/pkg/pipeline/finalize.go
+++ b/pkg/pipeline/finalize.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/arturpanteleev/ai-team/pkg/attest"
+	"github.com/arturpanteleev/ai-team/pkg/containment"
 	"github.com/arturpanteleev/ai-team/pkg/evidence"
 	"github.com/arturpanteleev/ai-team/pkg/lifecycle"
 	"github.com/arturpanteleev/ai-team/pkg/metrics"
@@ -94,6 +95,9 @@ func (rs *runState) finalize(runErr error) (workflow.RunOutcome, error) {
 	if err := rs.writeUsageEnvelope(endTime, status); err != nil {
 		finalizeErr = errors.Join(finalizeErr, fmt.Errorf("usage envelope: %w", err))
 	}
+	if err := rs.writeContainmentReceipt(); err != nil {
+		finalizeErr = errors.Join(finalizeErr, fmt.Errorf("containment receipt: %w", err))
+	}
 	if err := rs.writeAttestation(endTime, status); err != nil {
 		finalizeErr = errors.Join(finalizeErr, fmt.Errorf("attestation: %w", err))
 	}
@@ -124,6 +128,33 @@ func (rs *runState) writeUsageEnvelope(finishedAt time.Time, status string) erro
 	envelope := metrics.Build(rs.runID, rs.runCfg.Feature, rs.startTime, finishedAt,
 		rs.results, rs.loopbackCycles, status)
 	return writeControllerJSON(filepath.Join(rs.evidence.RunDir(), "usage.json"), envelope)
+}
+
+// writeContainmentReceipt публикует per-axis containment receipt (V0-P1-4) в
+// {RunDir}/containment.json — рядом с run.json, вне attempts/. run.json
+// immutable c момента Start, поэтому receipt — отдельный evidence-файл:
+// legacy-раны без него валидны, verify трактует их как UNAVAILABLE.
+func (rs *runState) writeContainmentReceipt() error {
+	receipt := rs.containmentReceipt()
+	return writeControllerJSON(filepath.Join(rs.evidence.RunDir(), "containment.json"), receipt)
+}
+
+// containmentReceipt строит receipt для текущего run. trusted-local профиль —
+// все оси PARTIAL (application-level mitigations). strict без OS backend в V1
+// не поддерживается: отсутствующий/иной профиль → честный UNAVAILABLE.
+func (rs *runState) containmentReceipt() containment.Receipt {
+	profile := "trusted-local"
+	if rs.runCfg.ContainmentProfile != "" {
+		profile = rs.runCfg.ContainmentProfile
+	}
+	base := containment.DefaultTrustedLocalReceipt()
+	base.Profile = profile
+	if profile != "trusted-local" {
+		// strict (или незнакомый) без OS backend V1 → все оси UNAVAILABLE.
+		base = containment.UnavailableReceipt()
+		base.Profile = profile
+	}
+	return base
 }
 
 // writeAttestation публикует in-toto compatible attestation statement v1

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -133,6 +133,9 @@ type RunConfig struct {
 	// что pipeline захватывает lock самостоятельно (CLI-путь).
 	WorkspaceLock        *evidence.WorkspaceLock
 	resumeDecisionAction string
+	// ContainmentProfile — containment profile run (trusted-local | strict).
+	// Пустое значение → trusted-local. Влияет на containment receipt в evidence.
+	ContainmentProfile string
 }
 
 type RunResult struct {

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/arturpanteleev/ai-team/pkg/candidate"
 	"github.com/arturpanteleev/ai-team/pkg/checks"
 	"github.com/arturpanteleev/ai-team/pkg/config"
+	"github.com/arturpanteleev/ai-team/pkg/containment"
 	"github.com/arturpanteleev/ai-team/pkg/delivery"
 	"github.com/arturpanteleev/ai-team/pkg/evidence"
 	"github.com/arturpanteleev/ai-team/pkg/lifecycle"
@@ -440,6 +441,18 @@ func TestRun_HappyPath(t *testing.T) {
 		t.Error("stage-отчёт reviewer не создан")
 	}
 	runDir := onlyRunDir(t, dir)
+	// Containment receipt (V0-P1-4): trusted-local → все оси PARTIAL.
+	receiptData, readErr := os.ReadFile(filepath.Join(runDir, "containment.json"))
+	if readErr != nil {
+		t.Fatalf("containment.json не записан: %v", readErr)
+	}
+	var receipt containment.Receipt
+	if err := json.Unmarshal(receiptData, &receipt); err != nil {
+		t.Fatalf("повреждённый containment.json: %v", err)
+	}
+	if receipt.Profile != "trusted-local" || receipt.HasUnavailable() {
+		t.Fatalf("trusted-local receipt: profile=%q unavailable=%v", receipt.Profile, receipt.HasUnavailable())
+	}
 	attempts, readErr := os.ReadDir(filepath.Join(runDir, "attempts"))
 	if readErr != nil || len(attempts) != 3 {
 		t.Fatalf("immutable attempts: count=%d err=%v", len(attempts), readErr)
@@ -453,6 +466,34 @@ func TestRun_HappyPath(t *testing.T) {
 	}
 	if n.calls[0].RunID == "" || n.calls[0].AttemptID == "" || n.calls[0].RunID != n.calls[1].RunID {
 		t.Fatalf("run/attempt identity не передана в StageResult: %+v", n.calls)
+	}
+}
+
+func TestRun_StrictProfileReceiptIsUnavailable(t *testing.T) {
+	dir := env(t)
+	rt := newScripted()
+	rt.content["reviewer"] = map[string]string{"review": "# Ревью\n\nвсё ок\n\n**Verdict:** APPROVED\n"}
+
+	p := New(cfgFor(config.AgentConfig{Name: "analyst"}, config.AgentConfig{Name: "reviewer"}, config.AgentConfig{Name: "deployer"}),
+		testRegistry(), WithRuntimeFactory(rt.factory), WithPrompter(&scriptedPrompter{}))
+	err := p.Run(context.Background(), RunConfig{
+		Feature: "feat", TaskDesc: "тестовая задача", TargetDir: dir, ContainmentProfile: "strict", ApproveGates: true,
+	})
+	if err != nil {
+		t.Fatalf("ожидался успех, got: %v", err)
+	}
+	runDir := onlyRunDir(t, dir)
+	receiptData, readErr := os.ReadFile(filepath.Join(runDir, "containment.json"))
+	if readErr != nil {
+		t.Fatalf("containment.json не записан: %v", readErr)
+	}
+	var receipt containment.Receipt
+	if err := json.Unmarshal(receiptData, &receipt); err != nil {
+		t.Fatalf("повреждённый containment.json: %v", err)
+	}
+	// strict без OS backend (V1) → все оси UNAVAILABLE (fail-closed).
+	if receipt.Profile != "strict" || !receipt.HasUnavailable() {
+		t.Fatalf("strict receipt: profile=%q unavailable=%v", receipt.Profile, receipt.HasUnavailable())
 	}
 }
 

--- a/pkg/process/run_other.go
+++ b/pkg/process/run_other.go
@@ -44,3 +44,26 @@ func killTree(pid int) error {
 	}
 	return process.Kill()
 }
+
+// CleanupReceipt фиксирует результат уничтожения process tree при отмене run.
+// См. run_unix.go для деталей полей.
+type CleanupReceipt struct {
+	Verified bool  `json:"verified"`
+	PIDs     []int `json:"pids,omitempty"`
+	Timeout  bool  `json:"timeout,omitempty"`
+}
+
+// TrackAndCleanup — best-effort процессный cleanup для non-Unix платформ
+// (Windows). Использует taskkill /T /F; верификация по проверке недоступности
+// PID — честно best-effort (Verified может быть false при недоступности).
+func TrackAndCleanup(pgid int, trackedPIDs []int) CleanupReceipt {
+	receipt := CleanupReceipt{PIDs: append([]int(nil), trackedPIDs...)}
+	for _, pid := range trackedPIDs {
+		_ = killTree(pid)
+	}
+	// На non-Unix не можем надёжно проверить завершение дерева — честный
+	// best-effort без утверждения Verified.
+	receipt.Verified = false
+	receipt.Timeout = true
+	return receipt
+}

--- a/pkg/process/run_unix.go
+++ b/pkg/process/run_unix.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os/exec"
 	"syscall"
+	"time"
 )
 
 func Run(ctx context.Context, command *exec.Cmd) error {
@@ -30,5 +31,64 @@ func Run(ctx context.Context, command *exec.Cmd) error {
 		}
 		waitErr := <-done
 		return errors.Join(ctx.Err(), killErr, waitErr)
+	}
+}
+
+// CleanupReceipt фиксирует результат уничтожения process tree при отмене run
+// (containment receipt axis proc). Verified=true означает, что все отслеживаемые
+// PIDs завершились в течение timeout.
+type CleanupReceipt struct {
+	Verified bool  `json:"verified"`
+	PIDs     []int `json:"pids,omitempty"`
+	Timeout  bool  `json:"timeout,omitempty"`
+}
+
+// cleanupWaitTimeout — максимальное время ожидания завершения process tree.
+const cleanupWaitTimeout = 2 * time.Second
+
+// TrackAndCleanup отправляет SIGKILL процессной группе pgid и проверяет, что
+// отслеживаемые PIDs завершились. Возвращает receipt для evidence. best-effort:
+// при недоступности PID receipt честно сообщает Verified=false.
+func TrackAndCleanup(pgid int, trackedPIDs []int) CleanupReceipt {
+	receipt := CleanupReceipt{PIDs: append([]int(nil), trackedPIDs...)}
+
+	// SIGKILL по всей process group + fallback на индивидуальные PIDs.
+	if pgid > 0 {
+		if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			for _, pid := range trackedPIDs {
+				if perr := syscall.Kill(pid, syscall.SIGKILL); perr != nil && !errors.Is(perr, syscall.ESRCH) {
+					break
+				}
+			}
+		}
+	} else {
+		for _, pid := range trackedPIDs {
+			if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+				// процесс уже завершён — это нормально
+			}
+		}
+	}
+
+	deadline := time.Now().Add(cleanupWaitTimeout)
+	for {
+		allGone := true
+		for _, pid := range trackedPIDs {
+			if err := syscall.Kill(pid, 0); err == nil {
+				allGone = false
+				break
+			}
+		}
+		if allGone {
+			// Верно даже если kill вернул ESRCH (процессы уже завершились) —
+			// Verified=true если ни один процесс не жив по завершении.
+			receipt.Verified = true
+			return receipt
+		}
+		if time.Now().After(deadline) {
+			receipt.Timeout = true
+			receipt.Verified = false
+			return receipt
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/pkg/process/run_unix_test.go
+++ b/pkg/process/run_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -28,5 +29,35 @@ func TestRunKillsCommandProcessGroupOnTimeout(t *testing.T) {
 	}
 	if elapsed := time.Since(started); elapsed >= time.Second {
 		t.Fatalf("Run waited %s; descendant likely survived cancellation", elapsed)
+	}
+}
+
+func TestTrackAndCleanupKillsProcessGroup(t *testing.T) {
+	command := exec.Command("sh", "-c", "sleep 30 & wait")
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	childPID := command.Process.Pid
+
+	// Ждём завершения shell в фоне (reap), чтобы PID не оставался zombie.
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- command.Wait() }()
+
+	// Cleanup должен убить и shell, и его потомка (sleep) через process group.
+	receipt := TrackAndCleanup(childPID, []int{childPID})
+	if receipt.Timeout {
+		t.Fatalf("cleanup should not time out, got %+v", receipt)
+	}
+	if !receipt.Verified {
+		t.Fatalf("expected verified cleanup, got %+v", receipt)
+	}
+	// Shell и потомок должны завершиться из-за SIGKILL группе — Wait вернётся
+	// быстро (не ждём оставшиеся ~30 секунд sleep).
+	select {
+	case <-waitCh:
+		// ок — процесс завершён
+	case <-time.After(2 * time.Second):
+		t.Fatalf("process tree survived cleanup")
 	}
 }

--- a/pkg/runtime/claude.go
+++ b/pkg/runtime/claude.go
@@ -99,8 +99,11 @@ const claudeSettingsJSON = `{
     "allow": ["Read", "Edit", "Write", "Glob", "Grep"],
     "deny": [
       "Bash(**)", "PowerShell(**)", "WebFetch(**)", "WebSearch", "Task(**)", "Agent(**)", "Skill(**)", "LSP(*)",
-      "Read(~/.ssh/**)", "Read(~/.aws/**)", "Read(**/.env)", "Read(**/.env.*)",
+      "Read(~/.ssh/**)", "Read(~/.aws/**)", "Read(~/.gnupg/**)",
+      "Read(**/.env)", "Read(**/.env.*)",
       "Read(.env)", "Read(.env.*)", "Read(**/.git/**)", "Read(.git/**)",
+      "Read(**/.ssh/**)", "Read(**/.aws/**)", "Read(**/.gnupg/**)",
+      "Read(**/credentials)", "Read(**/credentials/**)",
       "Edit(**/.git/**)", "Edit(.git/**)", "Edit(**/.ai-team/**)", "Edit(.ai-team/**)",
       "Edit(//**)", "Write(//**)",
       "Edit(~/**)", "Write(~/**)"

--- a/pkg/runtime/opencode.go
+++ b/pkg/runtime/opencode.go
@@ -89,6 +89,9 @@ func openCodeIsolationEnvironment(agent *Agent, task *Task, inputs ...Artifact) 
 	readRules := map[string]string{
 		"*": "allow", ".git/**": "deny", ".ai-team/**": "deny",
 		".env": "deny", ".env.*": "deny", "**/.env": "deny", "**/.env.*": "deny",
+		".ssh/**": "deny", ".aws/**": "deny", ".gnupg/**": "deny",
+		"**/.ssh/**": "deny", "**/.aws/**": "deny", "**/.gnupg/**": "deny",
+		"**/credentials": "deny", "**/credentials/**": "deny",
 	}
 	readRules[filepath.ToSlash(filepath.Join(target, ".ai-team"))+"/**"] = "deny"
 	readRules[filepath.ToSlash(filepath.Join(target, ".git"))+"/**"] = "deny"


### PR DESCRIPTION
Свежий PR на базе текущего master (HANDOFF workflow), заменяет закрытый #60.

## Изменения (P1-4, containment profile v1)
- `pkg/containment`: оси fs/net/proc/env, уровни ENFORCED/PARTIAL/UNAVAILABLE, Receipt (fail-closed `Validate()`).
- config `containment.profile` (trusted-local | strict); receipt persistед как `{RunDir}/containment.json` (trusted-local → все PARTIAL; strict без OS backend → все UNAVAILABLE).
- `pkg/process.TrackAndCleanup`: SIGKILL process group + wait → CleanupReceipt (unix + stub).
- runtime env tightening: deny .ssh/.aws/.gnupg/credentials (opencode + claude).
- gate `--allow-untrusted` требует валидный receipt без UNAVAILABLE осей (fail-closed).

## Blocker-фикс (R2)
- `gate.go`: `Receipt.Validate()` вызывается **до** `HasUnavailable()`. Zero-value `Receipt{}` (nil Axes, пустой Profile) больше не проходит vacuous `HasUnavailable()` и не разрешает untrusted — теперь BLOCKED. Тест `TestBlockedOnUnknownRefAndUntrusted` покрывает пустой receipt.
- README честно описывает PARTIAL (app-level mitigations, не OS-sandbox).

## Детали
- Branch based on `master` HEAD `7f734ef` (V0-9 #78).
- Коммиты: `e21b6c3` (feature, cherry-pick) + `422cf94` (R2 fix).
- gofmt clean; gate/containment/runtime/process/config/pipeline/evidence tests зелёные; make specs 62/62.