### PR TITLE
feat(pipeline,config,runtime): hard run budget + attested usage truthfulness (P1-7)

### DIFF
--- a/openspec/changes/budget-guard-usage-truthfulness/design.md
+++ b/openspec/changes/budget-guard-usage-truthfulness/design.md
@@ -1,0 +1,77 @@
+# Budget guard + usage truthfulness (P1-7)
+
+## Problem
+
+Две смежные проблемы бюджета run'а:
+
+1. **Нет верхней границы**. run может крутиться в loopback/retry бесконечно:
+   wall-time ограничен только per-stage timeout-ами, а суммарное число
+   попыток не ограничено ничем.
+2. **Tokens/cost вычисляются нечестно**. Pipeline ещё не потребляет usage из
+   адаптеров; envelope всегда пишет `tokens_unknown: true`, а если начнёт
+   принимать цифры — нужно гарантировать, что они приходят только от
+   аттестованного источника (capability `usage-reported`), а не guesses.
+
+## Requirements
+
+- Жёсткий бюджет run: `max_wall_time` (default 24h) и `max_attempts`
+  (default 100). Применяется ВСЕГДА, даже без секции `budget`.
+- Бюджет-брейч — явная причина остановки run (не generic error).
+- Usage принимается ТОЛЬКО от адаптера с capability `usage-reported`
+  (runtime `UsageSource`), разбор из вывода агента в `AgentCLIRuntime`.
+- Envelope содержит attested usage: `usage_reported`,
+  `tokens_input/output`, `cost_usd`; `tokens_unknown` остаётся при отсутствии
+  аттестации.
+
+## Non-goals
+
+- Не меняем per-stage timeout (stage_timeout) и workflow max_visits.
+- Не добавляем UI/документацию по budget-настройке (только конфиг).
+- Cost-конвертация между моделями не входит (брать как есть из адаптера).
+
+## Design
+
+### Config
+
+`pkg/config/config.go`: `BudgetConfig` (yaml `budget`, поля `max_wall_time`,
+`max_attempts`) с `Validate()` (положительное парсимое duration / неотрицательный
+int), `EffectiveMaxWallTime()` и `EffectiveMaxAttempts()` — nil-safety дефолты.
+Разрешён в allowlist/rawConfig/`Config.Validate`.
+
+### Runtime: attested usage
+
+- `adapter.go` уже имеет `Usage{TokensInput,TokensOutput,CostUSD,Attested}`,
+  `UsageSource.ParseUsage(io.Reader)` (для claude/codex). Это единственная
+  точка, где usage может появиться — harness сам цифры не придумывает.
+- `runtime.go`: optional interface `UsageReporter { Usage() *Usage }`.
+- `agentcli.go`: `AgentCLIRuntime.lastUsage`; в `Execute` ПОСЛЕ успеха, если
+  adapter реализует `UsageSource`, парсим stdout и сохраняем usage (только
+  `Attested`). На досупе в промпте/adapter usage не зашит.
+
+### Pipeline: лимиты и агрегация
+
+- runState: `budgetConfig` (из `p.cfg.Budget`, nil-safe дефолты) и
+  `usageTotal runtime.Usage`.
+- `RunWithResult`: execute обёрнут в `context.WithTimeout(ctx, budgetWall)`.
+  `errors.Is(runErr, context.DeadlineExceeded)` → причина `max_wall_time`.
+- `executeGraph`: ПЕРЕД `runStage` проверка
+  `attemptOrdinal >= maxAttempts` → бюджет-ошибка (cap строгий: лишняя
+  попытка не запускается).
+- `runStage`: после успеха, если runtime реализует `UsageReporter` и usage
+  `Attested` — суммирует в `rs.usageTotal`.
+
+### Metrics
+
+`metrics.go`: `Usage` model; `UsageEnvelope` + `UsageReported`,
+`TokensInput/Output`, `CostUSD`; `Build(...)` получает usage и ставит
+`TokensUnknown = !usage.Attested`. Call-site один — `finalize.go`
+(writeUsageEnvelope), конвертер `usageToMetrics` держит metrics без
+зависимости на runtime.
+
+## Risks
+
+- claude/codex ParseUsage может давать partial data — это не faux: берём что
+  аттестовано, остальное unknown + zero.
+- Looser attempt-порядок: cap считается по суммарным попыткам ВСЕХ стадий
+  (включая replay при resume). Для дефолта 100 это безопасно; для явных
+  маленьких значений понадобится точная настройка.

--- a/openspec/changes/budget-guard-usage-truthfulness/proposal.md
+++ b/openspec/changes/budget-guard-usage-truthfulness/proposal.md
@@ -1,0 +1,41 @@
+# Budget guard + usage truthfulness (P1-7)
+
+## Proposal
+
+**ID**: P1-7  |  **Trace**: #42 budget/usage envelope, ADP-1/ADP-2
+**Priority**: P1
+
+### ЧТО
+
+Ограничить каждый run жёстким бюджетом (wall-time + attempts),
+всегда, и принимать tokens/cost только от аттестованного adapter-usage.
+
+### ПОЧЕМУ
+
+- Без wall-time/attempt лимитов run в loopback/retry не имеет верхней
+  границы (мы это уже видели на практике).
+- Usage в envelope Честность: не придумывать цифры — только capability
+  `usage-reported` + парсинг вывода агента.
+
+### Скоуп
+
+1. Config: `budget.max_wall_time` (default 24h), `budget.max_attempts`
+   (default 100), валидация.
+2. Pipeline: wall-time ctx + attempt cap (до запуска лишней попытки),
+   break-reason в сообщении.
+3. Runtime: optional `UsageReporter`; `AgentCLIRuntime` разбирает usage из
+   вывода при успехе (только attested).
+4. Metrics: envelope несёт attested usage; `tokens_unknown` только когда
+   аттестации нет.
+
+### Критерии приёмки
+
+- Устанавливаемый budget реально останавливает run и называет лимит.
+- Без `budget` применяются дефолты (24h / 100).
+- Невалидный budget — ошибка конфига.
+- Attested usage попадает в usage.json (contextual), un-attested → unknown.
+
+### Похожее / альтернативы
+
+- per-stage timeout остаётся, но это не то же самое (нет общей границы).
+- Жёсткие дефолты проще, чем таймаут-классы.

