### PR TITLE
feat(evidence,pipeline): fail-closed evidence verification on resume (OPS-3)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,9 +116,19 @@ lifecycle transitions, terminal status, invalidations и exact digest каждо
 
 Изменяемый execution checkpoint хранится отдельно в
 `.ai-team/state/runs/<run_id>.json`. `RunEngine` атомарно обновляет его на
-границах stages и может после restart открыть проверенную evidence chain для
+ границах stages и может после restart открыть проверенную evidence chain для
 append. Resume сохраняет исходный `run_id`, добавляет `run_resumed` и
 продолжает ordinal sequence попыток; terminal state возобновить нельзя.
+
+Resume перед продолжением выполняет fail-closed проверку применимой evidence
+(OPS-3): `evidence.VerifyResumeEvidence` сверяет manifest identity/schema,
+digest config/workflow snapshot'ов против manifest, целостность event hash
+chain и digest attempt manifest'ов по replayed chain. Любое расхождение
+отклоняет resume со структурированной причиной (`ResumeEvidenceError` +
+`ErrResumeEvidence`), а при аппендабельном логе фиксирует событие
+`resume_blocked` с полем `reason`, — чтобы причина отказа осталась в
+tamper-evident evidence, а не только в стд-ошибке.
+
 
 Человеческое решение о переходе — отдельная typed сущность в
 `.ai-team/state/approvals/<run_id>/<approval_id>.json`. Она привязана к

--- a/openspec/changes/fail-closed-resume-evidence/design.md
+++ b/openspec/changes/fail-closed-resume-evidence/design.md
@@ -1,0 +1,63 @@
+# Fail-closed evidence verification on resume (OPS-3) — design
+
+## Точка вставки
+
+`evidence.Resume` (store.go) уже проверяет manifest identity/schema, digest
+config/workflow snapshot и event hash chain, но: (1) возвращает общим error без
+стабильного кода причины; (2) не проверяет attempt manifest digests по
+replayed chain отдельным шагом; (3) в `RunEngine.Cancel` и в resume-ветке
+`pipeline.RunWithResult` ошибка не фиксируется событием в evidence.
+
+OPS-3 вводит явный fail-closed гейт `VerifyResumeEvidence(runDir)`, вызываемый в
+resume-ветке `RunWithResult` ДО `evidence.Resume`. Это даёт единую точку ответа
+«можно ли продолжать» с категоризированной причиной, независимо от того, где
+именно расхождение (snapshot, цепочка, attempt manifest, терминальность).
+
+## Формат причины
+
+`ResumeEvidenceError{Reason ResumeEvidenceReason, Detail string}` + сентинель
+`ErrResumeEvidence` (`errors.Is`/`errors.As` совместимы). Reason — стабильный
+машинный код, чтобы потребитель (CLI/web/цикл) мог обработать однозначно и
+записать в `resume_blocked` без парсинга строк.
+
+## Проверка (порядок — fail-fast)
+
+1. `run.json` парсится (DisallowUnknownFields), schema + run_id валидны
+   (`manifest_identity`).
+2. digest `config.json` и `workflow.json` по manifest-полям
+   (`config_snapshot` / `workflow_snapshot`).
+3. `ReplayEventLog` (валидация hash chain + переходы) (`event_chain`);
+   `FinishedAt.IsZero()` обязателен, иначе `already_terminal`.
+4. digest attempt manifest'ов по `ManifestSHA256` из replayed chain
+   (`attempt_manifest`).
+
+## Запись причины (аппендабельный лог)
+
+`s.resume_blocked` запиcывается только когда лог цел (целостная цепочка
+позволяет append через `Store.Append`, который сам верифицирует цепочку).
+`AppendBlockedEvent` пере-открывает store по валидной chain
+(`openStoreForAppend`) — это независимо от `evidence.Resume`, который мог бы
+упасть на snapshot-ошибке. Event type `resume_blocked` — информационный:
+`ReplayEventLog` игнорирует незнакомые типы (нет default-error), поэтому новые
+events не ломают проекцию прошлого.
+
+Причина в `data`: `{"reason": "<стабильный код>", "detail": "<текст>"}`.
+
+## Отказ от альтернатив
+
+- **Усилить только `evidence.Resume`** — не даёт стабильного кода причины и не
+  фиксирует событие; OPS-3 требует «явно фиксировать причину отказа».
+- **Полный `VerifyAnchor` на resume** — anchor есть только у терминального run;
+  активный run ещё без anchor (backlog это явно отмечает). Отдельный
+  non-terminal гейт — правильно.
+- **Событие на каждый resume-отказ** — пишем только при целостной цепочке,
+  иначе запись сама невозможна; сам отказ уже fail-closed.
+
+## Риски
+
+- `VerifyResumeEvidence` дублирует часть чтений `evidence.Resume` — приемлемо:
+  это explicit гейт, читаемый и тестируемый отдельно; cost мал (несколько файлов
+  маленького размера).
+- Новый event type должен проходить `Store.Append` (валидация цепочки) и не
+  ломать `ReplayEventLog` — покрыто тестом (`event_chain` остаётся валидной
+  после `resume_blocked`).

