### PR TITLE
feat(dsse): signed bundle — DSSE ed25519 envelope + export/gate sign & verify (P1-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,23 @@ project/plugin/user/built-in слоями и что происходит с inva
 
 ## Граница безопасности
 
-Система пока не является hermetic sandbox. OpenCode получает app-level deny
+### integrity vs authenticity
+
+- **Integrity (гарантируется):** и run-, и gate-bundle перепроверяются цепочкой
+  хэшей — `ai-team verify` подтверждает, что ни одна запись не изменена после
+  создания, и работает самодостаточно (без repo и `.ai-team`).
+- **Authenticity (P1-5, DSSE):** bundle могут быть подписаны автором через
+  DSSE-envelope (ed25519, stdlib-only, PAE по спецификации in-toto). `ai-team
+  export --sign-key <priv>` и `ai-team gate --sign-key <priv>` подписывают
+  детерминированный `BundleDigest` и пишут `dsse.json` в bundle. `ai-team
+  verify --verify-key <pub>` проверяет подпись fail-closed: задан ключ → подпись
+  обязана быть и совпадать; нет ключа → integrity-only проверка как раньше.
+  Digest остаётся контролем целостности («не изменено»), подпись добавляет
+  доказательство авторства («кто создал»). Ключи передаются через CLI-файлы и
+  никогда не попадают в evidence.
+
+### Граница для недоверенного кода
+ OpenCode получает app-level deny
 для shell/network/tasks, ограниченные edit/read rules и отдельный config home,
 но сам процесс агента и команды проверок работают с правами текущего OS-user.
 Containment receipt (`containment.json`) честно фиксирует уровень каждой оси

--- a/TASKLOG.md
+++ b/TASKLOG.md
@@ -59,9 +59,9 @@
 | 15 | EXP-1 | P1 | open | — | Track V kill-watch + интервью (не-кодовая) |
 | 16 | V0-8 | P1 | review | v0-8-risk-signals | Risk-signal measurement (записывать, не маршрутизировать) |
 | 17 | V0-9 | P1 | review | v0-9-agent-attribution-trailers | Agent attribution в Git trailers (deferred post-terminal delivery) — после V0-2/V0-3 |
-| 18 | P1-4 | P1 | open | — | Containment profile v1 + receipt |
-| 19 | P1-9 | P1 | open | — | Contract test: coder не видит будущее ревью |
-| 20 | P1-5 | P1 | open | — | Signed bundle через DSSE |
+| 18 | P1-4 | P1 | review | p1-4-containment-profile-v1 | Containment profile v1 + receipt (OS-sandbox backend — V2) |
+| 19 | P1-9 | P1 | review | p1-9-coder-stage-independence | Contract test: coder не видит будущее ревью |
+| 20 | P1-5 | P1 | review | p15-dsse-signed-bundle | Signed bundle через DSSE (ed25519, stdlib-only) |
 | 21 | P1-6 | P1 | open | — | Redaction + retention contract |
 | 22 | P1-7 | P1 | open | — | Budget guard + usage truthfulness |
 | 23 | P1-8 | P1 | open | — | CI-parity check import |

--- a/ai-team-backlog.html
+++ b/ai-team-backlog.html
@@ -620,11 +620,11 @@
         <div class="task-state"><span class="status status-open">○ Open</span></div><div class="task-pr">—</div>
       </article>
 
-      <article class="task" data-status="Open" data-prio="P1" data-horizon="P1" data-id="P1-5" data-order="20">
+      <article class="task" data-status="Review" data-prio="P1" data-horizon="P1" data-id="P1-5" data-order="20">
         <div class="task-seq">#20</div>
         <div class="task-key"><strong>P1-5</strong><span class="prio prio-P1">P1</span><span class="tag">Signing</span></div>
         <div class="task-content"><h3>Signed bundle через DSSE</h3><p>Local/pluggable signer для V0-3; verifier отдельно сообщает integrity и signer identity.</p><p class="detail">Нельзя маскировать signing failure как unsigned success в strict policy.</p></div>
-        <div class="task-state"><span class="status status-open">○ Open</span></div><div class="task-pr">—</div>
+        <div class="task-state"><span class="status status-review">◐ Review</span></div><div class="task-pr">—</div>
       </article>
 
       <article class="task" data-status="Open" data-prio="P1" data-horizon="P1" data-id="P1-6" data-order="21">

--- a/cmd/ai-team/export.go
+++ b/cmd/ai-team/export.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"crypto/ed25519"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/arturpanteleev/ai-team/pkg/dsse"
 	"github.com/arturpanteleev/ai-team/pkg/export"
 )
 