--- a/openspec/changes/budget-guard-usage-truthfulness/specs/budget-guard-usage-truthfulness/spec.md
+++ b/openspec/changes/budget-guard-usage-truthfulness/specs/budget-guard-usage-truthfulness/spec.md
@@ -1,0 +1,54 @@
+# budget-guard-usage-truthfulness delta (P1-7)
+
+## ADDED Requirements
+
+### Requirement: Hard run budget limits (wall-time and attempts)
+
+Every run MUST be constrained by a hard budget: maximum wall-time and maximum
+total number of stage attempts. These limits MUST apply even when no
+`budget` section is configured (canonical defaults), so a run can never run
+unbounded.
+
+#### Scenario: Budget section is honored
+
+- **WHEN** `budget.max_wall_time` and `budget.max_attempts` are set in config
+- **THEN** the run is cancelled after the wall-time expires
+- **AND** no attempt beyond `max_attempts` is started
+
+#### Scenario: Defaults apply without budget section
+
+- **WHEN** no `budget` section is configured
+- **THEN** the run is still bounded by canonical defaults
+  (wall-time 24h, attempts 100)
+
+#### Scenario: Invalid budget is rejected at load
+
+- **WHEN** `max_wall_time` does not parse as a positive Go duration or
+  `max_attempts` is negative
+- **THEN** config validation MUST fail
+
+#### Scenario: Budget breach is reported as the run reason
+
+- **WHEN** the budget is exceeded
+- **THEN** the run stops with a reason naming the exceeded limit
+  (`max_wall_time` or `max_attempts`)
+
+### Requirement: Usage tokens/cost accepted only from attested adapter source
+
+Token and cost figures MUST NOT be faked by the harness. They are accepted
+ONLY from an adapter that supports the `usage-reported` capability and parse
+results from the agent's own output. The usage envelope tracks whether the
+values are attested.
+
+#### Scenario: Attested usage is persisted
+
+- **WHEN** an adapter with `usage-reported` capability provides parseable usage
+- **THEN** the aggregated usage is written to the run usage envelope
+  with `usage_reported: true`
+- **AND** `tokens_input`, `tokens_output` and `cost_usd` hold the sums
+
+#### Scenario: Unattested usage is not reported
+
+- **WHEN** the adapter cannot be parsed or does not attest usage
+- **THEN** the envelope keeps `tokens_unknown: true`
+- **AND** no token or cost values are claimed

--- a/openspec/changes/budget-guard-usage-truthfulness/tasks.md
+++ b/openspec/changes/budget-guard-usage-truthfulness/tasks.md
@@ -1,0 +1,18 @@
+# Budget guard + usage truthfulness (P1-7) — tasks
+
+Все шаги выполнены в одном кодовом изменении.
+
+1. `pkg/config`: `BudgetConfig` + `Validate`/effective-helpers, allowlist/
+   rawConfig/`Config.Validate`; юнит-тесты дефолтов и reject-кейсов.
+2. `pkg/runtime`: `UsageReporter` optional interface; `AgentCLIRuntime`
+   парсит usage из stdout при успехе (только attested).
+3. `pkg/pipeline`: runState `budgetConfig`/`usageTotal`; wall-time ctx в
+   `RunWithResult`; попытка-cap до `runStage` в `executeGraph`; агрегация
+   attested usage в `runStage`.
+4. `pkg/metrics`: `Usage`, `UsageEnvelope`-поля, `Build(..., usage)`;
+   обновление существующих тестов + новые кейсы.
+5. `finalize.go`: передача usage в `runState` → `metrics.Build`.
+6. OpenSpec delta `budget-guard-usage-truthfulness`.
+
+Verification: `go build ./...`, `go vet ./pkg/...`, `gofmt -l`, `go test ./...`
+(только 2 известных e2e baseline fail), `make specs`.