--- a/openspec/changes/fail-closed-resume-evidence/proposal.md
+++ b/openspec/changes/fail-closed-resume-evidence/proposal.md
@@ -1,0 +1,40 @@
+# Fail-closed evidence verification on resume (OPS-3)
+
+## Why
+
+При `--resume` контроллер доверяет сохранённым evidence активного run'а без
+явной повторной проверки применимой цепочки/снимков. Повреждение или подмена
+`run.json`/`config.json`/`workflow.json`/`events.jsonl`/attempt manifest'ов
+между прерыванием и продолжением могло остаться незамеченным (итоговая
+проверка anchor происходит только на терминальном run). Решение RQ12 «да» уже
+принято — задача чисто исполнительская: перед продолжением выполнять
+fail-closed проверку применимой evidence chain/snapshots и явно фиксировать
+причину отказа.
+
+## What Changes
+
+- **`pkg/evidence`**:
+  - `VerifyResumeEvidence(runDir)` — детерминированная fail-closed проверка
+    активного (не-терминального) run'а: manifest identity/schema, digest
+    config/workflow snapshot'ов против manifest, целостность event hash chain,
+    digest attempt manifest'ов (по replayed chain). Возвращает структурированную
+    причину через `ResumeEvidenceError{Reason, Detail}` + сентинель
+    `ErrResumeEvidence`.
+  - Причины (стабильные коды): `manifest_identity`, `config_snapshot`,
+    `workflow_snapshot`, `event_chain`, `attempt_manifest`, `already_terminal`.
+  - `AppendBlockedEvent(runDir, runID, reason, detail)` — записывает событие
+    `resume_blocked` с причиной, если event log аппендабелен (цепочка цела).
+- **`pkg/pipeline`**: при `ResumeRunID` перед `evidence.Resume` вызывается
+  `VerifyResumeEvidence`; при отказе (кроме сломанной цепочки/identity, где лог
+  неаппендабелен) — фиксируется `resume_blocked` событие, resume отклоняется.
+
+## Acceptance Criteria
+
+1. Fail-closed: повреждение `config.json` (или `workflow.json`, или
+   `events.jsonl`, или attempt manifest, или `run.json`) активного run'а →
+   `--resume` отклоняется с категоризированной причиной.
+2. Причина явно фиксируется в evidence: событие `resume_blocked` с полем
+   `reason` = стабильный код (при аппендабельном логе).
+3. Чистый resume без tamper'а работает как раньше (регрессия нет).
+4. Терминальный run отклоняется причиной `already_terminal`.
+5. `make specs` 66/66, `go test ./pkg/evidence ./pkg/pipeline` зелёные.