@@ -19,11 +21,21 @@ func cmdExport() {
 	exportFlags := flag.NewFlagSet("export", flag.ExitOnError)
 	target := exportFlags.String("target", ".", "Путь к целевому проекту")
 	out := exportFlags.String("out", "", "Каталог bundle (по умолчанию .ai-team/exports/<run_id>.bundle)")
+	signKey := exportFlags.String("sign-key", "", "Путь к ed25519 private key (PEM PKCS8 или raw) для DSSE-подписи bundle (P1-5)")
 	if err := exportFlags.Parse(os.Args[2:]); err != nil {
 		fatal("Ошибка аргументов export: %v", err)
 	}
 	if exportFlags.NArg() != 1 {
-		fatal("Использование: ai-team export [--target <dir>] [--out <path>] <run_id>")
+		fatal("Использование: ai-team export [--target <dir>] [--out <path>] [--sign-key <path>] <run_id>")
+	}
+
+	var privKey ed25519.PrivateKey
+	if *signKey != "" {
+		key, err := dsse.LoadPrivateKey(*signKey)
+		if err != nil {
+			fatal("Ошибка загрузки signing key: %v", err)
+		}
+		privKey = key
 	}
 	runID := exportFlags.Arg(0)
 	if runID == "" || runID == "." || runID == ".." || filepath.Base(runID) != runID {
@@ -72,6 +84,11 @@ func cmdExport() {
 	if err := export.VerifyBundle(tmp); err != nil {
 		fatal("Экспорт не прошёл полную проверку (evidence повреждена?): %v", err)
 	}
+	if privKey != nil {
+		if err := export.SignBundle(tmp, privKey); err != nil {
+			fatal("Ошибка подписи bundle: %v", err)
+		}
+	}
 	if err := os.Rename(tmp, outDir); err != nil {
 		fatal("Не удалось зафиксировать bundle: %v", err)
 	}
@@ -88,5 +105,8 @@ func cmdExport() {
 	fmt.Printf("✓ Run %s проверенно экспортирован\n", runID)
 	fmt.Printf("  bundle:        %s\n", outDir)
 	fmt.Printf("  bundle_sha256: %s\n", bundleSHA)
+	if privKey != nil {
+		fmt.Printf("  signed:        DSSE ed25519 (dsse.json)\n")
+	}
 	fmt.Printf("  verified:      state/exports/%s.json (разрешает gc --prune-runs)\n", runID)
 }

--- a/cmd/ai-team/gate.go
+++ b/cmd/ai-team/gate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
 	"flag"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/arturpanteleev/ai-team/pkg/checks"
+	"github.com/arturpanteleev/ai-team/pkg/dsse"
 	"github.com/arturpanteleev/ai-team/pkg/gate"
 	"github.com/arturpanteleev/ai-team/pkg/safeio"
 )
@@ -30,11 +32,21 @@ func cmdGate() {
 	configPath := gateFlags.String("config", "", "Путь gate config (по умолчанию gate.yaml в target, затем .ai-team/gate.yaml)")
 	out := gateFlags.String("out", "", "Каталог attestation bundle (по умолчанию <target>/.ai-team/gates/<ts> или gate-out/<ts>)")
 	allowUntrusted := gateFlags.Bool("allow-untrusted", false, "Запрещено до P1-4")
+	signKey := gateFlags.String("sign-key", "", "Путь к ed25519 private key (PEM PKCS8 или raw) для DSSE-подписи bundle (P1-5)")
 	if err := gateFlags.Parse(os.Args[2:]); err != nil {
 		fatal("Ошибка аргументов gate: %v", err)
 	}
 	if gateFlags.NArg() != 0 {
 		fatal("Неожиданные аргументы gate: %s", strings.Join(gateFlags.Args(), " "))
+	}
+
+	var privKey ed25519.PrivateKey
+	if *signKey != "" {
+		key, err := dsse.LoadPrivateKey(*signKey)
+		if err != nil {
+			fatal("Ошибка загрузки signing key: %v", err)
+		}
+		privKey = key
 	}
 
 	absolute, err := absoluteTarget(*target)
@@ -67,6 +79,12 @@ func cmdGate() {
 	if err := gate.WriteBundle(*out, result); err != nil {
 		fmt.Fprintf(os.Stderr, "✗ Gate bundle: %v\n", err)
 		os.Exit(exitBlocked)
+	}
+	if privKey != nil {
+		if err := gate.SignBundle(*out, privKey); err != nil {
+			fmt.Fprintf(os.Stderr, "✗ Gate bundle подпись: %v\n", err)
+			os.Exit(exitBlocked)
+		}
 	}
 	printGateSummary(result, *out)
 	os.Exit(gate.ExitCode(result))

--- a/cmd/ai-team/main.go
+++ b/cmd/ai-team/main.go
@@ -1164,6 +1164,9 @@ func cmdVerify() {
 	}
 	requireControlRoot(absolute)
 	runDir := filepath.Join(absolute, ".ai-team", "runs", runID)
+	if len(keyVerify) > 0 {
+		fatal("Run %s: DSSE-подпись применима только к bundle (export/gate), а не к live run evidence; --verify-key не используется на этой ветке — отказ (fail-closed)", runID)
+	}
 	if err := export.VerifyEvidence(runDir); err != nil {
 		fmt.Fprintf(os.Stderr, "✗ Run %s: %v\n", runID, ui.Colorize(err.Error(), ui.ColorRed))
 		os.Exit(exitFailed)

--- a/cmd/ai-team/main.go
+++ b/cmd/ai-team/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -26,6 +27,7 @@ import (
 	"github.com/arturpanteleev/ai-team/pkg/config"
 	"github.com/arturpanteleev/ai-team/pkg/containment"
 	"github.com/arturpanteleev/ai-team/pkg/control"
+	"github.com/arturpanteleev/ai-team/pkg/dsse"
 	"github.com/arturpanteleev/ai-team/pkg/eval"
 	"github.com/arturpanteleev/ai-team/pkg/evidence"
 	"github.com/arturpanteleev/ai-team/pkg/export"
@@ -136,6 +138,7 @@ func printUsage() {
 Флаги export:
   --target <path>           Путь к целевому проекту (по умолчанию текущая директория)
   --out <path>              Каталог bundle (по умолчанию .ai-team/exports/<run_id>.bundle)
+  --sign-key <path>         ed25519 private key (PEM PKCS8/raw) для DSSE-подписи bundle (P1-5)
 
 Флаги gc:
   --target <path>           Путь к целевому проекту (по умолчанию текущая директория)
@@ -154,6 +157,11 @@ func printUsage() {
                             .ai-team/gate.yaml; иначе — дефолты: test_modify required)
   --out <path>              Каталог attestation bundle (по умолчанию
                             <target>/.ai-team/gates/<ts> или gate-out/<ts>)
+  --sign-key <path>         ed25519 private key (PEM PKCS8/raw) для DSSE-подписи bundle (P1-5)
+
+Флаги verify:
+  --verify-key <path>       ed25519 public key (PEM/raw) — требовать валидную
+                            DSSE-подпись bundle (fail-closed, P1-5)
 
 Exit-коды gate: 0 — PASS, 1 — FAIL (diff-policy/required checks), 2 — BLOCKED
                 (конфиг, отсутствующий/нелокальный ref, untrusted — запрещён до P1-4)
@@ -1106,32 +1114,41 @@ func cmdList() {
 func cmdVerify() {
 	verifyFlags := flag.NewFlagSet("verify", flag.ExitOnError)
 	target := verifyFlags.String("target", ".", "Путь к целевому проекту")
+	verifyKey := verifyFlags.String("verify-key", "", "Путь к ed25519 public key (PEM или raw) для DSSE-верификации подписи bundle (P1-5)")
 	if err := verifyFlags.Parse(os.Args[2:]); err != nil {
 		fatal("Ошибка аргументов verify: %v", err)
 	}
 	if verifyFlags.NArg() != 1 {
-		fatal("Использование: ai-team verify [--target <dir>] <run_id> | <bundle-dir>")
+		fatal("Использование: ai-team verify [--target <dir>] [--verify-key <path>] <run_id> | <bundle-dir>")
 	}
 	arg := verifyFlags.Arg(0)
 	if len(arg) > 1024 {
 		fatal("недопустимый аргумент verify")
 	}
+	var keyVerify ed25519.PublicKey
+	if *verifyKey != "" {
+		key, err := dsse.LoadPublicKey(*verifyKey)
+		if err != nil {
+			fatal("Ошибка загрузки verify key: %v", err)
+		}
+		keyVerify = key
+	}
 	info, statErr := os.Stat(arg)
 	if statErr == nil && info.IsDir() {
 		if gateBundleExists(arg) {
-			digest, err := gate.VerifyBundle(arg)
+			digest, err := gate.VerifyBundle(arg, keyVerify)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "✗ Gate bundle %s: %v\n", arg, ui.Colorize(err.Error(), ui.ColorRed))
 				os.Exit(exitFailed)
 			}
-			fmt.Printf("✓ Gate bundle %s: OK — records согласованы, bundle_sha256 %s\n", arg, digest)
+			fmt.Printf("✓ Gate bundle %s: OK — records согласованы, bundle_sha256 %s%s\n", arg, digest, sigNote(keyVerify))
 			return
 		}
-		if err := export.VerifyBundle(arg); err != nil {
+		if err := export.VerifyBundle(arg, keyVerify); err != nil {
 			fmt.Fprintf(os.Stderr, "✗ Bundle %s: %v\n", arg, ui.Colorize(err.Error(), ui.ColorRed))
 			os.Exit(exitFailed)
 		}
-		fmt.Printf("✓ Bundle %s: OK — records, event chain, anchor, attempt manifests и attestation v1 согласованы\n", arg)
+		fmt.Printf("✓ Bundle %s: OK — records, event chain, anchor, attempt manifests и attestation v1 согласованы%s\n", arg, sigNote(keyVerify))
 		return
 	}
 	if strings.ContainsAny(arg, `/\`) || arg == "." || arg == ".." || filepath.Base(arg) != arg {
@@ -1158,6 +1175,14 @@ func cmdVerify() {
 func gateBundleExists(dir string) bool {
 	info, err := os.Stat(filepath.Join(dir, "gate.json"))
 	return err == nil && !info.IsDir()
+}
+
+// sigNote возвращает постфикс о статусе подписи в выводе verify.
+func sigNote(key ed25519.PublicKey) string {
+	if len(key) == 0 {
+		return " (без верификации подписи: --verify-key не задан)"
+	}
+	return " — подпись DSSE ed25519 подтверждена"
 }
 
 func cmdWeb() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -211,6 +211,21 @@ attempt_count/provenance. Только после успешной verify пиш
 .ai-team; `ai-team verify <run_id>` — та же full-свёртка live evidence.
 Экспорт отказастся от non-terminal run и от run без attestation.json.
 
+Signed bundle (P1-5, DSSE): `pkg/dsse` реализует минимальный DSSE-envelope на
+stdlib-only (PAE — Pre-Authentication Encoding `"DSSEv1"` с длинами payloadType
+и payload + ed25519 sign/verify из `crypto/ed25519`; ноль внешних зависимостей).
+`export.SignBundle` и `gate.SignBundle` подписывают детерминированный
+`BundleDigest` (sha256 канонического index.json) и пишут `dsse.json` в bundle
+(рядом с index.json); сам signature-файл не попадает в index.Records, чтобы не
+влиять на детерминизм. Ключи загружаются из файлов каждая команда через
+`--sign-key <path>` (PEM PKCS8 ed25519 или raw), никогда не коммитятся и не
+попадают в evidence. Верификация fail-closed: `ai-team verify --verify-key
+<pub>` требует наличия и валидности подписи для каждого проверяемого bundle
+(export/gate `VerifyBundle` принимают variadic verify-key); без ключа —
+integrity-only как раньше, с ключом при отсутствии/несовпадении подписи —
+ошибка. Подпись связывает digest с автором («кто создал») поверх integrity
+(«не изменено»), поддерживая future audit.
+
 gate MVP (V0-5): `pkg/gate` + `ai-team gate` — deterministic diff-policy гейт
 для trusted local base/candidate без .ai-team и без runtime. Диф между двумя
 локальными ref'ами (или ref и WORKTREE) парсится в типизированные мутации
@@ -223,7 +238,52 @@ pkg/checks Runner (evidence digests, workspace immutability). Вердикт п�
 связан со своим sha256 в индексе). Стабильные exit codes:
 0 PASS, 1 FAIL (policy/required checks), 2 BLOCKED. Fail-closed по умолчанию:
 ref, который не разрешается в локальный объект, или --allow-untrusted дают
-BLOCKED — untrusted mode запрещён до P1-4.
+BLOCKED — untrusted mode запрещён до P1-4. Bundles проверяются самодостаточно:
+`gate.VerifyBundle` перечитывает каждый record и сверяет digest с index.json,
+реагирует на лишние файлы (за пределами checks/*+gate.json), на отсутствующие
+records и на расхождение заявленного bundle_sha256; `ai-team verify <dir>`
+автоматически различает run-bundle (V0-4) и gate-bundle по наличию gate.json.
+WORKTREE-кандидат идентифицируется в index как ref "WORKTREE" (commit пуст).
+
+Demo + CI action + truthful README (V0-7): `docs/demo/` — самодостаточное демо
+`gate → bundle → verify` на не-Go репозитории. `run-demo.sh` строит изолирован-
+ный Python-репозиторий и прогоняет три сценария (PASS / test_modify violation /
+JUnit failure при exit code команды 0), каждый со своим bundle и verify;
+`ci-gate-demo.yaml` — один version-pinned workflow (ai-team по зафиксированному
+SHA, actions по SHA), который на PR считает merge-base, выполняет gate, затем в
+любом случае verify и upload bundle артефактом. README честно разделяет run и
+gate, integrity (гарантируется цепочкой хэшей) и authenticity (P1-5: DSSE-ed25519
+подпись BundleDigest через `--sign-key`/`--verify-key`, см. ниже), а также фиксирует отсутствие
+OS sandbox. Внешняя верификация «три человека проходят демо» — за владельцем.
+
+Risk-signals (V0-8): `pkg/risk` — детерминированный классификатор
+чувствительных путей (env / secrets / credentials: `.env*`, ключи и
+cert-расширения, id_*/secret-каталоги, credentials файлы; `.env.example` —
+шаблон, не сигнал). `gate.Result.Signals` собирает в bundle измеренные
+signals: размер diff (added/removed lines через `git diff --numstat`, файловый
+разбив added/modified/removed), количество тестовых изменений (class tests ×
+added/modified), чувствительные пути, `checks_run` и `failed_checks`. Сигналы
+записываются как данные и НЕ маршрутизируют pipeline (никакого
+автоматического решения на их основе); routing придёт отдельно в P2-1/P2-2
+вместе с продуктовым решением владельца. CLI summary печатает однострочный
+срез signals; в index.json и gate.json сигналы входят в record digest.
+
+JUnit XML typed adapter (V0-6): `pkg/junit` — bounded strict parser JUnit-отчётов
+(корни testsuite/testsuites, вложенные suite). Counts suites/testcases/
+failures/errors/skips выводятся только из реальных `<testcase>` элементов, а не
+из атрибутов-агрегатов (jest/maven/gradle заполняют их непоследовательно);
+zero-test/zero-passed отчёты отклоняются (не evidence). DOCTYPE/entity и
+прочие processing instructions запрещены, глубина ≤32, размер ≤64 MiB. В
+pkg/checks новый adapter `junit-xml` с `report_file` (repo-relative обязательный
+путь внутри target): command запускается в confined workingDir и пишет отчёт,
+adapter читает его строгим parser'ом и дигирует сырой файл (StructuredOutput-
+Bytes/SHA256), #тестов (discovered/passed/failed/errored/skipped) попадают в
+Result. Семантика Maven/Gradle: exit code команды не является авторитетным —
+failure/error в XML фейлит required check даже при `sh` exit 0. report_file —
+объявленный side-effect проверки и исключается из workspace-immutability
+детекции; всё остальное остаётся read-only. Golden fixtures: pytest, Jest,
+Gradle, Maven (плюс zero/doctype/entity). Снимает ограничение «только Go» для
+демо (V0-7) — проверки любых языковых флотов работают с одним adapter.
 
 Локальный `RunController` связывает HTTP с тем же `RunEngine`, резервирует
 run ID до запуска worker goroutine и запрещает дублирующий active worker.

--- a/openspec/changes/dsse-signed-bundle/design.md
+++ b/openspec/changes/dsse-signed-bundle/design.md
@@ -1,0 +1,98 @@
+# Signed bundle через DSSE — design
+
+## Контекст: что на самом деле подписываем
+
+- **Run bundle** (`pkg/export`): `export.BundleDigest(index)` —
+  sha256(канонический index.json). index.json на диске — `MarshalIndent`+`\n`,
+  но digest считается от **compact** `json.Marshal` (детерминирован).
+- **Gate bundle** (`pkg/gate`): `gate.BundleDigest(index)` — тот же паттерн.
+- **Дизест attestation** (`attest.Digest`) уже встроен в Git trailer
+  `ai-team-attestation` (delivery_deferred.go). Это отдельная ценность; P1-5
+  фокусируется на bundle-подписи, attestation-трейл остаётся как есть.
+
+Подписываемый payload — **canonical digital-identity bundle digest**
+(строка hex). Это детерминированно, компактно и не зависит от layout bundle.
+
+## D1: DSSE envelope без внешних зависимостей
+
+`pkg/dsse` (пакет-per-concern, зеркалит `pkg/attest`/`pkg/export`):
+
+- `PAE(payloadType, payload []byte) []byte` — стандартный DSSE
+  Pre-Authentication Encoding: `"DSSEv1" || len(payloadType) || payloadType ||
+  len(payload) || payload` (длины — big-endian uint64).
+- `Payload{Type string, Bytes []byte}`; `Envelope{PayloadCiphertext/PAE,
+  Signatures []Signature}` не обязателен полным: для одного ed25519-подписанта
+  достаточно `Peer{KeyID, Sig}` + наша структура envelope.
+- `Sign(priv ed25519.PrivateKey, pt string, payload []byte) ([]byte, error)` —
+  ed25519.Sign над PAE(pt, payload).
+- `Verify(pub ed25519.PublicKey, pt string, payload []byte, sig []byte) error` —
+  ed25519.Verify над той же PAE; константо-временное сравнение через
+  `crypto/subtle.ConstantTimeCompare`/`ed25519.Verify` (stdlib уже constant-time).
+- `LoadPrivateKey(path)`, `LoadPublicKey(path)` — через
+  `safeio.ReadRegularFile` + `pem.Decode` (PKCS8/PKCS1 ed25519) или raw ED25519
+  seed/лежащий ключ; формат — простой предпочтительный: PEM `PRIVATE KEY`/
+  `PUBLIC KEY`, а также fallback на raw base64/PEM-less для простоты. Решаем:
+  поддерживаем PEM (PKCS8 ed25519) как канонический, при отсутствии PEM — raw
+  32/64-байтный.
+
+Примечание: `ed25519.Sign` в Go всегда возвращает фиксированные 64 байта
+(детерминированно для ed25519 — w.r.t. RFC 8032 ed25519 is deterministic). Это
+позволяет при желании пересчитать signature для сверки.
+
+## D2: Интеграция подписи в export/gate bundle
+
+Чистый seam — в точке, где bundle уже собран и digest известен:
+
+- **export.Build → return index**; добавить подпись отдельной функцией после:
+  `export.SignBundle(index, outDir, priv) error` пишет `dsse.json`
+  (envelope с payloadType `"application/vnd.ai-team.bundle+hex"`, payload =
+  `BundleDigest(index)`), и НЕ добавляет его в index.Records (иначе частичный:
+  digest сменится). Вместо этого `dsse.json` — отдельный файл без записи в
+  index; но тогда он «лишний файл» в bundle и verify может не заметить
+  подмену. Решение: verify читает `dsse.json` как наличие-необязательное;
+  если файл присутствует — он обязан валидироваться против `BundleDigest`, и
+  не обязан быть в index.Records (чтобы не менять детерминизм), но дополнительно
+  проверяется его целостность напрямую (re-read + parse).
+- **VerifyBundle добавка**: `VerifyBundle(bundleDir, opts)` где opts
+  содержит `VerifyKey ed25519.PublicKey`. Если `dsse.json` отсутствует и ключа
+  нет — как раньше. Если ключ задан (или dsse.json есть) — проверить подпись
+  над `BundleDigest(index)` fail-closed. Возвращаем digest как раньше.
+
+Фактически: чтобы не ломать сигнатуру существующих вызовов, вводим
+`VerifyOptions{VerifyKey ed25519.PublicKey}` и `VerifyBundle(bundleDir,
+opts ...VerifyOptions)` (variadic strings, backward compat). То же для export:
+`VerifyBundle(bundleDir, key)`.
+
+## D3: CLI
+
+- `cmdExport`/`cmdGate`: `--sign-key <path>` — загрузить ed25519 confident key и
+  подписать bundle после записи.
+- `cmdVerify`: `--verify-key <path>` — загрузить публичный ключ и в fail-closed
+  режиме потребовать валидную подпись для каждого проверяемого bundle.
+- Оба подписывают только BundleDigest; ключ из файла (не из env в prod-коде).
+
+## D4: Backward compat + строгая семантика
+
+- Bundle без `dsse.json` и без `--verify-key` — валиден (как раньше, integrity).
+- Bundle с `dsse.json`, verify без ключа — предупредить? Решаем: verify без
+  ключа при наличии dsse.json не падает (нельзя проверить), но может вывести
+  warning. При заданном `--verify-key` и отсутствии dsse.json → FAIL (мы задали
+  ожидание подписи).
+- Сигнатура подписи детерминирована (ed25519), потому signature можно
+  пересчитать и сверить — включаем в тесты.
+
+## Отказ от альтернатив
+
+- **Внешняя библиотека (in-toto-golang / go-securesystemslib)** — избыточна для
+  одного ed25519-подписанта; PAE тривиален на stdlib; сохраняем lean deps.
+- **Подпись attestation.Predicate (расширение схемы)** — ломает golden fixture и
+  contract-compat statement; не трогаем. Attestation уже связан с Git через
+  trailer digest.
+- **Подпись всего raw payload (index.json bytes)** — подписываем детерминированный
+  digest, а не layout-зависимые байты (Microsoft и gate проще стыковать).
+
+## Риски
+
+- Verify должен сверять dsse.json с digest пересчитываемым из текущего index;
+  если кто-то подменит index + dsse.json согласованно, но ключ не тот — fake
+  ловится только ключом. Это ожидаемо (подпись = trust in key).

--- a/openspec/changes/dsse-signed-bundle/proposal.md
+++ b/openspec/changes/dsse-signed-bundle/proposal.md
@@ -1,0 +1,44 @@
+# Signed bundle через DSSE
+
+## Why
+
+README и ARCHITECTURE честно фиксируют разрыв: **integrity** гарантируется
+цепочкой хэшей (`ai-team verify` подтверждает, что записи не тронуты), но
+**authenticity** — нет: у bundle нет подписи автора. Digest — это контроль
+целостности (факт «не изменено»), а не доказательство авторства («кто создал»).
+Доверие к создателю — out-of-band решение человека/CI.
+
+P1-5 закрывает этот разрыв: подпись DSSE (in-toto style) на deteterministic
+`BundleDigest` run- и gate-bundle, верифицируемая публичным ключом. Это переносит
+bundle из «целостность без автора» в «подписано автором» — ключевой шаг к
+внешнему audit и к доверию к bundle как самостоятельному артефакту.
+
+## What Changes
+
+- **`pkg/dsse`**: канонический DSSE envelope (PAE — Pre-Authentication Encoding:
+  `"DSSEv1" + len(payloadType) + payloadType + len(payload) + payload`) + ed25519
+  sign/verify через stdlib `crypto/ed25519`. Ноль внешних зависимостей —
+  соответствует lean stdlib-позиции проекта.
+- **Подпись run- и gate-bundle**: sign детерминированного `BundleDigest`
+  (канонический index.json) в момент финализации bundle.
+- **CLI**: ключи через флаги/окружение (без коммита секретов):
+  - `ai-team export --sign-key <path>` / `ai-team gate --sign-key <path>` —
+    подписать bundle;
+  - `ai-team verify --verify-key <path>` — верифицировать подпись (fail-closed:
+    если signature-файл есть, а ключ задан и не совпадает → ошибка).
+- **Evidence**: signature записывается отдельным файлом bundle
+  (`dsse.json` / `.sig`) и перечисляется в index.Records, чтобы она сама
+  покрывалась хэш-цепочкой. При верификации signature-файл и digest проверяются
+  согласованно.
+
+## Success Criteria
+
+- [green] `pkg/dsse` unit-тесты: PAE roundtrip, sign/verify, tampered signature
+  ловится, wrong key ловится (fail-closed).
+- [green] export/gate подписывают bundle — signature-файл появляется и попадает
+  в index.Records; `ai-team verify --verify-key` проверяет.
+- [negative] Подмена payload / подпись другим ключом / отсутствие подписи при
+  заданном `--verify-key` → verify FAIL (закрытие authenticity gAP).
+- README «integrity vs authenticity» обновлён (заголовок сохранить как строку —
+  docs_test.go); AUDIT-статус по подписи.
+- `make specs` зелёный; `go test ./...` зелёный (кроме известного baseline e2e).

--- a/openspec/changes/dsse-signed-bundle/specs/dsse/spec.md
+++ b/openspec/changes/dsse-signed-bundle/specs/dsse/spec.md
@@ -1,0 +1,62 @@
+# dsse-signed-bundle delta (P1-5)
+
+## ADDED Requirements
+
+### Requirement: DSSE envelope for bundle signatures
+
+The system MUST provide a DSSE (in-toto-style) signature envelope implemented
+with the standard library only, using Pre-Authentication Encoding (PAE) and
+ed25519. It MUST be able to sign and verify a payload, and MUST reject a
+tampered payload or a mismatched public key.
+
+#### Scenario: Sign and verify a payload
+
+- **WHEN** a payload is signed with an ed25519 private key
+- **THEN** verification with the matching public key MUST succeed
+- **AND** verification of a modified payload MUST fail
+- **AND** verification with a different public key MUST fail
+
+### Requirement: Signed run and gate bundles
+
+`ai-team export` and `ai-team gate` MUST be able to sign their bundle `BundleDigest`
+with an ed25519 key, writing a signature file into the bundle
+(`dsse.json`) alongside `index.json`.
+
+#### Scenario: Bundle is signed
+
+- **WHEN** `ai-team export --sign-key <path>` (or `gate --sign-key <path>`) runs
+- **THEN** a `dsse.json` signature file MUST exist in the bundle
+- **AND** it MUST verify against the bundle `BundleDigest`
+
+### Requirement: Bundle signature verification
+
+`ai-team verify` MUST verify a bundle signature when a public key is provided
+(`--verify-key <path>`). If the key is provided but the signature is absent or
+invalid, verification MUST fail (fail-closed). A bundle without a signature
+remains valid when no key is requested.
+
+#### Scenario: Signature verifies
+
+- **WHEN** `ai-team verify --verify-key <path>` checks a correctly signed bundle
+- **THEN** verification MUST succeed
+
+#### Scenario: Signature invalid or missing with key required
+
+- **WHEN** the bundle signature is tampered, or absent while `--verify-key` is set
+- **THEN** verification MUST fail
+
+#### Scenario: Unsigned bundle verified without key
+
+- **WHEN** `ai-team verify` checks a bundle with no signature and no key requested
+- **THEN** verification MUST succeed (integrity only)
+
+### Requirement: Key files are never committed
+
+Ed25519 keys MUST be supplied at runtime via CLI flags pointing at files, and the
+system MUST NOT store private keys in config or evidence. Evidence MUST contain
+only the signature, never the private key.
+
+#### Scenario: Private key stays out of evidence
+
+- **WHEN** a signed bundle is produced
+- **THEN** the bundle evidence MUST NOT contain the ed25519 private key

--- a/openspec/changes/dsse-signed-bundle/tasks.md
+++ b/openspec/changes/dsse-signed-bundle/tasks.md
@@ -1,0 +1,39 @@
+# Tasks — Signed bundle через DSSE
+
+## D1. pkg/dsse (DSSE envelope, stdlib-only)
+
+- [ ] `pkg/dsse/dsse.go`: `PAE(payloadType, payload)` — `"DSSEv1"` + big-endian
+      uint64 lengths + payloadType + payload; `Envelope{PayloadType, Payload,
+      Signature}`; `Sign(priv, pt, payload) ([]byte, error)` — ed25519.Sign over
+      PAE; `Verify(pub, pt, payload, sig) error` — ed25519.Verify.
+- [ ] `pkg/dsse/keys.go`: `LoadPrivateKey(path)` (PEM PKCS8 ed25519; fallback raw
+      64-byte/seed), `LoadPublicKey(path)` (PEM PKCS8/PKIX; fallback raw
+      32-byte) — через `safeio.ReadRegularFile` + `pem.Decode`.
+- [ ] `pkg/dsse/dsse_test.go`: PAE roundtrip + canon, sign/verify happy,
+      tampered payload FAIL, wrong key FAIL, key load PEM+raw.
+
+## D2. Подпись + верификация в export/gate
+
+- [ ] `pkg/export/export.go`: `SignBundle(bundleDir, priv) error` writes
+      `dsse.json` (envelope, payload=`BundleDigest(index)`); `VerifyBundle`
+      gains variadic `VerifyOptions{VerifyKey}` — if key set/dsse.json present,
+      verify fail-closed over `BundleDigest`.
+- [ ] `pkg/gate/gate.go`: аналогично `SignBundle` + `VerifyBundle` variadic key.
+- [ ] Реэкспорт `dsse.json` не в index.Records (не ломать детерминизм) — verify
+      читает его отдельно.
+
+## D3. CLI
+
+- [ ] `cmd/ai-team/export.go`, `cmd/gate.go`: `--sign-key <path>` load key &
+      `SignBundle` after write.
+- [ ] `cmd/ai-team/main.go` cmdVerify: `--verify-key <path>`, wire into
+      export/gate VerifyBundle; gate/run dir branches.
+
+## D4. Тесты + доки
+
+- [ ] export/gate unit: signed bundle roundtrip, tamper fail, missing sig with
+      key fail, unsigned-no-key pass.
+- [ ] README «integrity vs authenticity» обновить (заголовок сохранить);
+      ARCHITECTURE секция.
+- [ ] `TASKLOG.md` #20→review; backlog #20→Review.
+- [ ] `make specs` (64+); `go test ./...` (кроме baseline e2e).

--- a/pkg/dsse/dsse.go
+++ b/pkg/dsse/dsse.go
@@ -1,0 +1,138 @@
+// Package dsse implements a minimal DSSE (in-toto-style) signature envelope
+// using only the standard library: Pre-Authentication Encoding (PAE) plus
+// ed25519 sign/verify. Used to bind authenticity to the deterministic
+// BundleDigest of run- and gate-bundles (P1-5). No external dependencies —
+// matches the project's lean, stdlib-first posture.
+package dsse
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Pre-Authentication Encoding prefix per DSSE spec.
+const paePrefix = "DSSEv1"
+
+var (
+	// ErrVerify — подпись не прошла проверку (подмена payload или ключ не тот).
+	ErrVerify = errors.New("dsse: подпись не совпадает")
+)
+
+// Envelope — сериализованный DSSE envelope над одним payload.
+// PayloadType — media type payload'а; Payload — подписываемые байты;
+// Signature — ed25519-подпись над PAE(payloadType, payload) (64 байта).
+// Для детерминированности (ed25519 детерминирован по RFC 8032) signature
+// можно пересчитать и сверить. KeyID/KeyHash не храним — подпись и ключ
+// связываются только выбором verify-ключа вызывающей стороной.
+type Envelope struct {
+	PayloadType string `json:"payloadType"`
+	Payload     []byte `json:"payload"`
+	Signature   []byte `json:"signature"`
+}
+
+// PAE возвращает каноническое Pre-Authentication Encoding окрытие payload'а:
+//
+//	DSSEv1 || len(payloadType, uint64 BE) || payloadType ||
+//	len(payload, uint64 BE) || payload
+//
+// Одинаковые (payloadType, payload) всегда дают одинаковые байты.
+func PAE(payloadType string, payload []byte) []byte {
+	var buf []byte
+	buf = append(buf, paePrefix...)
+	buf = appendUint64(buf, uint64(len(payloadType)))
+	buf = append(buf, payloadType...)
+	buf = appendUint64(buf, uint64(len(payload)))
+	buf = append(buf, payload...)
+	return buf
+}
+
+func appendUint64(dst []byte, v uint64) []byte {
+	var tmp [8]byte
+	binary.BigEndian.PutUint64(tmp[:], v)
+	return append(dst, tmp[:]...)
+}
+
+// Signinal подписывает payload ed25519-ключом priv над PAE(payloadType, payload).
+// Возвращает фиксированную 64-байтную подпись.
+func Sign(priv ed25519.PrivateKey, payloadType string, payload []byte) []byte {
+	return ed25519.Sign(priv, PAE(payloadType, payload))
+}
+
+// Verify проверяет подпись по открытому ключу pub над PAE(payloadType, payload).
+// Возвращает ErrVerify при несовпадении (подмена payload или неверный ключ).
+func Verify(pub ed25519.PublicKey, payloadType string, payload, sig []byte) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return fmt.Errorf("%w: некорректный открытый ключ (%d байт)", ErrVerify, len(pub))
+	}
+	if !ed25519.Verify(pub, PAE(payloadType, payload), sig) {
+		return ErrVerify
+	}
+	return nil
+}
+
+// SignEnvelope подписывает payload и возвращает готовый Envelope.
+func SignEnvelope(priv ed25519.PrivateKey, payloadType string, payload []byte) *Envelope {
+	return &Envelope{
+		PayloadType: payloadType,
+		Payload:     payload,
+		Signature:   Sign(priv, payloadType, payload),
+	}
+}
+
+// VerifyEnvelope проверяет envelope по открытому ключу.
+func VerifyEnvelope(pub ed25519.PublicKey, e *Envelope) error {
+	return Verify(pub, e.PayloadType, e.Payload, e.Signature)
+}
+
+// Marshal сериализует envelope в стабильный JSON (для dsse.json в bundle:
+// детерминирован, подпись не зависит от layout). delta-поле отсутствует.
+func Marshal(e *Envelope) ([]byte, error) {
+	return json.MarshalIndent(e, "", "  ")
+}
+
+// EnvelopeFileName — имя signature-файла в bundle (рядом с index.json).
+const EnvelopeFileName = "dsse.json"
+
+// SignaturePayloadType — media type подписываемого payload'а: детерминированный
+// BundleDigest (hex-строка) run- или gate-bundle.
+const SignaturePayloadType = "application/vnd.ai-team.bundle+hex"
+
+// SignBundleFile подписывает bundle digest и пишет EnvelopeFileName в bundleDir.
+// Errors оставляют каталог без частичного файла при ошибке записи.
+func SignBundleFile(bundleDir string, priv ed25519.PrivateKey, payloadType string, payload []byte) error {
+	env := SignEnvelope(priv, payloadType, payload)
+	data, err := Marshal(env)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	path := filepath.Join(bundleDir, EnvelopeFileName)
+	if err := os.WriteFile(path, data, 0444); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadEnvelopeFile читает EnvelopeFileName из bundleDir (nil, если нет файла).
+func ReadEnvelopeFile(bundleDir string) (*Envelope, bool, error) {
+	data, err := os.ReadFile(filepath.Join(bundleDir, EnvelopeFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var env Envelope
+	if err := dec.Decode(&env); err != nil {
+		return nil, false, err
+	}
+	return &env, true, nil
+}

--- a/pkg/dsse/dsse_test.go
+++ b/pkg/dsse/dsse_test.go
@@ -1,0 +1,161 @@
+package dsse
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPAE(t *testing.T) {
+	// Fixed vectors mirror the DSSE spec example for a short payload:
+	// payloadType "application/vnd.test" payload []byte("hello").
+	p1 := PAE("application/vnd.test", []byte("hello"))
+	if !bytes.HasPrefix(p1, []byte("DSSEv1")) {
+		t.Fatalf("PAE не начинается с DSSEv1")
+	}
+	// len("application/vnd.test") = 20
+	// len("hello") = 5
+	wantLen := len("DSSEv1") + 8 + 20 + 8 + 5
+	if len(p1) != wantLen {
+		t.Fatalf("PAE len = %d, want %d", len(p1), wantLen)
+	}
+	// Determinism.
+	if !bytes.Equal(PAE("application/vnd.test", []byte("hello")), p1) {
+		t.Fatalf("PAE не детерминирован")
+	}
+	// Empty payload: длина явно закодирована (0), отлична от непустого.
+	empty := PAE("t", nil)
+	if len(empty) != len("DSSEv1")+8+1+8+0 {
+		t.Fatalf("empty PAE len = %d", len(empty))
+	}
+	if bytes.Equal(empty, PAE("t", []byte("x"))) {
+		t.Fatalf("empty и non-empty PAE одинаковы (не должно)")
+	}
+}
+
+func TestSignVerifyHappy(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pt := "application/vnd.ai-team.bundle+hex"
+	payload := []byte("deadbeef")
+	sig := Sign(priv, pt, payload)
+	if len(sig) != ed25519.SignatureSize {
+		t.Fatalf("sig len %d, want %d", len(sig), ed25519.SignatureSize)
+	}
+	if err := Verify(pub, pt, payload, sig); err != nil {
+		t.Fatalf("verify happy: %v", err)
+	}
+	// Envelope roundtrip.
+	env := SignEnvelope(priv, pt, payload)
+	if err := VerifyEnvelope(pub, env); err != nil {
+		t.Fatalf("verify envelope: %v", err)
+	}
+}
+
+func TestVerifyTamperedPayload(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	pt := "application/vnd.ai-team.bundle+hex"
+	payload := []byte("digest-A")
+	sig := Sign(priv, pt, payload)
+	if err := Verify(pub, pt, []byte("digest-B"), sig); err == nil {
+		t.Fatalf("tampered payload должен FAIL")
+	}
+}
+
+func TestVerifyWrongKey(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	pub2, _, _ := ed25519.GenerateKey(rand.Reader)
+	payload := []byte("x")
+	sig := Sign(priv, "t", payload)
+	if err := Verify(pub2, "t", payload, sig); err == nil {
+		t.Fatalf("wrong key должен FAIL")
+	}
+}
+
+func TestVerifyWrongPayloadType(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	payload := []byte("x")
+	sig := Sign(priv, "type-A", payload)
+	if err := Verify(pub, "type-B", payload, sig); err == nil {
+		t.Fatalf("wrong payloadType должен FAIL")
+	}
+}
+
+func TestKeysPEMRoundtrip(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	dir := t.TempDir()
+
+	privDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+	privPath := filepath.Join(dir, "ed25519.pem")
+	if err := os.WriteFile(privPath, privPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+	loadedPriv, err := LoadPrivateKey(privPath)
+	if err != nil {
+		t.Fatalf("load private: %v", err)
+	}
+	if !loadedPriv.Equal(priv) {
+		t.Fatalf("private key mismatch")
+	}
+
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	pubPath := filepath.Join(dir, "ed25519.pub.pem")
+	if err := os.WriteFile(pubPath, pubPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+	loadedPub, err := LoadPublicKey(pubPath)
+	if err != nil {
+		t.Fatalf("load public: %v", err)
+	}
+	if !loadedPub.Equal(pub) {
+		t.Fatalf("public key mismatch")
+	}
+}
+
+func TestKeysRaw(t *testing.T) {
+	dir := t.TempDir()
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		t.Fatal(err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+
+	privPath := filepath.Join(dir, "key.raw")
+	if err := os.WriteFile(privPath, seed, 0600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadPrivateKey(privPath)
+	if err != nil {
+		t.Fatalf("raw seed load: %v", err)
+	}
+	if !loaded.Equal(priv) {
+		t.Fatalf("raw seed key mismatch")
+	}
+
+	pubPath := filepath.Join(dir, "key.pub")
+	if err := os.WriteFile(pubPath, priv.Public().(ed25519.PublicKey), 0644); err != nil {
+		t.Fatal(err)
+	}
+	loadedPub, err := LoadPublicKey(pubPath)
+	if err != nil {
+		t.Fatalf("raw public load: %v", err)
+	}
+	if !loadedPub.Equal(priv.Public()) {
+		t.Fatalf("raw public key mismatch")
+	}
+}

--- a/pkg/dsse/keys.go
+++ b/pkg/dsse/keys.go
@@ -1,0 +1,107 @@
+package dsse
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// LoadPrivateKey загружает ed25519 private key из файла. Поддерживает:
+//   - PEM PKCS8 ("PRIVATE KEY")
+//   - PEM PKCS1 ("RSA PRIVATE KEY") — не применим к ed25519, отклоняется
+//   - raw: 64-байтный PKCS8/raw seed 32 байта (fallback)
+//
+// Путь читается через os.ReadFile (ключ локальный, вне bundle-правил safeio)
+// и не должен попадать в evidence.
+func LoadPrivateKey(path string) (ed25519.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("dsse: читать private key %s: %w", path, err)
+	}
+	key, err := parsePrivateKey(data)
+	if err != nil {
+		return nil, fmt.Errorf("dsse: private key %s: %w", path, err)
+	}
+	return key, nil
+}
+
+// LoadPublicKey загружает ed25519 public key из файла (PEM PKCS8/PKIX или raw
+// 32-байтный).
+func LoadPublicKey(path string) (ed25519.PublicKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("dsse: читать public key %s: %w", path, err)
+	}
+	key, err := parsePublicKey(data)
+	if err != nil {
+		return nil, fmt.Errorf("dsse: public key %s: %w", path, err)
+	}
+	return key, nil
+}
+
+func parsePrivateKey(data []byte) (ed25519.PrivateKey, error) {
+	if block, _ := pem.Decode(data); block != nil {
+		if block.Type == "PRIVATE KEY" {
+			parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
+			key, ok := parsed.(ed25519.PrivateKey)
+			if !ok {
+				return nil, fmt.Errorf("PEM не ed25519 private key (%T)", parsed)
+			}
+			return key, nil
+		}
+		return nil, fmt.Errorf("неподдерживаемый PEM block %q", block.Type)
+	}
+	if len(data) == ed25519.SeedSize {
+		return ed25519.NewKeyFromSeed(data), nil
+	}
+	if len(data) == ed25519.PrivateKeySize {
+		return ed25519.PrivateKey(data), nil
+	}
+	return nil, fmt.Errorf("raw private key должен быть %d (seed) или %d (full) байт, получено %d",
+		ed25519.SeedSize, ed25519.PrivateKeySize, len(data))
+}
+
+func parsePublicKey(data []byte) (ed25519.PublicKey, error) {
+	if block, _ := pem.Decode(data); block != nil {
+		var parsed any
+		var err error
+		switch block.Type {
+		case "PRIVATE KEY", "PUBLIC KEY":
+			parsed, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+			if err == nil {
+				if key, ok := parsed.(ed25519.PrivateKey); ok {
+					return key.Public().(ed25519.PublicKey), nil
+				}
+			}
+			// try PKIX public
+			pub, pubErr := x509.ParsePKIXPublicKey(block.Bytes)
+			if pubErr != nil {
+				return nil, errors.Join(err, pubErr)
+			}
+			key, ok := pub.(ed25519.PublicKey)
+			if !ok {
+				return nil, fmt.Errorf("не ed25519 public key (%T)", pub)
+			}
+			return key, nil
+		case "ED25519 PRIVATE KEY":
+			// openssl genpkey -algorithm ED25519 emits PKCS8, handle direct
+			return nil, fmt.Errorf("use PKCS8 'PRIVATE KEY' PEM instead of %q", block.Type)
+		default:
+			return nil, fmt.Errorf("неподдерживаемый PEM block %q", block.Type)
+		}
+	}
+	if len(data) == ed25519.PublicKeySize {
+		return ed25519.PublicKey(data), nil
+	}
+	if len(data) == ed25519.SeedSize {
+		return ed25519.NewKeyFromSeed(data).Public().(ed25519.PublicKey), nil
+	}
+	return nil, fmt.Errorf("raw public key должен быть %d байт, получено %d",
+		ed25519.PublicKeySize, len(data))
+}

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -9,9 +9,11 @@ package export
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -21,6 +23,7 @@ import (
 	"time"
 
 	"github.com/arturpanteleev/ai-team/pkg/attest"
+	"github.com/arturpanteleev/ai-team/pkg/dsse"
 	"github.com/arturpanteleev/ai-team/pkg/evidence"
 	"github.com/arturpanteleev/ai-team/pkg/provenance"
 	"github.com/arturpanteleev/ai-team/pkg/retention"
@@ -175,6 +178,31 @@ func Build(runDir, outDir string) (*Index, error) {
 	return index, nil
 }
 
+// SignBundle подписывает детерминированный BundleDigest собранного bundle
+// (outDir с index.json) ed25519-ключом priv и пишет dsse.json
+// (SignaturePayloadType). Вызывается после Build.
+func SignBundle(outDir string, priv ed25519.PrivateKey) error {
+	data, err := safeio.ReadRegularFile(filepath.Join(outDir, indexFileName), maxIndexSize)
+	if err != nil {
+		return fmt.Errorf("export sign: index.json: %w", err)
+	}
+	var index Index
+	if err := json.Unmarshal(data, &index); err != nil {
+		return fmt.Errorf("export sign: index.json decode: %w", err)
+	}
+	if index.Type != BundleType || index.RunID == "" {
+		return fmt.Errorf("export sign: index.json не является run bundle")
+	}
+	digest, err := BundleDigest(&index)
+	if err != nil {
+		return fmt.Errorf("export sign: BundleDigest: %w", err)
+	}
+	if err := dsse.SignBundleFile(outDir, priv, dsse.SignaturePayloadType, []byte(digest)); err != nil {
+		return fmt.Errorf("export sign: %w", err)
+	}
+	return nil
+}
+
 func fromSlash(path string) string {
 	return filepath.FromSlash(strings.TrimSpace(path))
 }
@@ -245,7 +273,12 @@ func readRunManifest(runDir string) (*evidence.RunManifest, error) {
 // .ai-team: каждый record обязан совпадать со своим sha256, а все semantic
 // связи (run manifest ↔ config/workflow snapshots ↔ event chain ↔ anchor ↔
 // attempt manifests ↔ attestation v1 ↔ provenance) обязаны сойтись.
-func VerifyBundle(bundleDir string) error {
+//
+// Опционально (variadic keyVerify) проверяется DSSE-подпись bundle (P1-5):
+// если задан открытый ключ — подпись обязана присутствовать и совпадать
+// (fail-closed). Если dsse.json присутствует, а ключ пуст — сообщение о
+// неподтверждённой подписи (не ошибка, но требование при verify с ключом).
+func VerifyBundle(bundleDir string, keyVerify ...ed25519.PublicKey) error {
 	indexData, err := safeio.ReadRegularFile(filepath.Join(bundleDir, indexFileName), maxIndexSize)
 	if err != nil {
 		return fmt.Errorf("verify: bundle index: %w", err)
@@ -288,11 +321,50 @@ func VerifyBundle(bundleDir string) error {
 	if err := verifyCore(bundleDir, index.RunID, index.Records); err != nil {
 		return err
 	}
+	digest, err := BundleDigest(&index)
+	if err != nil {
+		return err
+	}
+	if err := verifySignature(bundleDir, digest, keyVerify...); err != nil {
+		return err
+	}
+	return nil
+}
+
+// verifySignature проверяет DSSE-подпись (dsse.json) против digest. Правила
+// (P1-5, fail-closed): ключ задан → подпись обязана быть и совпадать;
+// ключ пуст и подписи нет → pass (integrity-only); ключ пуст, подпись есть →
+// pass, но подпись остаётся непроверенной (без ключа проверить нельзя).
+func verifySignature(bundleDir, digest string, keyVerify ...ed25519.PublicKey) error {
+	env, present, err := dsse.ReadEnvelopeFile(bundleDir)
+	if err != nil {
+		return fmt.Errorf("verify: dsse.json: %w", err)
+	}
+	keyGiven := len(keyVerify) > 0 && len(keyVerify[0]) > 0
+	if !present {
+		if keyGiven {
+			return errors.New("verify: задан --verify-key, но dsse.json (подпись bundle) отсутствует")
+		}
+		return nil
+	}
+	if !keyGiven {
+		return nil
+	}
+	payloadType := dsse.SignaturePayloadType
+	want := []byte(digest)
+	if env.PayloadType != payloadType || string(env.Payload) != string(want) {
+		return errors.New("verify: подпись bundle не соответствует digest (payload подменён)")
+	}
+	if err := dsse.Verify(keyVerify[0], env.PayloadType, env.Payload, env.Signature); err != nil {
+		return fmt.Errorf("verify: подпись bundle недействительна: %w", err)
+	}
 	return nil
 }
 
 // ensureNoExtraneousFiles — bundle не должен содержать файлов вне index.json:
 // любой лишний файл вне whitelisted records — повод для подозрения, отклоняется.
+// Единственное исключение — dsse.json (DSSE-подпись bundle, P1-5): он пишется
+// рядом с index.json и не входит в records.
 func ensureNoExtraneousFiles(bundleDir string, index *Index) error {
 	seen := make(map[string]bool, len(index.Records))
 	for _, record := range index.Records {
@@ -309,7 +381,7 @@ func ensureNoExtraneousFiles(bundleDir string, index *Index) error {
 		if relErr != nil {
 			return relErr
 		}
-		if rel == indexFileName || seen[rel] {
+		if rel == indexFileName || rel == dsse.EnvelopeFileName || seen[rel] {
 			return nil
 		}
 		return fmt.Errorf("verify: неизвестный файл %q вне index.json (лишние файлы не допускаются)", rel)

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -406,3 +406,39 @@ func TestVerifyBundleTamperedSignature(t *testing.T) {
 		t.Fatal("tampered signature с ключом должен FAIL")
 	}
 }
+
+func TestVerifyBundleEmptySignatureFailsClosed(t *testing.T) {
+	base := t.TempDir()
+	runDir := buildTerminalRun(t, filepath.Join(base, "runs"))
+	bundle := filepath.Join(base, "bundle")
+	if _, err := Build(runDir, bundle); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	sigPath := filepath.Join(bundle, dsse.EnvelopeFileName)
+
+	writeEnv := func(t *testing.T, env *dsse.Envelope) {
+		t.Helper()
+		data, err := dsse.Marshal(env)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(sigPath, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Пустая подпись: с ключом — fail-closed (не молчаливый pass).
+	writeEnv(t, &dsse.Envelope{PayloadType: dsse.SignaturePayloadType, Payload: []byte("x"), Signature: nil})
+	if err := VerifyBundle(bundle, pub); err == nil {
+		t.Fatal("VerifyBundle с пустой подписью и ключом должен FAIL (fail-closed)")
+	}
+
+	// Искажённый dsse.json (не валидный envelope) — с ключом fail.
+	if err := os.WriteFile(sigPath, []byte("{not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyBundle(bundle, pub); err == nil {
+		t.Fatal("VerifyBundle с повреждённым dsse.json и ключом должен FAIL")
+	}
+}

--- a/pkg/export/export_test.go
+++ b/pkg/export/export_test.go
@@ -1,6 +1,8 @@
 package export
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	"github.com/arturpanteleev/ai-team/pkg/attest"
+	"github.com/arturpanteleev/ai-team/pkg/dsse"
 	"github.com/arturpanteleev/ai-team/pkg/evidence"
 	"github.com/arturpanteleev/ai-team/pkg/provenance"
 	"github.com/arturpanteleev/ai-team/pkg/retention"
@@ -325,5 +328,81 @@ func TestPublishVerifiedRoundtripRetention(t *testing.T) {
 	}
 	if !record.Verified || record.BundleSHA256 != sha {
 		t.Fatalf("roundtrip mismatch: %+v", record)
+	}
+}
+
+func TestBundleSignAndVerify(t *testing.T) {
+	base := t.TempDir()
+	runDir := buildTerminalRun(t, filepath.Join(base, "runs"))
+	bundle := filepath.Join(base, "bundle")
+	if _, err := Build(runDir, bundle); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SignBundle(bundle, priv); err != nil {
+		t.Fatalf("SignBundle: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(bundle, dsse.EnvelopeFileName)); err != nil {
+		t.Fatalf("dsse.json не создан: %v", err)
+	}
+
+	// Верификация с правильным ключом — успех.
+	if err := VerifyBundle(bundle); err != nil {
+		t.Fatalf("VerifyBundle unsigned-key (integrity): %v", err)
+	}
+	if err := VerifyBundle(bundle, pub); err != nil {
+		t.Fatalf("VerifyBundle correct key: %v", err)
+	}
+
+	// Подмена payload (индекс) при валидной подписи другого содержимого →
+	// digest изменится и подпись fail.
+	wrongPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	if err := VerifyBundle(bundle, wrongPub); err == nil {
+		t.Fatal("VerifyBundle wrong key должен FAIL")
+	}
+
+	// Удаление подписи при заданном ключе → fail-closed.
+	sigPath := filepath.Join(bundle, dsse.EnvelopeFileName)
+	if err := os.Remove(sigPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyBundle(bundle, pub); err == nil {
+		t.Fatal("VerifyBundle с ключом без dsse.json должен FAIL (fail-closed)")
+	}
+	if err := VerifyBundle(bundle); err != nil {
+		t.Fatalf("VerifyBundle без подписи и без ключа должен PASS: %v", err)
+	}
+}
+
+func TestVerifyBundleTamperedSignature(t *testing.T) {
+	base := t.TempDir()
+	runDir := buildTerminalRun(t, filepath.Join(base, "runs"))
+	bundle := filepath.Join(base, "bundle")
+	if _, err := Build(runDir, bundle); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	if err := SignBundle(bundle, priv); err != nil {
+		t.Fatalf("SignBundle: %v", err)
+	}
+	// Порти ском подписи в dsse.json.
+	if err := os.Chmod(filepath.Join(bundle, dsse.EnvelopeFileName), 0644); err != nil {
+		t.Fatal(err)
+	}
+	env, present, err := dsse.ReadEnvelopeFile(bundle)
+	if err != nil || !present {
+		t.Fatalf("read envelope: present=%v err=%v", present, err)
+	}
+	env.Signature[0] ^= 0xff
+	data, _ := dsse.Marshal(env)
+	if err := os.WriteFile(filepath.Join(bundle, dsse.EnvelopeFileName), append(data, '\n'), 0444); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyBundle(bundle, pub); err == nil {
+		t.Fatal("tampered signature с ключом должен FAIL")
 	}
 }

--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -10,6 +10,7 @@ package gate
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/arturpanteleev/ai-team/pkg/checks"
 	"github.com/arturpanteleev/ai-team/pkg/containment"
+	"github.com/arturpanteleev/ai-team/pkg/dsse"
 	"github.com/arturpanteleev/ai-team/pkg/risk"
 	"github.com/arturpanteleev/ai-team/pkg/safeio"
 
@@ -626,7 +628,11 @@ const maxRecordSize = 16 << 20 // 16 MiB на record файл при вериф�
 // gate.json либо отсутствует, либо совпадает с пересчитанным digest. Работает без
 // repo и .ai-team — bundle является единственным источником данных. Возвращает
 // детерминированный digest bundle.
-func VerifyBundle(bundleDir string) (string, error) {
+//
+// Опционально (variadic keyVerify, P1-5) проверяется DSSE-подпись bundle
+// (dsse.json): задан ключ → подпись обязана быть и совпадать (fail-closed);
+// ключ пуст и подписи нет → integrity-only pass.
+func VerifyBundle(bundleDir string, keyVerify ...ed25519.PublicKey) (string, error) {
 	dir, err := safeio.ExistingDir(bundleDir)
 	if err != nil {
 		return "", fmt.Errorf("verify gate bundle: %v", err)
@@ -682,7 +688,7 @@ func VerifyBundle(bundleDir string) (string, error) {
 			return relErr
 		}
 		slashed := filepath.ToSlash(rel)
-		if slashed == indexFileName {
+		if slashed == indexFileName || slashed == dsse.EnvelopeFileName {
 			return nil
 		}
 		if _, ok := expected[slashed]; !ok {
@@ -736,7 +742,36 @@ func VerifyBundle(bundleDir string) (string, error) {
 		return "", fmt.Errorf("verify gate bundle: заявленный bundle_sha256 %q не равен digest %q",
 			verdict.BundleSHA256, digest)
 	}
+	if err := verifyDSSeSignature(dir, digest, keyVerify...); err != nil {
+		return "", fmt.Errorf("verify gate bundle: %w", err)
+	}
 	return digest, nil
+}
+
+// verifyDSSeSignature проверяет DSSE-подпись (dsse.json) против digest
+// (P1-5, fail-closed). См. export.verifySignature за правилами.
+func verifyDSSeSignature(bundleDir, digest string, keyVerify ...ed25519.PublicKey) error {
+	env, present, err := dsse.ReadEnvelopeFile(bundleDir)
+	if err != nil {
+		return err
+	}
+	keyGiven := len(keyVerify) > 0 && len(keyVerify[0]) > 0
+	if !present {
+		if keyGiven {
+			return errors.New("задан --verify-key, но dsse.json (подпись bundle) отсутствует")
+		}
+		return nil
+	}
+	if !keyGiven {
+		return nil
+	}
+	if env.PayloadType != dsse.SignaturePayloadType || string(env.Payload) != digest {
+		return errors.New("подпись bundle не соответствует digest (payload подменён)")
+	}
+	if err := dsse.Verify(keyVerify[0], env.PayloadType, env.Payload, env.Signature); err != nil {
+		return err
+	}
+	return nil
 }
 
 const sha256BytesLen = 64
@@ -827,6 +862,28 @@ func WriteBundle(outDir string, result *Result) error {
 		return err
 	}
 	result.BundleSHA256 = BundleDigest(index)
+	return nil
+}
+
+// SignBundle подписывает детерминированный BundleDigest записанного bundle
+// (outDir с index.json) ed25519-ключом priv и пишет dsse.json. Вызывается в
+// cmdGate после WriteBundle.
+func SignBundle(outDir string, priv ed25519.PrivateKey) error {
+	data, err := safeio.ReadRegularFile(filepath.Join(outDir, indexFileName), maxIndexSize)
+	if err != nil {
+		return fmt.Errorf("gate sign: index.json: %w", err)
+	}
+	var index Index
+	if err := strictDecode(data, &index); err != nil {
+		return fmt.Errorf("gate sign: index.json decode: %w", err)
+	}
+	if index.Type != BundleType {
+		return fmt.Errorf("gate sign: index.json не является gate bundle")
+	}
+	digest := BundleDigest(&index)
+	if err := dsse.SignBundleFile(outDir, priv, dsse.SignaturePayloadType, []byte(digest)); err != nil {
+		return fmt.Errorf("gate sign: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/gate/gate_test.go
+++ b/pkg/gate/gate_test.go
@@ -3,6 +3,8 @@ package gate
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -16,6 +18,7 @@ import (
 
 	"github.com/arturpanteleev/ai-team/pkg/checks"
 	"github.com/arturpanteleev/ai-team/pkg/containment"
+	"github.com/arturpanteleev/ai-team/pkg/dsse"
 	"gopkg.in/yaml.v3"
 )
 
@@ -463,5 +466,57 @@ func TestVerifyBundleRoundtripAndTampering(t *testing.T) {
 		if _, err := VerifyBundle(fresh); err == nil {
 			t.Fatalf("tamper %q: VerifyBundle не обнаружил повреждение", name)
 		}
+	}
+}
+
+func TestGateBundleSignAndVerify(t *testing.T) {
+	fixed := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	result := &Result{
+		SchemaVersion: SchemaVersion, Base: "HEAD", Candidate: "HEAD",
+		BaseCommit: "aabb", CandidateCommit: "ccdd",
+		BaseTree: "tree-a", CandidateTree: "tree-b",
+		DiffPolicy: TestModifyRequired, PolicyVerdict: VerdictPassed,
+		Status: "passed", FinishedAt: fixed,
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Без подписи, без ключа — integrity-only pass.
+	unsigned := t.TempDir()
+	if err := WriteBundle(unsigned, result); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyBundle(unsigned); err != nil {
+		t.Fatalf("unsigned no-key pass: %v", err)
+	}
+	// Без подписи, но ключ задан — fail-closed.
+	if _, err := VerifyBundle(unsigned, pub); err == nil {
+		t.Fatal("unsigned + key должен FAIL (fail-closed)")
+	}
+
+	// С подписью: правильный ключ pass, чужой FAIL.
+	signed := t.TempDir()
+	if err := WriteBundle(signed, result); err != nil {
+		t.Fatal(err)
+	}
+	if err := SignBundle(signed, priv); err != nil {
+		t.Fatalf("SignBundle: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(signed, dsse.EnvelopeFileName)); err != nil {
+		t.Fatalf("dsse.json отсутствует: %v", err)
+	}
+	// dsse.json не должен ломать extra-file detection.
+	if _, err := VerifyBundle(signed); err != nil {
+		t.Fatalf("signed no-key pass: %v", err)
+	}
+	if _, err := VerifyBundle(signed, pub); err != nil {
+		t.Fatalf("signed correct key: %v", err)
+	}
+	wrongPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	if _, err := VerifyBundle(signed, wrongPub); err == nil {
+		t.Fatal("signed wrong key должен FAIL")
 	}
 }


### PR DESCRIPTION
Свежий PR на базе текущего master (HANDOFF workflow), заменяет закрытый #62.

## Изменения (P1-5 DSSE signed bundle)
- DSSE ed25519 envelope + sign/verify для export/gate bundle.

## Blocker-фикс (R2)
- `--verify-key` на run-evidence ветке (`verify <run_id>`) раньше молча игнорировался → пользователь получал pass без проверки подписи. Теперь при заданном `--verify-key` на этой ветке fail-closed с явной ошибкой (DSSE завязан на bundle, не на live run evidence).
- Bundle-ветка корректно применяет key.

## Should-fix
- Добавлен `TestVerifyBundleEmptySignatureFailsClosed` (пустая/повреждённая подпись в bundle-verify).

## Детали
- Branch based on `master` HEAD `e88ea8c` (#80).
- Коммиты: `a20297f` (feature) + `1d8cdec` (R2 fix).
- gofmt clean; export/gate/dsse тесты зелёные.