--- a/pkg/config/budget_test.go
+++ b/pkg/config/budget_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBudgetConfigDefaults(t *testing.T) {
+	var nilBudget *BudgetConfig
+	dur, str := nilBudget.EffectiveMaxWallTime()
+	if dur != 0 || str != DefaultBudgetMaxWallTime {
+		t.Fatalf("nil budget wall: (%v, %s)", dur, str)
+	}
+	if nilBudget.EffectiveMaxAttempts() != DefaultBudgetMaxAttempts {
+		t.Fatalf("nil budget attempts = %d", nilBudget.EffectiveMaxAttempts())
+	}
+
+	nilFields := &BudgetConfig{}
+	dur, _ = nilFields.EffectiveMaxWallTime()
+	if str != DefaultBudgetMaxWallTime || dur != 0 {
+		t.Fatalf("пустые поля должны давать дефолт wall-time: (%v, %s)", dur, str)
+	}
+	if nilFields.EffectiveMaxAttempts() != DefaultBudgetMaxAttempts {
+		t.Fatalf("пустые поля должны давать дефолт attempts")
+	}
+}
+
+func TestBudgetConfigExplicit(t *testing.T) {
+	bc := &BudgetConfig{MaxWallTime: "2h", MaxAttempts: 50}
+	if err := bc.Validate(); err != nil {
+		t.Fatalf("valid: %v", err)
+	}
+	dur, str := bc.EffectiveMaxWallTime()
+	want := 2 * time.Hour
+	if dur != want || str != "2h" {
+		t.Fatalf("wall = (%v, %s), want (%v, 2h)", dur, str, want)
+	}
+	if bc.EffectiveMaxAttempts() != 50 {
+		t.Fatalf("attempts = %d", bc.EffectiveMaxAttempts())
+	}
+}
+
+func TestBudgetConfigValidateRejects(t *testing.T) {
+	cases := map[string]*BudgetConfig{
+		"bad-duration": {MaxWallTime: "-2h", MaxAttempts: 10},
+		"parse-fail":   {MaxWallTime: "xyz", MaxAttempts: 10},
+		"neg-attempts": {MaxWallTime: "1h", MaxAttempts: -5},
+	}
+	for name, bc := range cases {
+		if err := bc.Validate(); err == nil {
+			t.Errorf("%s: должен быть отвергнут", name)
+		}
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,59 @@ type Config struct {
 	StageTimeout   string             `yaml:"stage_timeout,omitempty"`
 	Containment    *ContainmentConfig `yaml:"containment,omitempty"`
 	TreeHash       *TreeHashConfig    `yaml:"tree_hash,omitempty"`
+	Budget         *BudgetConfig      `yaml:"budget,omitempty"`
+}
+
+// BudgetConfig — глобальные жёсткие лимиты run (P1-7): total wall-time и
+// суммарное число попыток. Лимиты применяются ВСЕГДА (даже без секции —
+// канонические дефолты), это контракт: run не может превысить wall-time или
+// attempts бюджета.
+type BudgetConfig struct {
+	MaxWallTime string `yaml:"max_wall_time,omitempty"`
+	MaxAttempts int    `yaml:"max_attempts,omitempty"`
+}
+
+// Канонические дефолты бюджета (применяются при отсутствии явного budget).
+const (
+	DefaultBudgetMaxWallTime = "24h"
+	DefaultBudgetMaxAttempts = 100
+)
+
+// EffectiveMaxWallTime возвращает wall-time лимит: явный или канонический
+// дефолт. Значение валидно (Validate вызывается до запуска).
+func (bc *BudgetConfig) EffectiveMaxWallTime() (time.Duration, string) {
+	if bc == nil || strings.TrimSpace(bc.MaxWallTime) == "" {
+		return time.Duration(0), DefaultBudgetMaxWallTime
+	}
+	d, err := time.ParseDuration(bc.MaxWallTime)
+	if err != nil {
+		return time.Duration(0), bc.MaxWallTime
+	}
+	return d, bc.MaxWallTime
+}
+
+// EffectiveMaxAttempts возвращает лимит попыток: явный или дефолт.
+func (bc *BudgetConfig) EffectiveMaxAttempts() int {
+	if bc == nil || bc.MaxAttempts <= 0 {
+		return DefaultBudgetMaxAttempts
+	}
+	return bc.MaxAttempts
+}
+
+func (bc *BudgetConfig) Validate() error {
+	if bc == nil {
+		return nil
+	}
+	if bc.MaxWallTime != "" {
+		d, err := time.ParseDuration(bc.MaxWallTime)
+		if err != nil || d <= 0 {
+			return fmt.Errorf("budget.max_wall_time %q не парсится (пример: 2h)", bc.MaxWallTime)
+		}
+	}
+	if bc.MaxAttempts < 0 {
+		return fmt.Errorf("budget.max_attempts не может быть отрицательным")
+	}
+	return nil
 }
 
 // TreeHashConfig — project-specific настройки tree hashing (OPS-2).
@@ -115,7 +168,7 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	if err := validateMappingKeys(value, map[string]bool{
 		"schema_version": true, "pipeline": true, "cli": true, "model": true,
 		"effort": true, "stage_timeout": true, "workflow": true, "containment": true,
-		"tree_hash": true,
+		"tree_hash": true, "budget": true,
 	}, "config"); err != nil {
 		return err
 	}
@@ -128,6 +181,7 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 		StageTimeout  string          `yaml:"stage_timeout"`
 		Workflow      *WorkflowConfig `yaml:"workflow"`
 		TreeHash      *TreeHashConfig `yaml:"tree_hash"`
+		Budget        *BudgetConfig   `yaml:"budget"`
 	}
 	var raw rawConfig
 	if err := value.Decode(&raw); err != nil {
@@ -144,6 +198,7 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	c.StageTimeout = raw.StageTimeout
 	c.Workflow = raw.Workflow
 	c.TreeHash = raw.TreeHash
+	c.Budget = raw.Budget
 
 	if raw.Pipeline.Kind == 0 {
 		return fmt.Errorf("config: pipeline is required")
@@ -442,6 +497,11 @@ func (c *Config) Validate(reg AgentLookup) error {
 	}
 	if c.TreeHash != nil {
 		if err := c.TreeHash.Validate(); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if c.Budget != nil {
+		if err := c.Budget.Validate(); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,6 +20,16 @@ type StageMetrics struct {
 	DurationMS int64  `json:"duration_ms"`
 }
 
+// Usage — aggregated attested usage из adapters-layer (P1-7). Поля принимаются
+// ТОЛЬКО от адаптера с capability usage-reported (runtime.UsageSource);
+// Attested=true фиксирует этот источник аттестации.
+type Usage struct {
+	Attested     bool    `json:"attested"`
+	TokensInput  int64   `json:"tokens_input,omitempty"`
+	TokensOutput int64   `json:"tokens_output,omitempty"`
+	CostUSD      float64 `json:"cost_usd,omitempty"`
+}
+
 // UsageEnvelope — attempt-independent usage-сводка одного run.
 type UsageEnvelope struct {
 	SchemaVersion   int            `json:"schema_version"`
@@ -30,15 +40,22 @@ type UsageEnvelope struct {
 	TotalDurationMS int64          `json:"total_duration_ms"`
 	Stages          []StageMetrics `json:"stages"`
 	LoopbackCycles  int            `json:"loopback_cycles"`
-	// TokensUnknown — заготовка для adapters-layer: заполняется когда хост
-	// начнёт отдавать usage (токены сейчас недоступны через runtime interface).
-	TokensUnknown bool   `json:"tokens_unknown"`
-	Outcome       string `json:"outcome"`
+	// TokensUnknown — true, пока харнесс/адаптер не отдаёт attested usage.
+	TokensUnknown bool `json:"tokens_unknown"`
+	// UsageReported — true, когда хотя бы один адаптер аттестовал usage.
+	UsageReported bool `json:"usage_reported,omitempty"`
+	// TokensInput/TokensOutput/CostUSD — суммарные attested usage одного run.
+	TokensInput  int64   `json:"tokens_input,omitempty"`
+	TokensOutput int64   `json:"tokens_output,omitempty"`
+	CostUSD      float64 `json:"cost_usd,omitempty"`
+	Outcome      string  `json:"outcome"`
 }
 
 // Build агрегирует фиксированные результаты этапов в usage envelope.
 // Superseded попытки исключаются; этапы упорядочены по первому появлению.
-func Build(runID, feature string, startedAt, finishedAt time.Time, results []workflow.StageResult, loopbackCycles int, outcome string) UsageEnvelope {
+// usage — суммарный attested usage (P1-7); если Attested=false — usage
+// остаётся unknown.
+func Build(runID, feature string, startedAt, finishedAt time.Time, results []workflow.StageResult, loopbackCycles int, outcome string, usage Usage) UsageEnvelope {
 	index := make(map[string]int)
 	stages := make([]StageMetrics, 0)
 	for _, result := range results {
@@ -58,7 +75,7 @@ func Build(runID, feature string, startedAt, finishedAt time.Time, results []wor
 	if !startedAt.IsZero() && !finishedAt.IsZero() && !finishedAt.Before(startedAt) {
 		total = finishedAt.Sub(startedAt).Milliseconds()
 	}
-	return UsageEnvelope{
+	envelope := UsageEnvelope{
 		SchemaVersion:   SchemaVersion,
 		RunID:           runID,
 		Feature:         feature,
@@ -67,9 +84,14 @@ func Build(runID, feature string, startedAt, finishedAt time.Time, results []wor
 		TotalDurationMS: total,
 		Stages:          stages,
 		LoopbackCycles:  loopbackCycles,
-		TokensUnknown:   true, // заполняется когда хост начнёт отдавать usage
+		TokensUnknown:   !usage.Attested,
+		UsageReported:   usage.Attested,
+		TokensInput:     usage.TokensInput,
+		TokensOutput:    usage.TokensOutput,
+		CostUSD:         usage.CostUSD,
 		Outcome:         outcome,
 	}
+	return envelope
 }
 
 // TotalAttempts возвращает суммарное число не-superseded попыток.

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -25,7 +25,7 @@ func TestBuildExcludesSupersededAndAggregates(t *testing.T) {
 		fixedResult("coder", "run-1-004-coder", 30*time.Second, false),
 		fixedResult("reviewer", "run-1-005-reviewer", 5*time.Second, false),
 	}
-	envelope := Build("run-1", "feature-x", started, finished, results, 2, "completed")
+	envelope := Build("run-1", "feature-x", started, finished, results, 2, "completed", Usage{Attested: true, TokensInput: 123, TokensOutput: 45, CostUSD: 0.42})
 
 	if envelope.SchemaVersion != SchemaVersion {
 		t.Fatalf("schema_version = %d, хочу %d", envelope.SchemaVersion, SchemaVersion)
@@ -33,8 +33,14 @@ func TestBuildExcludesSupersededAndAggregates(t *testing.T) {
 	if envelope.RunID != "run-1" || envelope.Feature != "feature-x" {
 		t.Fatalf("identity: %+v", envelope)
 	}
-	if !envelope.TokensUnknown {
-		t.Fatal("tokens_unknown должен быть true, пока хост не отдаёт usage")
+	if envelope.TokensUnknown {
+		t.Fatal("tokens_unknown должен быть false при attested usage")
+	}
+	if !envelope.UsageReported {
+		t.Fatal("usage_reported должен быть true при attested usage")
+	}
+	if envelope.TokensInput != 123 || envelope.TokensOutput != 45 || envelope.CostUSD != 0.42 {
+		t.Fatalf("attested usage: %+v", envelope)
 	}
 	if envelope.Outcome != "completed" || envelope.LoopbackCycles != 2 {
 		t.Fatalf("outcome/loops: %+v", envelope)
@@ -58,12 +64,15 @@ func TestBuildExcludesSupersededAndAggregates(t *testing.T) {
 }
 
 func TestBuildZeroTimesOmitsTotalDuration(t *testing.T) {
-	envelope := Build("run-2", "f", time.Time{}, time.Time{}, nil, 0, "failed")
+	envelope := Build("run-2", "f", time.Time{}, time.Time{}, nil, 0, "failed", Usage{})
 	if envelope.TotalDurationMS != 0 {
 		t.Fatalf("total_duration_ms = %d при нулевых временах", envelope.TotalDurationMS)
 	}
 	if len(envelope.Stages) != 0 {
 		t.Fatalf("stages = %+v, хочу пусто", envelope.Stages)
+	}
+	if !envelope.TokensUnknown || envelope.UsageReported {
+		t.Fatalf("без attested usage envelope должен быть unknown: %+v", envelope)
 	}
 }
 
@@ -72,7 +81,7 @@ func TestFormatTable(t *testing.T) {
 	envelope := Build("run-1", "feature-x", started, started.Add(35*time.Second), []workflow.StageResult{
 		fixedResult("analyst", "a", 10*time.Second, false),
 		fixedResult("coder", "b", 20*time.Second, false),
-	}, 1, "completed")
+	}, 1, "completed", Usage{})
 	var out strings.Builder
 	if err := envelope.Format(&out); err != nil {
 		t.Fatalf("format: %v", err)

--- a/pkg/pipeline/budget_test.go
+++ b/pkg/pipeline/budget_test.go
@@ -1,0 +1,117 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arturpanteleev/ai-team/pkg/config"
+	"github.com/arturpanteleev/ai-team/pkg/metrics"
+	"github.com/arturpanteleev/ai-team/pkg/runtime"
+)
+
+func TestRun_BudgetAttemptsCap(t *testing.T) {
+	dir := env(t)
+	rt := newScripted()
+	rt.content["reviewer"] = map[string]string{"review": "**Verdict:** APPROVED\n"}
+
+	cfg := cfgFor(config.AgentConfig{Name: "analyst"}, config.AgentConfig{Name: "reviewer"}, config.AgentConfig{Name: "deployer"})
+	cfg.Budget = &config.BudgetConfig{MaxAttempts: 2}
+
+	err, _ := runPipeline(t, dir, cfg, rt, &scriptedPrompter{})
+	if err == nil {
+		t.Fatal("ожидалась бюджет-ошибка при переборе total attempts")
+	}
+	if !strings.Contains(err.Error(), "run budget: превышен лимит попыток max_attempts=2") {
+		t.Fatalf("ошибка бюджета не распознана: %v", err)
+	}
+	// analyst запущен, затем reviewer — попытка 3 должна не выполнить deployer.
+	if len(rt.executed) != 2 || rt.executed[1] != "reviewer" {
+		t.Fatalf("executed после кэпа: %v", rt.executed)
+	}
+}
+
+func TestRun_BudgetWallTime(t *testing.T) {
+	dir := env(t)
+	rt := newScripted()
+	rt.waitCtx["analyst"] = true // блокируется до отмены ctx
+
+	cfg := cfgFor(config.AgentConfig{Name: "analyst"}, config.AgentConfig{Name: "reviewer"})
+	cfg.Budget = &config.BudgetConfig{MaxWallTime: "200ms"}
+
+	start := time.Now()
+	err, _ := runPipeline(t, dir, cfg, rt, &scriptedPrompter{})
+	if err == nil {
+		t.Fatal("ожидалась бюджет-ошибка по wall-time")
+	}
+	if !strings.Contains(err.Error(), "run budget: превышен max_wall_time 200ms") {
+		t.Fatalf("ошибка бюджета не распознана: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("budget не остановил run вовремя: %v", elapsed)
+	}
+}
+
+// TestRun_AttestedUsagePersisted проверяет, что usage принимается ТОЛЬКО от
+// attested источника и попадает в usage.json envelope (P1-7).
+func TestRun_AttestedUsagePersisted(t *testing.T) {
+	dir := env(t)
+	rt := newScripted()
+	rt.content["reviewer"] = map[string]string{"review": "**Verdict:** APPROVED\n"}
+	rt.usagePer = map[string]*runtime.Usage{
+		"analyst":  {Attested: true, TokensInput: 111, TokensOutput: 22, CostUSD: 1.25},
+		"reviewer": {Attested: true, TokensInput: 10, TokensOutput: 5, CostUSD: 0.1},
+	}
+
+	cfg := cfgFor(config.AgentConfig{Name: "analyst"}, config.AgentConfig{Name: "reviewer"})
+	err, _ := runPipeline(t, dir, cfg, rt, &scriptedPrompter{})
+	if err != nil {
+		t.Fatalf("ожидался успех, got: %v", err)
+	}
+
+	runDir := onlyRunDir(t, dir)
+	raw, err := os.ReadFile(filepath.Join(runDir, "usage.json"))
+	if err != nil {
+		t.Fatalf("usage.json: %v", err)
+	}
+	var envelope metrics.UsageEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("usage.json не парсится: %v", err)
+	}
+	if !envelope.UsageReported || envelope.TokensUnknown {
+		t.Fatalf("ожидали attested usage: %+v", envelope)
+	}
+	if envelope.TokensInput != 121 || envelope.TokensOutput != 27 || envelope.CostUSD != 1.35 {
+		t.Fatalf("usage-значения: %+v", envelope)
+	}
+}
+
+// TestRun_UnattestedUsageStaysUnknown: адаптер БЕЗ attested usage не должен
+// влиять на envelope (остаётся tokens_unknown=true).
+func TestRun_UnattestedUsageStaysUnknown(t *testing.T) {
+	dir := env(t)
+	rt := newScripted()
+	rt.usage = &runtime.Usage{Attested: false, TokensInput: 9}
+
+	cfg := cfgFor(config.AgentConfig{Name: "analyst"})
+	err, _ := runPipeline(t, dir, cfg, rt, &scriptedPrompter{})
+	if err != nil {
+		t.Fatalf("ожидался успех, got: %v", err)
+	}
+
+	runDir := onlyRunDir(t, dir)
+	raw, err := os.ReadFile(filepath.Join(runDir, "usage.json"))
+	if err != nil {
+		t.Fatalf("usage.json: %v", err)
+	}
+	var envelope metrics.UsageEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("usage.json не парсится: %v", err)
+	}
+	if !envelope.TokensUnknown || envelope.UsageReported {
+		t.Fatalf("unattested usage не должен маркироваться reported: %+v", envelope)
+	}
+}

--- a/pkg/pipeline/execute.go
+++ b/pkg/pipeline/execute.go
@@ -53,6 +53,11 @@ func (rs *runState) executeGraph(ctx context.Context) error {
 		if node.MaxVisits > 0 && rs.visits[current] >= node.MaxVisits {
 			return fmt.Errorf("workflow graph: max_visits=%d исчерпан для %s", node.MaxVisits, current)
 		}
+		// P1-7: глобальный лимит попыток run'а (всегда, default 100). Проверка
+		// ДО исполнения: cap строгий, лишняя попытка не запускается.
+		if rs.attemptOrdinal >= rs.budgetConfig.EffectiveMaxAttempts() {
+			return fmt.Errorf("run budget: превышен лимит попыток max_attempts=%d", rs.budgetConfig.EffectiveMaxAttempts())
+		}
 		index := rs.graph.Index(current)
 		if err := rs.saveLifecycle(lifecycle.PhaseRunning, current); err != nil {
 			return err

--- a/pkg/pipeline/finalize.go
+++ b/pkg/pipeline/finalize.go
@@ -51,7 +51,7 @@ func (rs *runState) finalize(runErr error) (workflow.RunOutcome, error) {
 		}
 		return workflow.RunStopped, &RunError{Outcome: workflow.RunStopped, Err: runErr}
 	}
-	if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
+	if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) || errors.Is(runErr, ErrStageTimeout) {
 		if err := report.GenerateFinalReport(
 			rs.reportsDir, rs.runCfg.Feature, rs.results, rs.startTime, endTime,
 			rs.task.ArtifactRoot, status,

--- a/pkg/pipeline/finalize.go
+++ b/pkg/pipeline/finalize.go
@@ -17,6 +17,7 @@ import (
 	"github.com/arturpanteleev/ai-team/pkg/metrics"
 	"github.com/arturpanteleev/ai-team/pkg/notifier"
 	"github.com/arturpanteleev/ai-team/pkg/report"
+	"github.com/arturpanteleev/ai-team/pkg/runtime"
 	"github.com/arturpanteleev/ai-team/pkg/ui"
 	"github.com/arturpanteleev/ai-team/pkg/workflow"
 )
@@ -126,8 +127,19 @@ func (rs *runState) finalize(runErr error) (workflow.RunOutcome, error) {
 // {RunDir}/usage.json — рядом с run.json, вне attempts/.
 func (rs *runState) writeUsageEnvelope(finishedAt time.Time, status string) error {
 	envelope := metrics.Build(rs.runID, rs.runCfg.Feature, rs.startTime, finishedAt,
-		rs.results, rs.loopbackCycles, status)
+		rs.results, rs.loopbackCycles, status, usageToMetrics(rs.usageTotal))
 	return writeControllerJSON(filepath.Join(rs.evidence.RunDir(), "usage.json"), envelope)
+}
+
+// usageToMetrics переносит attested usage из runtime-слоя в metrics-слой
+// (P1-7). metrics остаётся без зависимости на runtime.
+func usageToMetrics(u runtime.Usage) metrics.Usage {
+	return metrics.Usage{
+		Attested:     u.Attested,
+		TokensInput:  u.TokensInput,
+		TokensOutput: u.TokensOutput,
+		CostUSD:      u.CostUSD,
+	}
 }
 
 // writeContainmentReceipt публикует per-axis containment receipt (V0-P1-4) в

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -657,6 +657,9 @@ func (p *Pipeline) RunWithResult(ctx context.Context, runCfg RunConfig) (RunResu
 		budgetCtx, cancel = context.WithTimeout(ctx, budgetDur)
 		defer cancel()
 		runErr = rs.execute(budgetCtx)
+		// Здесь матчится ТОЛЬКО подлинное превышение budget: per-stage таймауты
+		// возвращают ErrStageTimeout (не wrapping context.DeadlineExceeded) и
+		// до этой ветки не доходят — остаются resumable, а не терминал-бюджет.
 		if errors.Is(runErr, context.DeadlineExceeded) {
 			runErr = fmt.Errorf("run budget: превышен max_wall_time %s", budgetStr)
 		}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -176,6 +176,8 @@ type runState struct {
 	liveWorkspaceSHA string
 	loopbackCycles   int
 	deferredDelivery *deferredDelivery
+	budgetConfig     *config.BudgetConfig
+	usageTotal       runtime.Usage
 }
 
 // deferredDelivery (V0-9) — подготовленный canonical plan, чей commit/push/PR
@@ -601,6 +603,7 @@ func (p *Pipeline) RunWithResult(ctx context.Context, runCfg RunConfig) (RunResu
 		visits:           make(map[string]int),
 		candidate:        candidateManager,
 		sourceTarget:     sourceTarget,
+		budgetConfig:     p.cfg.Budget,
 	}
 	if len(resumeInvalidated) > 0 {
 		rs.loopbackCycles = 1
@@ -645,7 +648,21 @@ func (p *Pipeline) RunWithResult(ctx context.Context, runCfg RunConfig) (RunResu
 		rs.extraInputs[runCfg.retryFrom] = inputs
 	}
 
-	runErr := rs.execute(ctx)
+	// P1-7: жёсткий wall-time бюджет run'а (всегда, default 24h) поверх
+	// per-stage timeout-ов. Превышение → остановка run с явной причиной.
+	var runErr error
+	if budgetDur, budgetStr := rs.budgetConfig.EffectiveMaxWallTime(); budgetDur > 0 {
+		var cancel context.CancelFunc
+		var budgetCtx context.Context
+		budgetCtx, cancel = context.WithTimeout(ctx, budgetDur)
+		defer cancel()
+		runErr = rs.execute(budgetCtx)
+		if errors.Is(runErr, context.DeadlineExceeded) {
+			runErr = fmt.Errorf("run budget: превышен max_wall_time %s", budgetStr)
+		}
+	} else {
+		runErr = rs.execute(ctx)
+	}
 	outcome, finalErr := rs.finalize(runErr)
 	if finalErr != nil {
 		return RunResult{RunID: runID, Outcome: outcome}, finalErr

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -1908,11 +1908,33 @@ func TestRun_StageTimeout(t *testing.T) {
 	rt := newScripted()
 	rt.waitCtx["analyst"] = true
 
-	err, _ := runPipeline(t, dir,
-		cfgFor(config.AgentConfig{Name: "analyst", Timeout: "50ms"}),
-		rt, &scriptedPrompter{})
-	if err == nil || !strings.Contains(err.Error(), "превысил таймаут") {
-		t.Fatalf("ожидалась ошибка таймаута, got: %v", err)
+	cfg := cfgFor(config.AgentConfig{Name: "analyst", Timeout: "50ms"})
+	p := New(cfg, testRegistry(),
+		WithRuntimeFactory(rt.factory), WithPrompter(&scriptedPrompter{}))
+	result, err := p.RunWithResult(context.Background(), RunConfig{
+		Feature: "feat", TaskDesc: "тестовая задача", TargetDir: dir, ApproveGates: true,
+	})
+	if err == nil {
+		t.Fatal("ожидалась ошибка таймаута стадии")
+	}
+	// stage-timeout — resumable sentinel, а НЕ превышение run budget:
+	if !errors.Is(err, ErrStageTimeout) {
+		t.Fatalf("ожидался ErrStageTimeout, got: %v", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("stage-timeout не должен матчить context.DeadlineExceeded: %v", err)
+	}
+	if strings.Contains(err.Error(), "run budget") {
+		t.Fatalf("stage-timeout не должен превращаться в бюджет-ошибку: %v", err)
+	}
+	// resume сохраняет run identity (resumable, а не терминальный бюджет).
+	if result.RunID == "" {
+		t.Fatalf("stage-timeout должен быть resumable: %+v err=%v", result, err)
+	}
+	stateStore, _ := lifecycle.NewStore(dir)
+	state, loadErr := stateStore.Load(result.RunID)
+	if loadErr != nil || state.Phase != lifecycle.PhaseResumable {
+		t.Fatalf("stage-timeout должен перевести run в resumable: %+v err=%v", state, loadErr)
 	}
 }
 

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -164,6 +164,8 @@ type scriptedRuntime struct {
 	onExec    func(agentName string, inputs []runtime.Artifact)
 	calls     map[string]int
 	targetDir string
+	usage     *runtime.Usage
+	usagePer  map[string]*runtime.Usage
 }
 
 func newScripted() *scriptedRuntime {
@@ -180,10 +182,16 @@ func newScripted() *scriptedRuntime {
 
 func (r *scriptedRuntime) factory(string) (runtime.Runtime, error) { return r, nil }
 
+// Usage — UsageReporter для тестов (P1-7): имитирует attested usage.
+func (r *scriptedRuntime) Usage() *runtime.Usage { return r.usage }
+
 func (r *scriptedRuntime) Execute(ctx context.Context, a *runtime.Agent, task *runtime.Task, inputs []runtime.Artifact) error {
 	r.executed = append(r.executed, a.Name)
 	r.calls[a.Name]++
 	r.targetDir = task.TargetDir
+	if r.usagePer != nil {
+		r.usage = r.usagePer[a.Name]
+	}
 	if r.onExec != nil {
 		r.onExec(a.Name, inputs)
 	}

--- a/pkg/pipeline/stage.go
+++ b/pkg/pipeline/stage.go
@@ -26,6 +26,29 @@ import (
 // stage.go — исполнение одного этапа: runtime вызов, guard артефактов,
 // парсинг вердикта и сбор входов/выходов.
 
+// ErrStageTimeout — отдельный sentinel таймаута отдельной стадии. Намеренно
+// НЕ оборачивает context.DeadlineExceeded (в отличие от типовой ошибки),
+// чтобы бюджетный guard в pipeline.go (errors.Is(runErr, context.DeadlineExceeded))
+// не принимал таймаут стадии за превышение общего budget run'а и не превращал
+// resumable стадию в терминальную бюджет-ошибку.
+var ErrStageTimeout = errors.New("stage timeout")
+
+// stageTimeoutError — ошибка таймаута стадии. Реализует Is так, что матчится
+// только ErrStageTimeout, но не context.DeadlineExceeded → бюджетный guard
+// и resumable-переход finalize.go не путают её с подлинным превышением budget.
+type stageTimeoutError struct {
+	stage   string
+	timeout time.Duration
+}
+
+func (e *stageTimeoutError) Error() string {
+	return fmt.Sprintf("этап %s превысил таймаут %s", e.stage, e.timeout)
+}
+
+func (e *stageTimeoutError) Is(target error) bool {
+	return target == ErrStageTimeout
+}
+
 func (rs *runState) runStage(ctx context.Context, i int, name string) (r notifier.StageResult) {
 	stageStart := time.Now()
 	rs.attemptOrdinal++
@@ -252,7 +275,14 @@ func (rs *runState) runStage(ctx context.Context, i int, name string) (r notifie
 	}
 
 	if execErr != nil {
+		if stageCtx.Err() == context.DeadlineExceeded && timeout > 0 && ctx.Err() == nil {
+			// Исчерпан собственный per-stage таймаут, родительский (бюджетный)
+			// ctx жив → resumable sentinel, не матчащий context.DeadlineExceeded.
+			return fail(&stageTimeoutError{stage: name, timeout: timeout})
+		}
 		if stageCtx.Err() == context.DeadlineExceeded {
+			// Истёк родительский (бюджетный) ctx — подлинное превышение budget,
+			// сохраняем context.DeadlineExceeded для бюджетного guard'а.
 			return fail(fmt.Errorf("этап %s превысил таймаут %s: %w", name, timeout, context.DeadlineExceeded))
 		}
 		return fail(execErr)
@@ -391,6 +421,8 @@ func mergeChecks(base, overrides []checks.Definition) []checks.Definition {
 func (rs *runState) deriveStageState(result *notifier.StageResult) {
 	execution := workflow.ExecutionSucceeded
 	switch {
+	case errors.Is(result.Err, ErrStageTimeout):
+		execution = workflow.ExecutionTimedOut
 	case errors.Is(result.Err, context.Canceled):
 		execution = workflow.ExecutionCanceled
 	case errors.Is(result.Err, context.DeadlineExceeded):

--- a/pkg/pipeline/stage.go
+++ b/pkg/pipeline/stage.go
@@ -258,6 +258,17 @@ func (rs *runState) runStage(ctx context.Context, i int, name string) (r notifie
 		return fail(execErr)
 	}
 
+	// P1-7: usage принимается ТОЛЬКО от attested adapter (runtime.UsageReporter);
+	// бакетускается в общий usage envelope run'а.
+	if reporter, ok := stageRuntime.(runtime.UsageReporter); ok {
+		if u := reporter.Usage(); u != nil && u.Attested {
+			rs.usageTotal.Attested = true
+			rs.usageTotal.TokensInput += u.TokensInput
+			rs.usageTotal.TokensOutput += u.TokensOutput
+			rs.usageTotal.CostUSD += u.CostUSD
+		}
+	}
+
 	outputs, err := rs.collectOutputs(a, name)
 	r.Outputs = outputs
 	if err != nil {

--- a/pkg/runtime/agentcli.go
+++ b/pkg/runtime/agentcli.go
@@ -24,7 +24,16 @@ const DefaultCLI = "opencode"
 // запуска процесса и логирования. Путь к харнессу и изоляция выбираются из
 // реестра адаптеров по имени бинарника (CLI). Никакой opencode-специфики в
 // этом типе нет — только контракт RuntimeAdapter.
-type AgentCLIRuntime struct{}
+type AgentCLIRuntime struct {
+	lastUsage *Usage
+}
+
+// Usage возвращает attested usage последнего успешного Execute (nil, если
+// адаптер не аттестует usage или разбор не удался). Удовлетворяет
+// UsageReporter (P1-7): tokens/cost принимаются только от attested источника.
+func (r *AgentCLIRuntime) Usage() *Usage {
+	return r.lastUsage
+}
 
 func (r *AgentCLIRuntime) Execute(ctx context.Context, agent *Agent, task *Task, inputs []Artifact) error {
 	cli := agent.CLI
@@ -127,6 +136,18 @@ func (r *AgentCLIRuntime) Execute(ctx context.Context, agent *Agent, task *Task,
 			return fmt.Errorf("агент %s: %w", agent.Name, classifier.ClassifyError(output))
 		}
 		return fmt.Errorf("агент %s завершился с ошибкой: %w", agent.Name, err)
+	}
+
+	// P1-7: usage принимается ТОЛЬКО от адаптера с attested usage-reported
+	// (UsageSource); при ошибке разбора молча пропускаем (usage остаётся
+	// unknown), не проваливая успешный run.
+	if source, ok := adapter.(UsageSource); ok {
+		output := capturedStdout.String()
+		if u, err := source.ParseUsage(strings.NewReader(output)); err == nil && u != nil && u.Attested {
+			r.lastUsage = u
+		} else {
+			r.lastUsage = nil
+		}
 	}
 
 	return nil

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -15,6 +15,14 @@ type Runtime interface {
 	Execute(ctx context.Context, agent *Agent, task *Task, inputs []Artifact) error
 }
 
+// UsageReporter — опциональный интерфейс runtime: после успешного Execute
+// отдаёт attested usage-данные (tokens/cost), принятые ТОЛЬКО от адаптера с
+// capability usage-reported (P1-7). Возвращает nil, если источник не
+// аттестован или usage не получен.
+type UsageReporter interface {
+	Usage() *Usage
+}
+
 // Artifact is kept as a compatibility alias; the domain type lives in workflow.
 type Artifact = workflow.Artifact
 


### PR DESCRIPTION
Свежий PR на базе текущего master (HANDOFF workflow), заменяет закрытый #68.

## Изменения (P1-7 budget guard)
- Hard run budget (max_wall_time) + attested usage truthfulness.

## Blocker-фикс (R2)
- Stage-timeout больше НЕ маскируется под budget breach. Введён отдельный sentinel `ErrStageTimeout` (type `stageTimeoutError` c кастомным `Is`), который НЕ оборачивает `context.DeadlineExceeded`. Бюджетный guard (`errors.Is(runErr, context.DeadlineExceeded)`) теперь срабатывает ТОЛЬКО на подлинное превышение budget (родительский budgetCtx мёртв), а per-stage timeout остаётся resumable.
- Разведены причины: per-stage timeout (parent жив) → resumable `ErrStageTimeout`; genuine budget breach → прежний message.
- `TestRun_StageTimeout` переписан: `errors.Is(err, ErrStageTimeout)` true, `errors.Is(err, context.DeadlineExceeded)` false, `Phase == PhaseResumable`, нет 'run budget' в message.
- finalize: `ErrStageTimeout` теперь сохраняется как `PhaseResumable` (не terminal).

## Детали
- Branch rebased на master HEAD 493d586 (после #86).
- Коммиты: 053bd37 (feature) + 718a051 (R2 fix).
- gofmt clean; pipeline/metrics тесты зелёные (вкл. полный go test ./...).