--- a/openspec/changes/fail-closed-resume-evidence/specs/resume-evidence/spec.md
+++ b/openspec/changes/fail-closed-resume-evidence/specs/resume-evidence/spec.md
@@ -1,0 +1,59 @@
+# fail-closed-resume-evidence delta (OPS-3)
+
+## ADDED Requirements
+
+### Requirement: Fail-closed evidence verification on resume
+
+Before continuing a non-terminal run, the system MUST verify the applicable
+evidence chain and snapshots (run manifest identity/schema, config and workflow
+snapshot digests, the event hash chain, and attempt manifest digests) in a
+fail-closed way, and MUST reject the resume with a structured reason on any
+mismatch.
+
+#### Scenario: Tampered config snapshot blocks resume
+
+- **WHEN** a run is interrupted, its `config.json` snapshot is modified, and
+  resume is attempted
+- **THEN** resume MUST be rejected with reason `config_snapshot`
+- **AND** the resume MUST NOT proceed to continue the run
+
+#### Scenario: Tampered event chain blocks resume
+
+- **WHEN** any event in `events.jsonl` is modified
+- **THEN** resume MUST be rejected with reason `event_chain`
+
+#### Scenario: Attempt manifest mismatch blocks resume
+
+- **WHEN** an attempt manifest digest no longer matches the replayed chain
+- **THEN** resume MUST be rejected with reason `attempt_manifest`
+
+### Requirement: Structured rejection reason
+
+The rejection MUST expose a stable machine-readable reason code and a sentinel
+error, so callers can programmatically classify the failure.
+
+#### Scenario: Reason is machine-readable
+
+- **WHEN** resume is rejected due to evidence mismatch
+- **THEN** the returned error MUST wrap the sentinel `ErrResumeEvidence`
+- **AND** carry a `reason` code from the stable set
+  (`manifest_identity`, `config_snapshot`, `workflow_snapshot`, `event_chain`,
+  `attempt_manifest`, `already_terminal`)
+
+### Requirement: Explicit recording of rejection reason
+
+When the event log is appendable, the run MUST record a `resume_blocked` event
+carrying the rejection reason and detail, so the failure cause is persisted in
+the tamper-evident evidence log.
+
+#### Scenario: Rejection reason is recorded
+
+- **WHEN** resume is rejected with an appendable event log
+- **THEN** the run's evidence log MUST contain a `resume_blocked` event
+- **AND** its `data.reason` MUST equal the stable reason code
+- **AND** the event chain MUST remain valid after the appended event
+
+#### Scenario: Terminal run
+
+- **WHEN** resume is attempted on a terminal run
+- **THEN** it MUST be rejected with reason `already_terminal`

--- a/openspec/changes/fail-closed-resume-evidence/tasks.md
+++ b/openspec/changes/fail-closed-resume-evidence/tasks.md
@@ -1,0 +1,35 @@
+# Tasks — Fail-closed evidence verification on resume (OPS-3)
+
+## T1. pkg/evidence: явный fail-closed гейт
+
+- [x] `pkg/evidence/resumeverify.go`:
+  - сентинель `ErrResumeEvidence`, тип `ResumeEvidenceError{Reason, Detail}`
+    (errors.As/Is), стабильные коды `ResumeEvidenceReason`
+    (`manifest_identity`, `config_snapshot`, `workflow_snapshot`,
+    `event_chain`, `attempt_manifest`, `already_terminal`).
+  - `VerifyResumeEvidence(runDir)` — fail-fast проверка: run.json
+    (schema/run_id), config/workflow snapshot digests, ReplayEventLog (chain +
+    terminality), attempt manifest digests.
+  - `AppendBlockedEvent(runDir, runID, reason, detail)` +
+    `openStoreForAppend` — запись `resume_blocked` при аппендабельной chain.
+
+## T2. pkg/evidence: тесты
+
+- [x] `resumeverify_test.go`: активный run проходит; config tamper →
+      `config_snapshot`; event chain tamper → `event_chain`; terminal →
+      `already_terminal` + sentinel unwrap.
+
+## T3. pkg/pipeline: интеграция
+
+- [x] resume-ветка `RunWithResult`: `VerifyResumeEvidence` ДО `evidence.Resume`;
+      при отказе (не chain/identity) `AppendBlockedEvent`; возврат
+      категоризированной ошибки.
+- [x] `resume_evidence_test.go`: повреждение config активного run'а →
+      resume отклоняется + `resume_blocked` записан с reason=`config_snapshot`,
+      chain остаётся валидной.
+
+## T4. Verification
+
+- [x] `go build ./...`, `go vet`, `gofmt -l` чисто.
+- [x] `go test ./pkg/evidence ./pkg/pipeline` зелёные;
+      `make specs` 66/66.

--- a/pkg/evidence/resumeverify.go
+++ b/pkg/evidence/resumeverify.go
@@ -1,0 +1,131 @@
+package evidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/arturpanteleev/ai-team/pkg/safeio"
+)
+
+// ErrResumeEvidence — сентинель: apply-осведомлённая evidence chain/snapshots
+// run'а не прошла fail-closed проверку перед resume (OPS-3).
+var ErrResumeEvidence = errors.New("resume evidence verification failed")
+
+// ResumeEvidenceReason — стабильный машинный код причины отказа, чтобы
+// rejection reason можно было явно фиксировать и однозначно обрабатывать.
+type ResumeEvidenceReason string
+
+const (
+	ReasonManifestIdentity ResumeEvidenceReason = "manifest_identity" // run.json schema/run_id mismatch
+	ReasonConfigSnapshot   ResumeEvidenceReason = "config_snapshot"   // config digest не совпадает с manifest
+	ReasonWorkflowSnapshot ResumeEvidenceReason = "workflow_snapshot" // workflow digest не совпадает с manifest
+	ReasonEventChain       ResumeEvidenceReason = "event_chain"       // events.jsonl hash chain / parse сломан
+	ReasonAttemptManifest  ResumeEvidenceReason = "attempt_manifest"  // digest attempt manifest не совпадает
+	ReasonAlreadyTerminal  ResumeEvidenceReason = "already_terminal"
+)
+
+// ResumeEvidenceError детализирует ошибку fail-closed проверки evidence.
+type ResumeEvidenceError struct {
+	Reason ResumeEvidenceReason
+	Detail string
+}
+
+// AppendBlockedEvent записывает событие resume_blocked с указанной причиной
+// (OPS-3), если event chain run'а аппендабельна (целостна). Возвращает ошибку
+// только если лог недоступен или повреждён — тогда cause нефиксируемо, но и
+// сам провал уже означает fail-closed отказ resume.
+func AppendBlockedEvent(runDir, runID string, reason ResumeEvidenceReason, detail string) error {
+	store, err := openStoreForAppend(runDir, runID)
+	if err != nil {
+		return err
+	}
+	return store.Append(Event{
+		Type: "resume_blocked", Timestamp: time.Now().UTC(),
+		Data: map[string]any{"reason": string(reason), "detail": detail},
+	})
+}
+
+// openStoreForAppend пере-открывает store по валидной event chain, чтобы
+// записать событие без повторного прохода всей snapshot-проверки Resume.
+func openStoreForAppend(runDir, runID string) (*Store, error) {
+	events, err := VerifyEventLog(filepath.Join(runDir, "events.jsonl"), runID)
+	if err != nil {
+		return nil, fmt.Errorf("blocked event: event chain: %w", err)
+	}
+	if len(events) == 0 {
+		return nil, fmt.Errorf("blocked event: пустой event log")
+	}
+	return &Store{
+		root: filepath.Dir(runDir), runID: runID,
+		nextID: uint64(len(events)), lastEventHash: events[len(events)-1].SHA256,
+		provenance: make(map[string]ArtifactRecord),
+	}, nil
+}
+
+func (e *ResumeEvidenceError) Error() string {
+	if e.Detail == "" {
+		return fmt.Sprintf("%s: %s", ErrResumeEvidence, e.Reason)
+	}
+	return fmt.Sprintf("%s: %s: %s", ErrResumeEvidence, e.Reason, e.Detail)
+}
+
+func (e *ResumeEvidenceError) Unwrap() error { return ErrResumeEvidence }
+
+func resumeErr(reason ResumeEvidenceReason, format string, args ...interface{}) *ResumeEvidenceError {
+	return &ResumeEvidenceError{Reason: reason, Detail: fmt.Sprintf(format, args...)}
+}
+
+// VerifyResumeEvidence — fail-closed проверка применимой evidence
+// chain/snapshots НЕ-терминального run перед его продолжением (OPS-3).
+// Выполняется строго детерминированно и возвращает структурированную причину
+// (Reasion) при любом расхождении: manifest identity, config/workflow snapshot
+// digests, event hash chain, attempt manifest digests. Терминальный run
+// отклоняется отдельной причиной.
+func VerifyResumeEvidence(runDir string) error {
+	manifestData, err := safeio.ReadRegularFile(filepath.Join(runDir, "run.json"), 1<<20)
+	if err != nil {
+		return resumeErr(ReasonManifestIdentity, "run.json: %v", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(manifestData))
+	decoder.DisallowUnknownFields()
+	var manifest RunManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return resumeErr(ReasonManifestIdentity, "run manifest decode: %v", err)
+	}
+	if manifest.SchemaVersion != SchemaVersion || manifest.RunID == "" || filepath.Base(manifest.RunID) != manifest.RunID {
+		return resumeErr(ReasonManifestIdentity, "schema/run_id mismatch (schema=%d run=%q)", manifest.SchemaVersion, manifest.RunID)
+	}
+
+	configData, err := safeio.ReadRegularFile(filepath.Join(runDir, manifest.ConfigEvidence), 8<<20)
+	if err != nil || sha256Bytes(configData) != manifest.ConfigSHA256 {
+		return resumeErr(ReasonConfigSnapshot, "config snapshot identity mismatch")
+	}
+	workflowData, err := safeio.ReadRegularFile(filepath.Join(runDir, manifest.ResolvedWorkflow), 8<<20)
+	if err != nil || sha256Bytes(workflowData) != manifest.ResolvedWorkflowSHA256 {
+		return resumeErr(ReasonWorkflowSnapshot, "resolved workflow snapshot identity mismatch")
+	}
+
+	replayed, err := ReplayEventLog(filepath.Join(runDir, "events.jsonl"), manifest.RunID)
+	if err != nil {
+		return resumeErr(ReasonEventChain, "event chain: %v", err)
+	}
+	if !replayed.FinishedAt.IsZero() {
+		return resumeErr(ReasonAlreadyTerminal, "run %s уже terminal", manifest.RunID)
+	}
+
+	for _, attempt := range replayed.Attempts {
+		if attempt.ManifestSHA256 == "" {
+			continue
+		}
+		manifestPath := filepath.Join(runDir, "attempts", attempt.AttemptID, "manifest.json")
+		artifactType, size, digest, digestErr := ArtifactDigest(manifestPath)
+		if digestErr != nil || artifactType != "file" || size == 0 || digest != attempt.ManifestSHA256 {
+			return resumeErr(ReasonAttemptManifest, "attempt %s manifest digest mismatch", attempt.AttemptID)
+		}
+	}
+	return nil
+}

--- a/pkg/evidence/resumeverify_test.go
+++ b/pkg/evidence/resumeverify_test.go
@@ -1,0 +1,101 @@
+package evidence
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildNonTerminalRun создаёт активный (не-терминальный) run: run_started +
+// attempt_started, без run_finished и без anchor.
+func buildNonTerminalRun(t *testing.T, runID string) string {
+	t.Helper()
+	target := t.TempDir()
+	store, err := Start(filepath.Join(target, "runs"), testRunManifest(runID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if err := store.Append(Event{Type: "run_started", Timestamp: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Append(Event{Type: "attempt_started", Stage: "check", AttemptID: runID + "-001-check",
+		Timestamp: now.Add(time.Second), Data: map[string]any{"stage_index": 1}}); err != nil {
+		t.Fatal(err)
+	}
+	return store.RunDir()
+}
+
+func TestVerifyResumeEvidencePassesOnActiveRun(t *testing.T) {
+	runDir := buildNonTerminalRun(t, "run-resume-ok")
+	if err := VerifyResumeEvidence(runDir); err != nil {
+		t.Fatalf("активный run должен пройти fail-closed проверку: %v", err)
+	}
+}
+
+func TestVerifyResumeEvidenceDetectsConfigTamper(t *testing.T) {
+	runDir := buildNonTerminalRun(t, "run-resume-config")
+	configPath := filepath.Join(runDir, "config.json")
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("config.json expected at %s: %v", configPath, err)
+	}
+	if err := os.Chmod(configPath, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"schema_version":1,"galtered":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := VerifyResumeEvidence(runDir)
+	var rv *ResumeEvidenceError
+	if !errors.As(err, &rv) || rv.Reason != ReasonConfigSnapshot {
+		t.Fatalf("ожидали ReasonConfigSnapshot, получили %v", err)
+	}
+}
+
+func TestVerifyResumeEvidenceDetectsEventChainTamper(t *testing.T) {
+	runDir := buildNonTerminalRun(t, "run-resume-chain")
+	// подменяем run_started в середине — hash chain сломается
+	path := filepath.Join(runDir, "events.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var ev Event
+		if json.Unmarshal([]byte(line), &ev) == nil && ev.Type == "run_started" {
+			ev.Data = map[string]any{"tampered": true}
+			encoded, _ := json.Marshal(ev)
+			lines[i] = string(encoded)
+		}
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err = VerifyResumeEvidence(runDir)
+	var rv *ResumeEvidenceError
+	if !errors.As(err, &rv) || rv.Reason != ReasonEventChain {
+		t.Fatalf("ожидали ReasonEventChain, получили %v", err)
+	}
+}
+
+func TestVerifyResumeEvidenceRejectsTerminalRun(t *testing.T) {
+	// buildAnchoredRun создаёт терминальный run
+	runDir := buildAnchoredRun(t, "run-resume-terminal")
+	err := VerifyResumeEvidence(runDir)
+	var rv *ResumeEvidenceError
+	if !errors.As(err, &rv) || rv.Reason != ReasonAlreadyTerminal {
+		t.Fatalf("ожидали ReasonAlreadyTerminal, получили %v", err)
+	}
+	cause := rv.Unwrap()
+	if !errors.Is(err, ErrResumeEvidence) || !errors.Is(cause, ErrResumeEvidence) {
+		t.Fatalf("должен быть сентинель ErrResumeEvidence")
+	}
+}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -399,7 +399,8 @@ func (p *Pipeline) RunWithResult(ctx context.Context, runCfg RunConfig) (RunResu
 		if verifyErr != nil {
 			recErr := &evidence.ResumeEvidenceError{}
 			if errors.As(verifyErr, &recErr) && recErr.Reason != evidence.ReasonEventChain &&
-				recErr.Reason != evidence.ReasonManifestIdentity {
+				recErr.Reason != evidence.ReasonManifestIdentity &&
+				recErr.Reason != evidence.ReasonAlreadyTerminal {
 				_ = evidence.AppendBlockedEvent(runEvidenceDir, runID, recErr.Reason, recErr.Detail)
 			}
 			return RunResult{}, fmt.Errorf("resume evidence run: %w", verifyErr)

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -391,6 +391,19 @@ func (p *Pipeline) RunWithResult(ctx context.Context, runCfg RunConfig) (RunResu
 	attemptOrdinal := 0
 	if runCfg.ResumeRunID != "" {
 		var manifest evidence.RunManifest
+		runEvidenceDir := filepath.Join(runCfg.TargetDir, ".ai-team", "runs", runID)
+		// OPS-3: fail-closed проверка применимой evidence chain/snapshots перед
+		// продолжением. Если цепочка/снимки повреждены — отклоняем resume и явно
+		// фиксируем причину в evidence (resume_blocked), пока лог аппендабелен.
+		verifyErr := evidence.VerifyResumeEvidence(runEvidenceDir)
+		if verifyErr != nil {
+			recErr := &evidence.ResumeEvidenceError{}
+			if errors.As(verifyErr, &recErr) && recErr.Reason != evidence.ReasonEventChain &&
+				recErr.Reason != evidence.ReasonManifestIdentity {
+				_ = evidence.AppendBlockedEvent(runEvidenceDir, runID, recErr.Reason, recErr.Detail)
+			}
+			return RunResult{}, fmt.Errorf("resume evidence run: %w", verifyErr)
+		}
 		evidenceStore, manifest, replayedRun, err = evidence.Resume(filepath.Join(runCfg.TargetDir, ".ai-team", "runs"), runID)
 		if err != nil {
 			return RunResult{}, fmt.Errorf("resume evidence run: %w", err)

--- a/pkg/pipeline/resume_evidence_test.go
+++ b/pkg/pipeline/resume_evidence_test.go
@@ -95,3 +95,72 @@ func TestRun_ResumeBlockedRecordsEvent(t *testing.T) {
 		t.Fatalf("событие resume_blocked не записано")
 	}
 }
+
+// TestRun_ResumeBlockedNotAppendedOnTerminal проверяет OPS-3: если resume
+// отвергнут с причиной already_terminal (run уже terminal), событие
+// resume_blocked НЕ дописывается после run_finished — терминальное событие
+// остаётся последним в event log.
+func TestRun_ResumeBlockedNotAppendedOnTerminal(t *testing.T) {
+	dir := env(t)
+	gitInit(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".ai-team/\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "."}, {"commit", "-qm", "init"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	rt := newScripted()
+	cfg := cfgFor(config.AgentConfig{Name: "analyst"})
+	p := New(cfg, testRegistry(), WithRuntimeFactory(rt.factory), WithPrompter(&scriptedPrompter{}))
+
+	// Terminal run до completion.
+	result, err := p.RunWithResult(context.Background(), RunConfig{
+		Feature: "feat", TaskDesc: "тест", TargetDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("terminal run: %v", err)
+	}
+	runDir := filepath.Join(dir, ".ai-team", "runs", result.RunID)
+	terminal, evErr := evidence.VerifyEventLog(filepath.Join(runDir, "events.jsonl"), result.RunID)
+	if evErr != nil {
+		t.Fatalf("event chain: %v", evErr)
+	}
+	if len(terminal) == 0 || terminal[len(terminal)-1].Type != "run_finished" {
+		t.Fatalf("ожидался последним run_finished, got %d events (last=%q)", len(terminal), lastType(terminal))
+	}
+
+	// Resume терминального run должен отклониться (already_terminal).
+	if _, err := p.RunWithResult(context.Background(), RunConfig{
+		ResumeRunID: result.RunID, TargetDir: dir,
+	}); err == nil {
+		t.Fatal("resume терминального run должен отклониться")
+	}
+
+	// Terminal событие должно остаться последним: resume_blocked НЕ дописывается.
+	after, evErr := evidence.VerifyEventLog(filepath.Join(runDir, "events.jsonl"), result.RunID)
+	if evErr != nil {
+		t.Fatalf("event chain после отклонения resume: %v", evErr)
+	}
+	if len(after) != len(terminal) {
+		t.Fatalf("event log изменился после отклонения resume: было %d, стало %d", len(terminal), len(after))
+	}
+	if len(after) == 0 || after[len(after)-1].Type != "run_finished" {
+		t.Fatalf("после отклонения resume терминальное событие должно остаться последним, got last=%q", lastType(after))
+	}
+	for _, ev := range after {
+		if ev.Type == "resume_blocked" {
+			t.Fatalf("resume_blocked не должен дописываться после run_finished")
+		}
+	}
+}
+
+func lastType(events []evidence.Event) string {
+	if len(events) == 0 {
+		return "<none>"
+	}
+	return events[len(events)-1].Type
+}

--- a/pkg/pipeline/resume_evidence_test.go
+++ b/pkg/pipeline/resume_evidence_test.go
@@ -1,0 +1,97 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/arturpanteleev/ai-team/pkg/approval"
+	"github.com/arturpanteleev/ai-team/pkg/config"
+	"github.com/arturpanteleev/ai-team/pkg/evidence"
+)
+
+// TestRun_ResumeBlockedRecordsEvent проверяет OPS-3: если evidence
+// chain/snapshots активного run'а повреждены, resume fail-closed отклоняется
+// и причина явно фиксируется событием resume_blocked (при аппендабельном логе).
+func TestRun_ResumeBlockedRecordsEvent(t *testing.T) {
+	dir := env(t)
+	gitInit(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".ai-team/\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "."}, {"commit", "-qm", "init"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	rt := newScripted()
+	cfg := cfgForGraph(func(wf *config.WorkflowConfig) {
+		wf.Edges[0].Approval = &config.WorkflowApprovalConfig{
+			Roles: []string{"product_owner"}, Quorum: "any",
+			Actions: map[string]string{"approve": "reviewer", "reject": "$stop"},
+		}
+	}, config.AgentConfig{Name: "analyst"}, config.AgentConfig{Name: "reviewer"})
+	p := New(cfg, testRegistry(), WithRuntimeFactory(rt.factory), WithPrompter(&scriptedPrompter{}))
+
+	first, err := p.RunWithResult(context.Background(), RunConfig{
+		Feature: "feat", TaskDesc: "тест", TargetDir: dir,
+	})
+	var required *ApprovalRequiredError
+	if !errors.As(err, &required) {
+		t.Fatalf("ожидался pending approval, got result=%+v err=%v", first, err)
+	}
+	// Разрешаем approval, чтобы resume прошёл мимо approval-гейта и дошёл до
+	// fail-closed проверки evidence (иначе resume остановится на pending раньше).
+	approvalStore, aerr := approval.NewStore(dir)
+	if aerr != nil {
+		t.Fatal(aerr)
+	}
+	if _, derr := approvalStore.Decide(first.RunID, required.ApprovalID, approval.Decision{
+		ActorID: "product-1", ActorRole: "product_owner", Action: "approve",
+		SubjectHash: required.SubjectHash,
+	}); derr != nil {
+		t.Fatal(derr)
+	}
+
+	// Повреждаем config snapshot активного run'а (evidence tamper).
+	runDir := filepath.Join(dir, ".ai-team", "runs", first.RunID)
+	configPath := filepath.Join(runDir, "config.json")
+	if err := os.Chmod(configPath, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"schema_version":1,"galtered":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resume должен fail-closed отклониться.
+	if _, err := p.RunWithResult(context.Background(), RunConfig{
+		ResumeRunID: first.RunID, TargetDir: dir,
+	}); err == nil {
+		t.Fatal("resume с повреждённой config snapshot должен отклониться")
+	}
+
+	// Причина должна быть явно зафиксирована в evidence событием resume_blocked.
+	events, evErr := evidence.VerifyEventLog(filepath.Join(runDir, "events.jsonl"), first.RunID)
+	if evErr != nil {
+		t.Fatalf("event chain должна остаться валидной (аппендабельной): %v", evErr)
+	}
+	found := false
+	for _, ev := range events {
+		if ev.Type == "resume_blocked" {
+			found = true
+			reason, _ := ev.Data["reason"].(string)
+			if reason != "config_snapshot" {
+				t.Fatalf("resume_blocked reason=%q, ожидали config_snapshot", reason)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("событие resume_blocked не записано")
+	}
+}


### PR DESCRIPTION
Свежий PR на базе текущего master (HANDOFF workflow), заменяет закрытый #65.

## Изменения (OPS-3 fail-closed resume)
- Fail-closed проверка evidence при резюме.

## Blocker-фикс (R2)
- resume_blocked больше не дописывается после run_finished: в guard добавлено `recErr.Reason != evidence.ReasonAlreadyTerminal` — терминальное событие остаётся последним (нарушение инварианта до этого было).

## Should-fix
- Добавлен тест `TestRun_ResumeBlockedNotAppendedOnTerminal`: run доводится до terminal, resume отклоняется, event count не меняется, последнее событие run_finished, resume_blocked после него отсутствует.

## Детали
- Branch rebased на master HEAD d2fc0bc (после #82).
- Коммиты: dc1f43b (feature) + 8366169 (R2 fix).
- gofmt clean; pipeline/evidence тесты зелёные (вкл. resume_blocked).