### PR TITLE
P1-6 privacy redaction contract + fail-closed export block + retention (R2 review fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ non-interactive режиме: он сохраняет запрос решени�
 | `ai-team worker --target <dir> --db <path>` | исполнить один strict worker job из stdin (обычно вызывается launcher-ом) |
 | `ai-team list` | список доступных агентов (имя, runtime, источник в layered registry) |
 | `ai-team ci-import [--target <dir>] [--format github-actions]` | импортировать ограниченный объяснимый набор checks из project CI (GitHub Actions) без исполнения произвольного YAML; показывает effective suite и fingerprint перед запуском |
-| `ai-team redact verify\|scan\|redact [--target <dir>] [--run <id>] [--path <rel>]` | P1-6 privacy-контракт: secrets-скан evidence, fail-closed verify для экспорта или detached-копия с заменой секретов на `[REDACTED:...]` |
+| `ai-team redact <verify\|scan\|redact> [--target <dir>] [--run <id>] [--path <rel>] [--out <dir>]` | P1-6 privacy-контракт: secrets-скан evidence (subcommand — перед флагами), fail-closed verify для экспорта или detached-копия с заменой секретов на `[REDACTED:...]` (--out вне source) |
 | `ai-team gate --target <dir> --base <ref> --candidate <ref|WORKTREE> [--config <file>] [--out <dir>]` | детерминированный diff-policy вердикт + typed checks + attestation bundle; exit 0/1/2 |
 | `ai-team export [--target <dir>] [--out <path>] <run_id>` | собрать проверенный portable bundle терминального run |
 | `ai-team verify <bundle-dir>` / `verify --target <dir> <run_id>` | самодостаточная проверка run-/gate-bundle или локальной evidence |

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ non-interactive режиме: он сохраняет запрос решени�
 | `ai-team worker --target <dir> --db <path>` | исполнить один strict worker job из stdin (обычно вызывается launcher-ом) |
 | `ai-team list` | список доступных агентов (имя, runtime, источник в layered registry) |
 | `ai-team ci-import [--target <dir>] [--format github-actions]` | импортировать ограниченный объяснимый набор checks из project CI (GitHub Actions) без исполнения произвольного YAML; показывает effective suite и fingerprint перед запуском |
+| `ai-team redact verify\|scan\|redact [--target <dir>] [--run <id>] [--path <rel>]` | P1-6 privacy-контракт: secrets-скан evidence, fail-closed verify для экспорта или detached-копия с заменой секретов на `[REDACTED:...]` |
 | `ai-team gate --target <dir> --base <ref> --candidate <ref|WORKTREE> [--config <file>] [--out <dir>]` | детерминированный diff-policy вердикт + typed checks + attestation bundle; exit 0/1/2 |
 | `ai-team export [--target <dir>] [--out <path>] <run_id>` | собрать проверенный portable bundle терминального run |
 | `ai-team verify <bundle-dir>` / `verify --target <dir> <run_id>` | самодостаточная проверка run-/gate-bundle или локальной evidence |

--- a/cmd/ai-team/export.go
+++ b/cmd/ai-team/export.go
@@ -10,6 +10,7 @@ import (
 	"github.com/arturpanteleev/ai-team/pkg/dsse"
 	"github.com/arturpanteleev/ai-team/pkg/export"
 	"github.com/arturpanteleev/ai-team/pkg/logging"
+	"github.com/arturpanteleev/ai-team/pkg/redact"
 )
 
 // cmdExport собирает проверенный portable bundle терминального run (V0-4):
@@ -50,6 +51,29 @@ func cmdExport() {
 	runDir := filepath.Join(absolute, ".ai-team", "runs", runID)
 	if _, err := os.Stat(filepath.Join(runDir, "anchor.json")); err != nil {
 		fatal("run %s не является терминальным (нет anchor.json): %v", runID, err)
+	}
+
+	// P1-6: обязательный fail-closed блокер перед внешней публикацией bundle.
+	// Secrets-скан evidence run'а; при находках (и политике по умолчанию)
+	// экспорт отклоняется. From config: redaction.include/exclude +
+	// redaction.disable_export_block. Отсутствие конфига — default-политика.
+	cfg, cfgErr := loadPolicyConfig(absolute)
+	if cfgErr != nil {
+		fatal("Ошибка загрузки конфига: %v", cfgErr)
+	}
+	policy := redactionPolicy(cfg)
+	scanRoot := runDir
+	report, redactErr := redact.Verify(scanRoot, policy)
+	if redactErr != nil {
+		fmt.Fprintf(os.Stderr, "✗ Export blocked: evidence run %s содержит секреты: %v\n", runID, redactErr)
+		logging.Emit(logging.Record{Level: "error", Command: "export", Type: "redact_block",
+			Message: redactErr.Error(), Data: map[string]any{"run_id": runID, "blocked": true}})
+		fatal("Экспорт заблокирован: redaction не прошла (см. ai-team redact verify --run %s)", runID)
+	}
+	if len(report.Violations) > 0 {
+		logging.Emit(logging.Record{Level: "warn", Command: "export", Type: "redact_findings",
+			Message: "Секреты найдены, но политика разрешает экспорт",
+			Data:    map[string]any{"run_id": runID, "violations": len(report.Violations)}})
 	}
 
 	outDir := *out

--- a/cmd/ai-team/export.go
+++ b/cmd/ai-team/export.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/ed25519"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"

--- a/cmd/ai-team/export.go
+++ b/cmd/ai-team/export.go
@@ -62,6 +62,9 @@ func cmdExport() {
 		fatal("Ошибка загрузки конфига: %v", cfgErr)
 	}
 	policy := redactionPolicy(cfg)
+	// SF3: include/exclude glob'ы документированы repository-relative — матчим
+	// их от корня репозитория, а не от суженного корня (каталог одного run).
+	policy.RepoRoot = absolute
 	scanRoot := runDir
 	report, redactErr := redact.Verify(scanRoot, policy)
 	if redactErr != nil {

--- a/cmd/ai-team/gc.go
+++ b/cmd/ai-team/gc.go
@@ -46,6 +46,9 @@ func cmdGC() {
 		}
 		cfg = &config.Config{}
 	}
+	if err := cfg.Retention.Validate(); err != nil {
+		fatal("Ошибка retention-конфига: %v", err)
+	}
 	flagVisited := map[string]bool{}
 	flags.Visit(func(f *flag.Flag) { flagVisited[f.Name] = true })
 	if !flagVisited["older-than"] {

--- a/cmd/ai-team/gc.go
+++ b/cmd/ai-team/gc.go
@@ -4,10 +4,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/arturpanteleev/ai-team/pkg/config"
 	"github.com/arturpanteleev/ai-team/pkg/evidence"
 	"github.com/arturpanteleev/ai-team/pkg/retention"
 )
@@ -33,6 +35,32 @@ func cmdGC() {
 		fatal("Ошибка target: %v", err)
 	}
 	requireControlRoot(absTarget)
+
+	// P1-6: retention-контракт настраивается в config (retention).
+	// Явные CLI-флаги имеют приоритет над конфигом. Отсутствие config.yaml —
+	// канонические дефолты.
+	cfg, cfgErr := config.Load(filepath.Join(absTarget, ".ai-team", "config.yaml"))
+	if cfgErr != nil {
+		if _, statErr := os.Stat(filepath.Join(absTarget, ".ai-team", "config.yaml")); !os.IsNotExist(statErr) {
+			fatal("Ошибка загрузки конфига: %v", cfgErr)
+		}
+		cfg = &config.Config{}
+	}
+	flagVisited := map[string]bool{}
+	flags.Visit(func(f *flag.Flag) { flagVisited[f.Name] = true })
+	if !flagVisited["older-than"] {
+		d, err := cfg.Retention.EffectiveOlderThanDuration()
+		if err != nil {
+			fatal("retention.older_than: %v", err)
+		}
+		*olderThan = d
+	}
+	if !flagVisited["keep-last"] {
+		*keepLast = cfg.Retention.EffectiveKeepLast()
+	}
+	if cfg.Retention != nil && cfg.Retention.PruneRuns {
+		*pruneRuns = true
+	}
 
 	// gc мутирует control-каталог — как pipeline, он обязан держать
 	// workspace lock и отказываться работать при параллельном run.

--- a/cmd/ai-team/main.go
+++ b/cmd/ai-team/main.go
@@ -82,6 +82,8 @@ func main() {
 		cmdList()
 	case "ci-import":
 		cmdCIImport()
+	case "redact":
+		cmdRedact()
 	case "usage":
 		cmdUsage()
 	case "export":
@@ -122,6 +124,9 @@ func printUsage() {
   ai-team scheduler-worker         Claim и выполнить job из persistent queue
   ai-team list                     Список доступных агентов
   ai-team usage <run_id>           Usage-сводка завершённого run (этапы, попытки, время)
+  ai-team redact verify|scan|redact   P1-6 redaction-контракт: сеcrets-скан evidence,
+                                   verify (fail-closed для экспорта) или detached-копия
+                                   с заменой секретов на [REDACTED:...]
   ai-team export <run_id>          Собрать проверенный portable bundle терминального run
                                    (whitelisted typed records и digests; публикует
                                    verified-запись state/exports)

--- a/cmd/ai-team/redact.go
+++ b/cmd/ai-team/redact.go
@@ -38,6 +38,18 @@ func loadPolicyConfig(target string) (*config.Config, error) {
 	return config.Load(cfgPath)
 }
 
+// resolveScanPath резолвит repository-относительный --path внутри корня
+// сканирования и проверяет, что результат не выходит за его пределы
+// (контентный guard, аналог validRunID для --run — защита от ../..-обхода).
+func resolveScanPath(base, pathArg string) (string, error) {
+	joined := filepath.Join(base, strings.TrimPrefix(filepath.FromSlash(pathArg), "./"))
+	rel, err := filepath.Rel(base, joined)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("--path %q выходит за пределы корня сканирования", pathArg)
+	}
+	return joined, nil
+}
+
 // cmdRedact — P1-6 privacy-контракт:
 //
 //	ai-team redact verify --target <dir> [--run <id>]
@@ -99,7 +111,10 @@ func cmdRedact() {
 		scanRoot = filepath.Join(scanRoot, *runID)
 	}
 	if *pathArg != "" {
-		scanRoot = filepath.Join(scanRoot, strings.TrimPrefix(filepath.FromSlash(*pathArg), "./"))
+		scanRoot, err = resolveScanPath(scanRoot, *pathArg)
+		if err != nil {
+			fatal("%v", err)
+		}
 	}
 
 	// SF4: относительный --out резолвится от target, а не от CWD (match README);

--- a/cmd/ai-team/redact.go
+++ b/cmd/ai-team/redact.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arturpanteleev/ai-team/pkg/config"
+	"github.com/arturpanteleev/ai-team/pkg/logging"
+	"github.com/arturpanteleev/ai-team/pkg/redact"
+)
+
+// redactionPolicy собирает policy из redaction-секции конфига (nil-конфиг —
+// канонические fail-closed дефолты): include/exclude + disable_export_block.
+func redactionPolicy(cfg *config.Config) redact.Policy {
+	policy := redact.Policy{FailOnSecrets: true}
+	if cfg != nil && cfg.Redaction != nil {
+		policy.Include = cfg.Redaction.Include
+		policy.Exclude = cfg.Redaction.Exclude
+		policy.FailOnSecrets = cfg.Redaction.EffectiveFailExportOnSecrets()
+	}
+	return policy
+}
+
+// loadPolicyConfig грузит .ai-team/config.yaml; при отсутствии файла отдаёт
+// пустой конфиг (дефолт-политика), а не ошибку.
+func loadPolicyConfig(target string) (*config.Config, error) {
+	cfgPath := filepath.Join(target, ".ai-team", "config.yaml")
+	if _, err := os.Lstat(cfgPath); err != nil {
+		if os.IsNotExist(err) {
+			return &config.Config{}, nil
+		}
+		return nil, err
+	}
+	return config.Load(cfgPath)
+}
+
+// cmdRedact — P1-6 privacy-контракт:
+//
+//	ai-team redact verify --target <dir> [--run <id>] [-json listed]
+//	ai-team redact scan   --target <dir> [--path <rel>]
+//	ai-team redact redact --target <dir> --out <dir> [--path <rel>]
+func cmdRedact() {
+	redactFlags := flag.NewFlagSet("redact", flag.ExitOnError)
+	target := redactFlags.String("target", ".", "Путь к целевому проекту")
+	runID := redactFlags.String("run", "", "Ограничить скан одним run (run_id)")
+	pathArg := redactFlags.String("path", "", "Ограничить скан repository-относительным путём")
+	outDir := redactFlags.String("out", ".ai-team/redacted", "Каталог для redaction-копии (для redact)")
+	redactFlags.Parse(os.Args[2:])
+
+	if redactFlags.NArg() != 1 {
+		fatal("Использование: ai-team redact < verify | scan | redact > [--target <dir>] [--run <id>] [--path <rel>]")
+	}
+	absolute, err := absoluteTarget(*target)
+	if err != nil {
+		fatal("Ошибка target: %v", err)
+	}
+	*target = absolute
+	requireControlRoot(*target)
+
+	cfg, err := loadPolicyConfig(*target)
+	if err != nil {
+		fatal("Ошибка загрузки конфига: %v", err)
+	}
+	policy := redactionPolicy(cfg)
+
+	scanRoot, err := redactRoot(*target)
+	if err != nil {
+		fatal("%v", err)
+	}
+	if *runID != "" {
+		if !validRunID(*runID) {
+			fatal("недопустимый run_id %q", *runID)
+		}
+		scanRoot = filepath.Join(scanRoot, *runID)
+	}
+	if *pathArg != "" {
+		scanRoot = filepath.Join(scanRoot, strings.TrimPrefix(filepath.FromSlash(*pathArg), "./"))
+	}
+
+	switch redactFlags.Arg(0) {
+	case "verify":
+		report, err := redact.Verify(scanRoot, policy)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "✗ Redaction %s: %v\n", scanRoot, err)
+			logging.Emit(logging.Record{Level: "error", Command: "redact", Type: "redact_verify",
+				Message: err.Error(), Data: redactReportData(report)})
+			os.Exit(exitFailed)
+		}
+		fmt.Printf("✓ Redaction %s: clean (%d файлов)\n", scanRoot, report.Files)
+		logging.Emit(logging.Record{Level: "ok", Command: "redact", Type: "redact_verify",
+			Message: "Redaction clean", Data: redactReportData(report), Exit: exitOK})
+	case "scan":
+		found, scanned, total, err := redact.ScanDir(scanRoot, policy)
+		if err != nil {
+			fatal("Ошибка скана: %v", err)
+		}
+		report := redact.Report{Files: scanned, Bytes: total, Verdict: "clean"}
+		for _, f := range found {
+			report.Violations = append(report.Violations, redact.Violation{Path: f.Path, Findings: f.Findings})
+		}
+		if len(report.Violations) > 0 {
+			for _, v := range report.Violations {
+				for _, f := range v.Findings {
+					fmt.Printf("  %s:%d %s (%s)\n", v.Path, f.Line, f.Matched, f.Reason)
+				}
+			}
+		}
+		logging.Emit(logging.Record{Level: "ok", Command: "redact", Type: "redact_scan",
+			Message: fmt.Sprintf("Scan: %d files, %d findings", scanned, len(report.Violations)),
+			Data:    redactReportData(&report), Exit: exitOK})
+	case "redact":
+		applyRedact(scanRoot, *outDir, policy)
+	default:
+		fatal("Неизвестная подкоманда redact: %s", redactFlags.Arg(0))
+	}
+}
+
+func applyRedact(source, out string, policy redact.Policy) {
+	if _, err := os.Stat(source); err != nil {
+		fatal("redact: источник не найден: %v", err)
+	}
+	if !filepath.IsAbs(out) {
+		abs, err := filepath.Abs(out)
+		if err != nil {
+			fatal("redact: out path: %v", err)
+		}
+		out = abs
+	}
+	if _, err := os.Stat(out); err == nil {
+		fatal("redact: целевой каталог уже существует: %s", out)
+	}
+	if err := os.MkdirAll(out, 0755); err != nil {
+		fatal("redact: создание out: %v", err)
+	}
+	var files, redacted, total int64
+	walkErr := filepath.WalkDir(source, func(p string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(source, p)
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return os.MkdirAll(filepath.Join(out, rel), 0755)
+		}
+		if entry.Type()&fs.ModeSymlink != 0 || entry.Type()&(fs.ModeDevice|fs.ModeNamedPipe|fs.ModeSocket) != 0 {
+			return nil
+		}
+		if !policy.Applies(filepath.ToSlash(rel)) {
+			return nil
+		}
+		findings, err := redact.ScanFile(p, policy.MaxBytes)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(out, rel)
+		if len(findings) == 0 {
+			return copyRegular(p, target)
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(target, redact.RedactFile(data), 0600); err != nil {
+			return err
+		}
+		redacted++
+		files++
+		total += int64(len(data))
+		return nil
+	})
+	if walkErr != nil {
+		fatal("redact: %v", walkErr)
+	}
+	fmt.Printf("✓ Redacted %s → %s (%d файлов, из них redacted %d)\n", source, out, files, redacted)
+	logging.Emit(logging.Record{Level: "ok", Command: "redact", Type: "redact_apply",
+		Message: "Redaction применена", Data: map[string]any{"source": source, "out": out,
+			"files": files, "redacted": redacted, "bytes": total}, Exit: exitOK})
+}
+
+func copyRegular(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0644)
+}
+
+func redactReportData(report *redact.Report) map[string]any {
+	if report == nil {
+		return map[string]any{"verdict": "error"}
+	}
+	return map[string]any{
+		"verdict":    report.Verdict,
+		"files":      report.Files,
+		"bytes":      report.Bytes,
+		"violations": len(report.Violations),
+	}
+}
+
+// redactRoot — корень сканирования: .ai-team/runs, если он есть, иначе target.
+func redactRoot(target string) (string, error) {
+	runs := filepath.Join(target, ".ai-team", "runs")
+	if _, err := os.Stat(runs); err == nil {
+		return runs, nil
+	}
+	return target, nil
+}
+
+func validRunID(id string) bool {
+	if id == "" || id == "." || id == ".." || id != filepath.Base(id) {
+		return false
+	}
+	return !strings.ContainsAny(id, `/\:`+"*?[]{}")
+}

--- a/cmd/ai-team/redact.go
+++ b/cmd/ai-team/redact.go
@@ -40,19 +40,37 @@ func loadPolicyConfig(target string) (*config.Config, error) {
 
 // cmdRedact — P1-6 privacy-контракт:
 //
-//	ai-team redact verify --target <dir> [--run <id>] [-json listed]
+//	ai-team redact verify --target <dir> [--run <id>]
 //	ai-team redact scan   --target <dir> [--path <rel>]
 //	ai-team redact redact --target <dir> --out <dir> [--path <rel>]
+//
+// Подкоманда (verify|scan|redact) — первый позиционный аргумент; её нужно
+// вынуть ДО flag.Parse, иначе Go-flag остановится на первом не-флаге и
+// задокументированная форма `redact verify --target <dir>` не разберёт флаги.
 func cmdRedact() {
+	sub := ""
+	rest := os.Args[2:]
+	if len(rest) > 0 && !strings.HasPrefix(rest[0], "-") {
+		sub = rest[0]
+		rest = rest[1:]
+	}
+
 	redactFlags := flag.NewFlagSet("redact", flag.ExitOnError)
 	target := redactFlags.String("target", ".", "Путь к целевому проекту")
 	runID := redactFlags.String("run", "", "Ограничить скан одним run (run_id)")
 	pathArg := redactFlags.String("path", "", "Ограничить скан repository-относительным путём")
 	outDir := redactFlags.String("out", ".ai-team/redacted", "Каталог для redaction-копии (для redact)")
-	redactFlags.Parse(os.Args[2:])
+	if err := redactFlags.Parse(rest); err != nil {
+		fatal("Ошибка аргументов redact: %v", err)
+	}
+	if redactFlags.NArg() != 0 {
+		fatal("Неожиданные аргументы redact: %s", strings.Join(redactFlags.Args(), " "))
+	}
 
-	if redactFlags.NArg() != 1 {
-		fatal("Использование: ai-team redact < verify | scan | redact > [--target <dir>] [--run <id>] [--path <rel>]")
+	switch sub {
+	case "verify", "scan", "redact":
+	default:
+		fatal("Использование: ai-team redact < verify | scan | redact > [--target <dir>] [--run <id>] [--path <rel>] [--out <dir>]")
 	}
 	absolute, err := absoluteTarget(*target)
 	if err != nil {
@@ -66,6 +84,9 @@ func cmdRedact() {
 		fatal("Ошибка загрузки конфига: %v", err)
 	}
 	policy := redactionPolicy(cfg)
+	// SF3: include/exclude glob'ы документированы repository-relative — матчим
+	// их от корня репозитория, а не от суженного корня сканирования.
+	policy.RepoRoot = *target
 
 	scanRoot, err := redactRoot(*target)
 	if err != nil {
@@ -81,7 +102,16 @@ func cmdRedact() {
 		scanRoot = filepath.Join(scanRoot, strings.TrimPrefix(filepath.FromSlash(*pathArg), "./"))
 	}
 
-	switch redactFlags.Arg(0) {
+	// SF4: относительный --out резолвится от target, а не от CWD (match README);
+	// default .ai-team/redacted — каталог внутри target, но вне evidence-корня.
+	if *outDir == "" {
+		fatal("redact: --out обязателен для подкоманды redact")
+	}
+	if !filepath.IsAbs(*outDir) {
+		*outDir = filepath.Join(*target, *outDir)
+	}
+
+	switch sub {
 	case "verify":
 		report, err := redact.Verify(scanRoot, policy)
 		if err != nil {
@@ -113,28 +143,39 @@ func cmdRedact() {
 			Message: fmt.Sprintf("Scan: %d files, %d findings", scanned, len(report.Violations)),
 			Data:    redactReportData(&report), Exit: exitOK})
 	case "redact":
-		applyRedact(scanRoot, *outDir, policy)
-	default:
-		fatal("Неизвестная подкоманда redact: %s", redactFlags.Arg(0))
+		if err := applyRedact(scanRoot, *outDir, policy); err != nil {
+			fatal("redact: %v", err)
+		}
 	}
 }
 
-func applyRedact(source, out string, policy redact.Policy) {
+func applyRedact(source, out string, policy redact.Policy) error {
 	if _, err := os.Stat(source); err != nil {
-		fatal("redact: источник не найден: %v", err)
+		return fmt.Errorf("источник не найден: %v", err)
 	}
+	absSource, err := filepath.Abs(source)
+	if err != nil {
+		return fmt.Errorf("source path: %v", err)
+	}
+	source = absSource
 	if !filepath.IsAbs(out) {
 		abs, err := filepath.Abs(out)
 		if err != nil {
-			fatal("redact: out path: %v", err)
+			return fmt.Errorf("out path: %v", err)
 		}
 		out = abs
 	}
+	// SF4: запретить out внутри source — иначе WalkDir рекурсивно спиралит по
+	// создаваемой redacted-копии (излюбленный путь к бесконечному циклу).
+	rel, err := filepath.Rel(source, out)
+	if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("--out (%s) не может лежать внутри источника (%s)", out, source)
+	}
 	if _, err := os.Stat(out); err == nil {
-		fatal("redact: целевой каталог уже существует: %s", out)
+		return fmt.Errorf("целевой каталог уже существует: %s", out)
 	}
 	if err := os.MkdirAll(out, 0755); err != nil {
-		fatal("redact: создание out: %v", err)
+		return fmt.Errorf("создание out: %v", err)
 	}
 	var files, redacted, total int64
 	walkErr := filepath.WalkDir(source, func(p string, entry fs.DirEntry, walkErr error) error {
@@ -151,7 +192,13 @@ func applyRedact(source, out string, policy redact.Policy) {
 		if entry.Type()&fs.ModeSymlink != 0 || entry.Type()&(fs.ModeDevice|fs.ModeNamedPipe|fs.ModeSocket) != 0 {
 			return nil
 		}
-		if !policy.Applies(filepath.ToSlash(rel)) {
+		// SF3: include/exclude — repository-relative (от policy.RepoRoot),
+		// а не от суженного корня сканирования.
+		matcherRel, matcherErr := redact.PolicyRel(policy.RepoRoot, source, p)
+		if matcherErr != nil {
+			return matcherErr
+		}
+		if !policy.Applies(matcherRel) {
 			return nil
 		}
 		findings, err := redact.ScanFile(p, policy.MaxBytes)
@@ -175,12 +222,13 @@ func applyRedact(source, out string, policy redact.Policy) {
 		return nil
 	})
 	if walkErr != nil {
-		fatal("redact: %v", walkErr)
+		return walkErr
 	}
 	fmt.Printf("✓ Redacted %s → %s (%d файлов, из них redacted %d)\n", source, out, files, redacted)
 	logging.Emit(logging.Record{Level: "ok", Command: "redact", Type: "redact_apply",
 		Message: "Redaction применена", Data: map[string]any{"source": source, "out": out,
 			"files": files, "redacted": redacted, "bytes": total}, Exit: exitOK})
+	return nil
 }
 
 func copyRegular(src, dst string) error {

--- a/cmd/ai-team/redact_integration_test.go
+++ b/cmd/ai-team/redact_integration_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arturpanteleev/ai-team/pkg/redact"
+)
+
+// TestRedactVerifyBlocksOnSecrets — интеграционная проверка fail-closed
+// политики (P1-6): verify над evidence run'а при секрете возвращает ошибку.
+func TestRedactVerifyBlocksOnSecrets(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, ".ai-team", "runs", "run-1")
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "events.jsonl"),
+		[]byte("{\"prompt\":\"token="+"ghp_"+strings.Repeat("4", 36)+"\"}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := redact.Policy{FailOnSecrets: true}
+	if _, err := redact.Verify(runDir, policy); err == nil {
+		t.Fatal("fail-closed verify должен вернуть ошибку при секрете")
+	}
+}
+
+// TestExportRefusesSecretsUsesPolicy — блокирующая логика экспорта держится
+// на Verified политике: при disable_export_block скан позволяет экспорт.
+func TestExportRefusesSecretsUsesPolicy(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, ".ai-team", "runs", "run-1")
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "events.jsonl"),
+		[]byte("password=Yv3sM3Yl0n9WxQ2aB1cD4eF6g\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := redact.Policy{FailOnSecrets: false}
+	report, err := redact.Verify(runDir, policy)
+	if err != nil {
+		t.Fatalf("с FailOnSecrets=false verify не должен фейлить: %v", err)
+	}
+	if report == nil || len(report.Violations) == 0 {
+		t.Fatal("ожидалась зарегистрированная violation при выключенном блокере")
+	}
+}

--- a/cmd/ai-team/redact_integration_test.go
+++ b/cmd/ai-team/redact_integration_test.go
@@ -50,3 +50,66 @@ func TestExportRefusesSecretsUsesPolicy(t *testing.T) {
 		t.Fatal("ожидалась зарегистрированная violation при выключенном блокере")
 	}
 }
+
+// TestRedactCommandRedactsHappyPath — CLI-путь `redact redact` через
+// applyRedact (Policy.MaxBytes==0 по умолчанию) должен работать: файл с
+// секретом даёт redaction-копию, чистый файл копируется без изменений.
+func TestRedactCommandRedactsHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "evidence")
+	if err := os.MkdirAll(source, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "secret.txt"),
+		[]byte("GITHUB_TOKEN="+"ghp_"+strings.Repeat("1", 36)+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "clean.txt"),
+		[]byte("обычный текст\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(dir, "redacted")
+	if err := applyRedact(source, out, redact.Policy{}); err != nil {
+		t.Fatalf("applyRedact: %v", err)
+	}
+
+	secretOut, err := os.ReadFile(filepath.Join(out, "secret.txt"))
+	if err != nil {
+		t.Fatalf("ожидалась redaction-копия secret.txt: %v", err)
+	}
+	if strings.Contains(string(secretOut), "ghp_") {
+		t.Errorf("секрет не был заменён в копии: %q", secretOut)
+	}
+	if !strings.Contains(string(secretOut), "[REDACTED:github token]") {
+		t.Errorf("ожидался маркер замены, got: %q", secretOut)
+	}
+	cleanOut, err := os.ReadFile(filepath.Join(out, "clean.txt"))
+	if err != nil {
+		t.Fatalf("ожидалась копия clean.txt: %v", err)
+	}
+	if string(cleanOut) != "обычный текст\n" {
+		t.Errorf("чистый файл должен копироваться без изменений, got %q", cleanOut)
+	}
+}
+
+// TestApplyRedactRejectsOutInsideSource — SF4: --out внутри источника должен
+// отклоняться сразу (иначе WalkDir спиралит по создаваемой копии).
+func TestApplyRedactRejectsOutInsideSource(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "evidence")
+	if err := os.MkdirAll(source, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "x.txt"),
+		[]byte("GITHUB_TOKEN="+"ghp_"+strings.Repeat("2", 36)+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(source, "redacted")
+	if err := os.MkdirAll(out, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyRedact(source, out, redact.Policy{}); err == nil {
+		t.Fatal("applyRedact должен вернуть ошибку при out внутри source")
+	}
+}

--- a/cmd/ai-team/redact_integration_test.go
+++ b/cmd/ai-team/redact_integration_test.go
@@ -113,3 +113,18 @@ func TestApplyRedactRejectsOutInsideSource(t *testing.T) {
 		t.Fatal("applyRedact должен вернуть ошибку при out внутри source")
 	}
 }
+
+// TestResolveScanPathRejectsTraversal — --path не должен выходить за пределы
+// корня сканирования (../..-обход блокируется).
+func TestResolveScanPathRejectsTraversal(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "scan")
+	want := filepath.Join(base, "sub", "file.txt")
+	if got, err := resolveScanPath(base, "sub/file.txt"); err != nil || got != want {
+		t.Fatalf("resolveScanPath(sub/file.txt) = %q, %v; want %q", got, err, want)
+	}
+	for _, malformed := range []string{"..", "../..", "../../etc", "a/../../etc"} {
+		if got, err := resolveScanPath(base, malformed); err == nil {
+			t.Errorf("resolveScanPath(%q) = %q, ожидалась ошибка (выход за корень)", malformed, got)
+		}
+	}
+}

--- a/openspec/changes/redaction-retention-contract/design.md
+++ b/openspec/changes/redaction-retention-contract/design.md
@@ -1,0 +1,68 @@
+# Redaction + retention contract (P1-6) — design
+
+## Проблема
+
+Evidence хранит агентский вывод и снапшоты конфигов/workflow. Secrets-скан
++ redaction обязательны перед внешней публикацией (bundle, SIEM, архив).
+Retention (уборка .ai-team) уже есть в `pkg/retention`/`ai-team gc`, но не
+настраивается из config и не оформлена как контракт без legal-обещаний.
+
+## Requirements
+
+- Field classification: `secret`/`internal`/`public` по имени поля.
+- Консервативный сканер: известные префиксы ключей + assignment-паттерны;
+  без ложных срабатываний на плейсхолдеры (`<...>`, `example`, env-ссылки `$X`).
+- include/exclude glob'ы в repository-относительном формате (`pkg/scope`).
+- `redact verify` — fail-closed; `export` блокируется при находках (по умолчанию;
+  opt-out `disable_export_block`).
+- Retention настраивается в config; `ai-team gc` берёт дефолты, явные флаги
+  переопределяют.
+- Raw logs — opt-in; никогда не сохраняются без `redaction.raw_logs: true`.
+
+## Design
+
+### pkg/redact
+
+- `scanner.go`: `Scan(data []byte) []Finding`; правила — private key block, AWS
+  AKIA/ASIA, GitHub ghp_..., OpenAI sk-, Slack xox*, Google AIza, JWT eyJ, basic
+  auth URL, secret assignment (ключей password/secret/token/api_key/access_key/
+  private_key/client_secret/signing_key). Assignment-правило фильтруется
+  `likelySecretValue`: len>=16 + uppercase + digit; reject плейсхолдеры
+  ("example","placeholder","changeme","your-"), `<...>`, `${...}`, `$VAR`.
+  Детерминированная сортировка результатов (line, reason, matched).
+  `ClassifyField(name) FieldClass` — документированная таблица.
+  `IsBinary`/`ScanFile` (safeio no-follow, лимит 8 MiB).
+- `policy.go`: `Policy{Include,Exclude,FailOnSecrets,MaxBytes,SkipBinary}`,
+  `Applies(rel)` через `scope.MatchAny`, `Validate` через `scope.Validate`.
+- `verify.go`: `ScanDir` (WalkDir без симлинков/special), `Verify` →
+  `Report{Verdict, Files, Bytes, Violations}`, ошибка при violations и
+  FailOnSecrets. `RedactFile` — построчная замена `[REDACTED:reason]`.
+
+### Config
+
+`redaction` (include/exclude, raw_logs, disable_export_block) и `retention`
+(older_than, keep_last, prune_runs) с Validate, allowlist/rawConfig/assignment.
+`EffectiveFailExportOnSecrets` = включён по умолчанию, только явный
+`disable_export_block: true` отключает. `EffectiveOlderThanDuration`/`KeepLast`
+nil-safe дефолты 720h/20.
+
+### CLI
+
+- `ai-team redact verify|scan|redact` — новый command-файл; policy из config;
+  scan-root = `.ai-team/runs` (или `--path`/`--run`); logging.Emit JSON.
+- `export.go`: перед `export.Build` — `redact.Verify(runDir, policy)`; при
+  ошибке — fail-closed, bundle не создаётся, `type: redact_block`.
+- `gc.go`: `retention` дефолты из config при отсутствии явных флагов.
+
+## Risks
+
+- Сканер может пропускать нестандартные форматы секретов (например, ключи без
+  префиксов) — это консервативный выбор: меньше ложных тревог, а блocker не
+  должен блокировать экспорт из-за шума. Покрывается расширением правил.
+- `disable_export_block` — явный отказ от защиты; имя выбрано с приоритетом
+  fail-closed.
+
+## Compliance note
+
+Retention и redaction — технический контракт housekeeping, НЕ обещание legal
+compliance: сроки хранения юридически определяются вне системы.

--- a/openspec/changes/redaction-retention-contract/proposal.md
+++ b/openspec/changes/redaction-retention-contract/proposal.md
@@ -1,0 +1,45 @@
+# Redaction + retention contract (P1-6)
+
+## Proposal
+
+**ID**: P1-6  |  **Trace**: privacy-контракт, блокер перед внешней публикацией
+**Priority**: P1
+
+### ЧТО
+
+Полевая классификация, secrets-сканер, include/exclude policy и настраиваемая
+retention; обязательный fail-closed блокер перед публикацией bundle наружу и
+перед внешним архивом/SIEM.
+
+### ПОЧЕМУ
+
+Evidence содержит агентский вывод и снапшоты — в них могут протекать секреты.
+Публикация bundle или внешний архив без сканирования = раскрытие кредов. Raw
+logs должны быть opt-in, а retention — настраиваемой и при этом честной (без
+обещаний legal compliance).
+
+### Скоуп
+
+1. `pkg/redact`: классификатор полей (secret/internal/public), консервативный
+   secrets-сканер, include/exclude policy (repository-relative glob'ы через
+   `pkg/scope`), verify (fail-closed) и redaction-копия `[REDACTED:...]`.
+2. Config: `redaction` (include/exclude, raw_logs opt-in, disable_export_block)
+   и `retention` (older_than, keep_last, prune_runs) + валидация.
+3. CLI `ai-team redact verify|scan|redact`; `export` — fail-closed блокер;
+   `gc` берёт дефолты из config.
+4. OpenSpec delta.
+
+### Критерии приёмки
+
+- Сканер ловит известные формы секретов, не шумит на плейсхолдеры/env-ссылки.
+- `redact verify` и `export` блокируются при секретах (по умолчанию).
+- Классификация полей документирована.
+- Retention настраивается из config; gc-флаги имеют приоритет.
+- Raw logs — opt-in, никогда по умолчанию.
+
+### Похожее / альтернативы
+
+- Без сканера: ручная «тщательность» — уже сбоила, блокер обязателен.
+- Постоянное хранение redacted-копий вместо scan-and-block: ломает
+  самоописываемость evidence; мы делаем detached copy только по явному
+  `redact redact`.

--- a/openspec/changes/redaction-retention-contract/specs/redaction-retention-contract/spec.md
+++ b/openspec/changes/redaction-retention-contract/specs/redaction-retention-contract/spec.md
@@ -1,0 +1,69 @@
+# redaction-retention-contract delta (P1-6)
+
+## ADDED Requirements
+
+### Requirement: Secrets scanner over evidence
+
+Evidence content MUST be scannable for known secret shapes before it can be
+published or archived externally. The scanner is conservative (known prefixes
+and assignment patterns); confirmed findings are recordable and machine-readable.
+
+#### Scenario: Scanner detects common secrets
+
+- **WHEN** a file contains a private key block, AWS/GitHub/OpenAI/Slack/Google
+  token, JWT, basic-auth URL or a secret assignment (`PASSWORD=...` with a
+  high-entropy value)
+- **THEN** the scan reports findings with a reason, matched value and line
+- **AND** placeholder/vault/env-reference values are NOT reported
+
+#### Scenario: Redact command produces sanitized copy
+
+- **WHEN** `ai-team redact redact` runs over evidence
+- **THEN** a detached copy is written where every secret match is replaced
+  with `[REDACTED:<reason>]`
+
+### Requirement: Fail-closed export blocker
+
+Exporting a run bundle externally MUST be blocked (fail-closed) when evidence
+contains secrets, unless the operator explicitly disables the blocker.
+
+#### Scenario: Export refused on secrets
+
+- **WHEN** `ai-team export <run_id>` runs over evidence containing secrets
+- **THEN** export MUST fail and name the redaction reason
+- **AND** no bundle or verified-export record is produced
+
+#### Scenario: Blocker is on by default
+
+- **WHEN** no `redaction` section is configured
+- **THEN** the export blocker MUST be enabled
+- **AND** only `redaction.disable_export_block: true` disables it (never by absence)
+
+### Requirement: Field classification contract
+
+Sensitive field names MUST be classifiable as `secret`/`internal`/`public` so
+future consumers can enforce field-level redaction without inventing their own rules.
+
+#### Scenario: Secret field names classify as secret
+
+- **WHEN** a field key matches `password`, `token`, `secret`, `api_key`,
+  `access_key`, `private_key`, `client_secret`, `signing_key`
+- **THEN** it classifies as `secret`
+
+### Requirement: Configurable retention without compliance promise
+
+Retention of `.ai-team` artifacts MUST be configurable (age, keep-last count,
+optional pruning of exported evidence), and MUST be described as a technical
+housekeeping contract — not a legal-compliance obligation.
+
+#### Scenario: Retention section drives gc defaults
+
+- **WHEN** `retention.older_than`, `retention.keep_last` or `retention.prune_runs`
+  are set in config
+- **THEN** `ai-team gc` uses them as defaults
+- **AND** explicit `gc` flags take precedence over config
+
+#### Scenario: Invalid retention config is rejected
+
+- **WHEN** `older_than` does not parse as a duration or `keep_last` is negative
+- **THEN** config validation MUST fail

--- a/openspec/changes/redaction-retention-contract/tasks.md
+++ b/openspec/changes/redaction-retention-contract/tasks.md
@@ -1,0 +1,16 @@
+# Redaction + retention contract (P1-6) — tasks
+
+1. `pkg/redact`: scanner (правила + фильтр ложных срабатываний),
+   `ClassifyField`, policy (include/exclude via `pkg/scope`), `ScanDir`/`Verify`
+   (fail-closed), `RedactFile`. Тесты: детекция, ignore benign, redaction,
+   classify, policy globs, verify fail-closed/exclude.
+2. `pkg/config`: `RedactionConfig` + `RetentionConfig` (+ эффективные дефолты),
+   allowlist/rawConfig/assignment/`Config.Validate`. Тесты валидации.
+3. CLI: `cmd/ai-team/redact.go` (`verify|scan|redact`, policy из config, scanning
+   `.ai-team/runs`), dispatch + usage.
+4. `cmd/ai-team/export.go`: fail-closed блокер (`redact.Verify` перед Build).
+5. `cmd/ai-team/gc.go`: retention-дефолты из config (явные флаги приоритетны).
+6. README usage roots; OpenSpec delta `redaction-retention-contract`.
+
+Verification: `go build ./...`, `go vet`, `gofmt -l`, `go test ./...` (только 2
+известных e2e baseline fail), `make specs`.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,12 @@ func (bc *BudgetConfig) Validate() error {
 // разрешёнными. Блок экспорта по секретам включён ПО УМОЛЧАНИЮ (fail-closed):
 // отключить можно только явным disable_export_block: true. Никаких обещаний
 // legal compliance.
+//
+// ScanSensitiveFields и RawLogs — зарезервированные future knobs: сейчас
+// `scan`/`verify` работают по ключам событий через ClassifyField, а raw-вывод
+// никогда не пишется в evidence. Поля принимаются конфигом без ошибки, но
+// эффект появится вместе с соответствующими фичами; менять семантику по
+// умолчанию они не должны.
 type RedactionConfig struct {
 	ScanSensitiveFields bool     `yaml:"scan_sensitive_fields,omitempty"`
 	Include             []string `yaml:"include,omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/arturpanteleev/ai-team/pkg/checks"
+	"github.com/arturpanteleev/ai-team/pkg/redact"
 	"github.com/arturpanteleev/ai-team/pkg/runtime"
 	"github.com/arturpanteleev/ai-team/pkg/workflow"
 	"gopkg.in/yaml.v3"
@@ -39,6 +40,8 @@ type Config struct {
 	Containment    *ContainmentConfig `yaml:"containment,omitempty"`
 	TreeHash       *TreeHashConfig    `yaml:"tree_hash,omitempty"`
 	Budget         *BudgetConfig      `yaml:"budget,omitempty"`
+	Redaction      *RedactionConfig   `yaml:"redaction,omitempty"`
+	Retention      *RetentionConfig   `yaml:"retention,omitempty"`
 }
 
 // BudgetConfig — глобальные жёсткие лимиты run (P1-7): total wall-time и
@@ -91,6 +94,87 @@ func (bc *BudgetConfig) Validate() error {
 		return fmt.Errorf("budget.max_attempts не может быть отрицательным")
 	}
 	return nil
+}
+
+// RedactionConfig — privacy-контракт (P1-6): полевая классификация, secrets
+// scanner, include/exclude policy и fail-closed блок экспорта. raw_logs —
+// opt-in сохранение raw вывода; без явного true raw logs не считаются
+// разрешёнными. Блок экспорта по секретам включён ПО УМОЛЧАНИЮ (fail-closed):
+// отключить можно только явным disable_export_block: true. Никаких обещаний
+// legal compliance.
+type RedactionConfig struct {
+	ScanSensitiveFields bool     `yaml:"scan_sensitive_fields,omitempty"`
+	Include             []string `yaml:"include,omitempty"`
+	Exclude             []string `yaml:"exclude,omitempty"`
+	RawLogs             bool     `yaml:"raw_logs,omitempty"`
+	DisableExportBlock  bool     `yaml:"disable_export_block,omitempty"`
+}
+
+func (rc *RedactionConfig) Validate() error {
+	if rc == nil {
+		return nil
+	}
+	policy := redact.Policy{Include: rc.Include, Exclude: rc.Exclude}
+	return policy.Validate()
+}
+
+// EffectiveFailExportOnSecrets — эффект fail-closed блока экспорта
+// (включён по умолчанию; отключается только явным disable_export_block).
+func (rc *RedactionConfig) EffectiveFailExportOnSecrets() bool {
+	if rc == nil {
+		return true
+	}
+	return !rc.DisableExportBlock
+}
+
+// RetentionConfig — настраиваемая retention (P1-6): дефолты для `ai-team gc`
+// без обещания legal compliance (это техническая уборка, не obligations-контракт).
+type RetentionConfig struct {
+	OlderThan string `yaml:"older_than,omitempty"`
+	KeepLast  int    `yaml:"keep_last,omitempty"`
+	PruneRuns bool   `yaml:"prune_runs,omitempty"`
+}
+
+// Канонические дефолты retention.
+const (
+	DefaultRetentionOlderThan = "720h"
+	DefaultRetentionKeepLast  = 20
+)
+
+func (rc *RetentionConfig) Validate() error {
+	if rc == nil {
+		return nil
+	}
+	if rc.OlderThan != "" {
+		if _, err := time.ParseDuration(rc.OlderThan); err != nil {
+			return fmt.Errorf("retention.older_than %q не парсится (пример: 720h)", rc.OlderThan)
+		}
+	}
+	if rc.KeepLast < 0 {
+		return fmt.Errorf("retention.keep_last не может быть отрицательным")
+	}
+	return nil
+}
+
+// EffectiveOlderThanDuration — распарсенный older_than (0 — канонический
+// дефолт 720h).
+func (rc *RetentionConfig) EffectiveOlderThanDuration() (time.Duration, error) {
+	if rc == nil || rc.OlderThan == "" {
+		d, err := time.ParseDuration(DefaultRetentionOlderThan)
+		if err != nil {
+			return 0, err
+		}
+		return d, nil
+	}
+	return time.ParseDuration(rc.OlderThan)
+}
+
+// EffectiveKeepLast возвращает keep_last или дефолт.
+func (rc *RetentionConfig) EffectiveKeepLast() int {
+	if rc == nil || rc.KeepLast <= 0 {
+		return DefaultRetentionKeepLast
+	}
+	return rc.KeepLast
 }
 
 // TreeHashConfig — project-specific настройки tree hashing (OPS-2).
@@ -168,20 +252,22 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	if err := validateMappingKeys(value, map[string]bool{
 		"schema_version": true, "pipeline": true, "cli": true, "model": true,
 		"effort": true, "stage_timeout": true, "workflow": true, "containment": true,
-		"tree_hash": true, "budget": true,
+		"tree_hash": true, "budget": true, "redaction": true, "retention": true,
 	}, "config"); err != nil {
 		return err
 	}
 	type rawConfig struct {
-		SchemaVersion int             `yaml:"schema_version"`
-		Pipeline      yaml.Node       `yaml:"pipeline"`
-		CLI           string          `yaml:"cli"`
-		Model         string          `yaml:"model"`
-		Effort        string          `yaml:"effort"`
-		StageTimeout  string          `yaml:"stage_timeout"`
-		Workflow      *WorkflowConfig `yaml:"workflow"`
-		TreeHash      *TreeHashConfig `yaml:"tree_hash"`
-		Budget        *BudgetConfig   `yaml:"budget"`
+		SchemaVersion int              `yaml:"schema_version"`
+		Pipeline      yaml.Node        `yaml:"pipeline"`
+		CLI           string           `yaml:"cli"`
+		Model         string           `yaml:"model"`
+		Effort        string           `yaml:"effort"`
+		StageTimeout  string           `yaml:"stage_timeout"`
+		Workflow      *WorkflowConfig  `yaml:"workflow"`
+		TreeHash      *TreeHashConfig  `yaml:"tree_hash"`
+		Budget        *BudgetConfig    `yaml:"budget"`
+		Redaction     *RedactionConfig `yaml:"redaction"`
+		Retention     *RetentionConfig `yaml:"retention"`
 	}
 	var raw rawConfig
 	if err := value.Decode(&raw); err != nil {
@@ -199,6 +285,8 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	c.Workflow = raw.Workflow
 	c.TreeHash = raw.TreeHash
 	c.Budget = raw.Budget
+	c.Redaction = raw.Redaction
+	c.Retention = raw.Retention
 
 	if raw.Pipeline.Kind == 0 {
 		return fmt.Errorf("config: pipeline is required")
@@ -502,6 +590,16 @@ func (c *Config) Validate(reg AgentLookup) error {
 	}
 	if c.Budget != nil {
 		if err := c.Budget.Validate(); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if c.Redaction != nil {
+		if err := c.Redaction.Validate(); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if c.Retention != nil {
+		if err := c.Retention.Validate(); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/pkg/config/privacy_test.go
+++ b/pkg/config/privacy_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestRedactionConfigValidate(t *testing.T) {
+	ok := &RedactionConfig{Include: []string{"runs/**"}, Exclude: []string{"**/reports/**"}}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("валидный redaction: %v", err)
+	}
+	bad := &RedactionConfig{Include: []string{"../escape"}}
+	if err := bad.Validate(); err == nil {
+		t.Error("traversal-включение должно быть отвергнуто")
+	}
+}
+
+func TestRedactionEffectiveFailClosedByDefault(t *testing.T) {
+	if !(&RedactionConfig{}).EffectiveFailExportOnSecrets() {
+		t.Error("по умолчанию экспорт должен быть fail-closed")
+	}
+	if (&RedactionConfig{DisableExportBlock: true}).EffectiveFailExportOnSecrets() {
+		t.Error("явный disable_export_block должен снимать блок")
+	}
+	var nilCfg *RedactionConfig
+	if !nilCfg.EffectiveFailExportOnSecrets() {
+		t.Error("nil redaction → блок экспорта включён")
+	}
+}
+
+func TestRetentionConfigValidateAndEffective(t *testing.T) {
+	ok := &RetentionConfig{OlderThan: "720h", KeepLast: 5}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("валидный retention: %v", err)
+	}
+	bad := &RetentionConfig{OlderThan: "not-a-duration"}
+	if err := bad.Validate(); err == nil {
+		t.Error("невалидный older_than должен быть отвергнут")
+	}
+
+	var nilCfg *RetentionConfig
+	if keep := nilCfg.EffectiveKeepLast(); keep != DefaultRetentionKeepLast {
+		t.Fatalf("nil keep_last = %d", keep)
+	}
+	dur, err := nilCfg.EffectiveOlderThanDuration()
+	if err != nil || dur.Hours() != 720 {
+		t.Fatalf("nil older_than = %v (%v)", dur, err)
+	}
+}

--- a/pkg/redact/policy.go
+++ b/pkg/redact/policy.go
@@ -26,6 +26,11 @@ type Policy struct {
 	MaxBytes int64
 	// SkipBinary — не сканировать бинарные файлы.
 	SkipBinary bool
+	// RepoRoot — корень репозитория: протокол-относительный glob'ы
+	// include/exclude резолвятся от него, а не от суженного корня сканирования
+	// (.ai-team/runs или каталог одного run). Пустое значение = корнем служит
+	// сам корень сканирования (совместимость с узкими вызовами).
+	RepoRoot string
 }
 
 func (p Policy) withDefaults() Policy {

--- a/pkg/redact/policy.go
+++ b/pkg/redact/policy.go
@@ -1,0 +1,63 @@
+package redact
+
+import (
+	"fmt"
+
+	"github.com/arturpanteleev/ai-team/pkg/scope"
+)
+
+// ScanDefaults — канонические параметры сканирования.
+const (
+	MaxScanFileBytes = 8 << 20 // 8 MiB на файл
+)
+
+// Policy — конфигурируемая политика redaction (include/exclude на
+// repository-относительные glob'ы + raw logs opt-in).
+type Policy struct {
+	// Include — если непусто, сканируются только matching-файлы (значение —
+	// repository-относительные пути, slash-separated). Пусто = все файлы.
+	Include []string
+	// Exclude — matching-файлы исключаются из сканирования.
+	Exclude []string
+	// FailOnSecrets — fail-closed: наличие находок делает Verify/export
+	// проваленным. При false находки только регистрируются.
+	FailOnSecrets bool
+	// MaxBytes — предел размера сканируемого файла.
+	MaxBytes int64
+	// SkipBinary — не сканировать бинарные файлы.
+	SkipBinary bool
+}
+
+func (p Policy) withDefaults() Policy {
+	if p.MaxBytes <= 0 {
+		p.MaxBytes = MaxScanFileBytes
+	}
+	return p
+}
+
+// Applies определяет, должен ли файл (repository-относительный путь с '/')
+// попадать в обзор сканирования по текущей политике.
+func (p Policy) Applies(relPath string) bool {
+	if len(p.Exclude) > 0 && scope.MatchAny(p.Exclude, relPath) {
+		return false
+	}
+	if len(p.Include) > 0 {
+		return scope.MatchAny(p.Include, relPath)
+	}
+	return true
+}
+
+// Validate проверяет include/exclude glob'ы (repository-relative, не '.'/'..').
+func (p Policy) Validate() error {
+	for _, g := range p.Include {
+		if err := scope.Validate(g); err != nil {
+			return fmt.Errorf("redaction.include %q: %w", g, err)
+		}
+	}
+	for _, g := range p.Exclude {
+		if err := scope.Validate(g); err != nil {
+			return fmt.Errorf("redaction.exclude %q: %w", g, err)
+		}
+	}
+	return nil
+}

--- a/pkg/redact/scanner.go
+++ b/pkg/redact/scanner.go
@@ -1,0 +1,236 @@
+// Package redact реализует контракт P1-6: классификация чувствительных полей,
+// secrets-сканер, include/exclude policy и redaction evidence перед внешней
+// публикацией. Скан консервативный (известные префиксы и assignment-паттерны):
+// без ложных срабатываний на обычные слова; подтверждённые находки — повод
+// для fail-closed блока export (флаг fail_export_on_secrets).
+package redact
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/arturpanteleev/ai-team/pkg/safeio"
+)
+
+// FieldClass — класс чувствительности поля (документированный контракт).
+type FieldClass int
+
+const (
+	FieldPublic   FieldClass = iota // безопасно публиковать как есть
+	FieldInternal                   // внутри организации, но не наружу
+	FieldSecret                     // только в защищённых хранилищах, не наружу
+)
+
+func (c FieldClass) String() string {
+	switch c {
+	case FieldInternal:
+		return "internal"
+	case FieldSecret:
+		return "secret"
+	default:
+		return "public"
+	}
+}
+
+// ClassExpr — правило классификации имени поля по regexp-ключу.
+type ClassExpr struct {
+	KeyPattern string
+	Class      FieldClass
+}
+
+// ClassifyField классифицирует имя поля (нижний регистр, подчёркивания
+// нормализованы) по базовой таблице классов. Используется как
+// документированный контракт: секретные поля нельзя наружу без redaction.
+func ClassifyField(name string) FieldClass {
+	key := strings.ToLower(strings.ReplaceAll(name, "-", "_"))
+	key = strings.TrimSpace(key)
+	for _, rule := range secretFieldRules {
+		if rule.KeyPattern != "" && matchesKey(key, rule.KeyPattern) {
+			return rule.Class
+		}
+	}
+	return FieldPublic
+}
+
+var secretFieldRules = []ClassExpr{
+	{KeyPattern: "password", Class: FieldSecret},
+	{KeyPattern: "passwd", Class: FieldSecret},
+	{KeyPattern: "secret", Class: FieldSecret},
+	{KeyPattern: "token", Class: FieldSecret},
+	{KeyPattern: "api_key", Class: FieldSecret},
+	{KeyPattern: "apikey", Class: FieldSecret},
+	{KeyPattern: "access_key", Class: FieldSecret},
+	{KeyPattern: "private_key", Class: FieldSecret},
+	{KeyPattern: "client_secret", Class: FieldSecret},
+	{KeyPattern: "signing_key", Class: FieldSecret},
+}
+
+func matchesKey(name, pattern string) bool {
+	if pattern == "password" {
+		// точное слово или суффикс _password: избегаем matchesKey("ik_password")
+		if name == pattern || strings.HasSuffix(name, "_"+pattern) {
+			return true
+		}
+		return false
+	}
+	return name == pattern || strings.HasSuffix(name, "_"+pattern) ||
+		strings.Contains(name, pattern)
+}
+
+// Finding — одно подтверждённое вхождение секрета в содержимом файла.
+type Finding struct {
+	Reason   string `json:"reason"`
+	Matched  string `json:"matched"`
+	Redacted string `json:"redacted"`
+	Line     int    `json:"line"`
+}
+
+// RedactedValue возвращает безопасную замену для вставки вместо секрета.
+func (f Finding) RedactedValue() string {
+	return "[REDACTED:" + f.Reason + "]"
+}
+
+type secretRule struct {
+	name       string
+	regex      *regexp.Regexp
+	valueGroup int // группа со значением секрета (-1 — нет); фильтр ложных срабатываний
+}
+
+var (
+	secretOnce sync.Once
+	secretRe   []secretRule
+)
+
+func compileSecretRules() []secretRule {
+	secretOnce.Do(func() {
+		patterns := []struct {
+			name       string
+			re         string
+			valueGroup int
+		}{
+			{"private key", `-----BEGIN [A-Z ]*PRIVATE KEY-----`, -1},
+			{"aws access key", `\b(?:AKIA|ASIA|AGPA|AIDA|AROA)[0-9A-Z]{16}\b`, -1},
+			{"github token", `\bgh(?:p|o|u|s|r)_[0-9A-Za-z]{36,255}\b`, -1},
+			{"openai key", `\bsk-(?:proj-|dev-|svc-|sess-)?[0-9A-Za-z]{16,}\b`, -1},
+			{"slack token", `\bxox[abporsa]?-[0-9A-Za-z-]{10,}\b`, -1},
+			{"google api key", `\bAIza[0-9A-Za-z\-_]{20,}\b`, -1},
+			{"jwt", `\beyJ[0-9A-Za-z_-]{10,}\.[0-9A-Za-z_-]{10,}\.[0-9A-Za-z_-]{10,}\b`, -1},
+			{"basic auth url", `\b[a-zA-Z][a-zA-Z0-9+.-]*://[^:/@\s]+:[^@\s]+@`, -1},
+			{"secret assignment", `(?m)^\s*(?:password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|auth[_-]?token|signing[_-]?key)\s*[:=]\s*["']?([0-9A-Za-z+/_\-.\=]{16,})`, 2},
+		}
+		for _, p := range patterns {
+			re, err := regexp.Compile(p.re)
+			if err != nil {
+				panic(fmt.Sprintf("redact: invalid rule %s: %v", p.name, err))
+			}
+			secretRe = append(secretRe, secretRule{name: p.name, regex: re, valueGroup: p.valueGroup})
+		}
+	})
+	return secretRe
+}
+
+// likelySecretValue фильтрует ложные срабатывания secret assignment:
+// значения-плейсхолдеры, vault/env-ссылки и короткие слова без верхнего
+// регистра и цифр не считаются секретом.
+func likelySecretValue(value string) bool {
+	value = strings.Trim(value, "\"' ")
+	if len(value) < 16 {
+		return false
+	}
+	if strings.ContainsAny(value, "<>") || strings.Contains(value, "${") ||
+		strings.HasPrefix(value, "$") {
+		return false
+	}
+	lower := strings.ToLower(value)
+	for _, marker := range []string{"example", "placeholder", "changeme", "your-", "dummy", "sample", "<insert"} {
+		if strings.Contains(lower, marker) {
+			return false
+		}
+	}
+	var hasUpper, hasDigit bool
+	for _, r := range value {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		}
+	}
+	return hasUpper && hasDigit
+}
+
+// Scan возвращает все подтверждённые секретные вхождения в data. Результат
+// стабильно упорядочен (по правилу, затем по позиции) для детерминизма.
+func Scan(data []byte) []Finding {
+	var findings []Finding
+	for lineNumber, rawLine := range bytes.Split(data, []byte("\n")) {
+		line := string(rawLine)
+		for _, rule := range compileSecretRules() {
+			if rule.valueGroup >= 0 {
+				for _, loc := range rule.regex.FindAllStringSubmatchIndex(line, -1) {
+					if len(loc) < rule.valueGroup+2 {
+						continue
+					}
+					value := line[loc[rule.valueGroup]:loc[rule.valueGroup+1]]
+					if !likelySecretValue(value) {
+						continue
+					}
+					m := line[loc[0]:loc[1]]
+					findings = append(findings, Finding{
+						Reason:   rule.name,
+						Matched:  m,
+						Redacted: "[REDACTED:" + rule.name + "]",
+						Line:     lineNumber + 1,
+					})
+				}
+				continue
+			}
+			for _, loc := range rule.regex.FindAllStringIndex(line, -1) {
+				m := line[loc[0]:loc[1]]
+				findings = append(findings, Finding{
+					Reason:   rule.name,
+					Matched:  m,
+					Redacted: "[REDACTED:" + rule.name + "]",
+					Line:     lineNumber + 1,
+				})
+			}
+		}
+	}
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Line != findings[j].Line {
+			return findings[i].Line < findings[j].Line
+		}
+		if findings[i].Reason != findings[j].Reason {
+			return findings[i].Reason < findings[j].Reason
+		}
+		return findings[i].Matched < findings[j].Matched
+	})
+	return findings
+}
+
+// IsBinary грубо определяет, является ли содержимое бинарным (NUL в первых
+// 4KiB). Бинарные файлы не сканируются.
+func IsBinary(data []byte) bool {
+	window := data
+	if len(window) > 4096 {
+		window = window[:4096]
+	}
+	return bytes.IndexByte(window, 0) >= 0
+}
+
+// ScanFile читает regular file (no-follow, через канонический safeio лимит)
+// и сканирует его. Возвращает nil, nil для бинарных файлов.
+func ScanFile(path string, maxBytes int64) ([]Finding, error) {
+	data, err := safeio.ReadRegularFile(path, maxBytes)
+	if err != nil {
+		return nil, err
+	}
+	if IsBinary(data) {
+		return nil, nil
+	}
+	return Scan(data), nil
+}

--- a/pkg/redact/scanner.go
+++ b/pkg/redact/scanner.go
@@ -133,6 +133,28 @@ func compileSecretRules() []secretRule {
 	return secretRe
 }
 
+// beginPrivateKeyRe / endPrivateKeyRe — границы PEM-блока private key.
+// RedactFile вырезает весь блок (BEGIN … END), а не только BEGIN-строку:
+// иначе base64-тело ключа оставалось бы в redacted-копии.
+var (
+	beginPrivateKeyOnce  sync.Once
+	beginPrivateKeyReVal *regexp.Regexp
+	endPrivateKeyReVal   *regexp.Regexp
+)
+
+func beginPrivateKeyRe() *regexp.Regexp {
+	beginPrivateKeyOnce.Do(func() {
+		beginPrivateKeyReVal = regexp.MustCompile(`(?m)^[ \t]*-----BEGIN [A-Z ]*PRIVATE KEY-----$`)
+		endPrivateKeyReVal = regexp.MustCompile(`(?m)^[ \t]*-----END [A-Z ]*PRIVATE KEY-----$`)
+	})
+	return beginPrivateKeyReVal
+}
+
+func endPrivateKeyRe() *regexp.Regexp {
+	beginPrivateKeyRe()
+	return endPrivateKeyReVal
+}
+
 // likelySecretValue фильтрует ложные срабатывания secret assignment:
 // значения-плейсхолдеры, vault/env-ссылки и короткие слова без верхнего
 // регистра и цифр не считаются секретом.
@@ -223,8 +245,12 @@ func IsBinary(data []byte) bool {
 }
 
 // ScanFile читает regular file (no-follow, через канонический safeio лимит)
-// и сканирует его. Возвращает nil, nil для бинарных файлов.
+// и сканирует его. Возвращает nil, nil для бинарных файлов. maxBytes<=0
+// означает канонический дефолт MaxScanFileBytes (как и в ScanDir/Verify).
 func ScanFile(path string, maxBytes int64) ([]Finding, error) {
+	if maxBytes <= 0 {
+		maxBytes = MaxScanFileBytes
+	}
 	data, err := safeio.ReadRegularFile(path, maxBytes)
 	if err != nil {
 		return nil, err

--- a/pkg/redact/scanner_test.go
+++ b/pkg/redact/scanner_test.go
@@ -1,0 +1,87 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanDetectsCommonSecrets(t *testing.T) {
+	ghToken := "ghp_" + strings.Repeat("1", 36)
+	slackToken := "xoxb-" + strings.Repeat("9", 22)
+	openaiKey := "sk-proj-" + strings.Repeat("a", 24)
+	pemHeader := "-----BEGIN RSA " + "PRIVATE KEY-----"
+	pemFooter := "-----END RSA " + "PRIVATE KEY-----"
+	input := []byte(`GITHUB_TOKEN=` + ghToken + `
+aws_access_key_id="AKIAIOSFODNN7EXAMPLE"
+url=https://user:sekret@example.com/path
+secret = yV3sM3Yl0n9WxQ2aB1cD4eF6gH8jK0lM2nP4qR6sT8
+` + pemHeader + `
+MIIEpAIBAAKCAQEA
+` + pemFooter + `
+` + openaiKey + `
+` + slackToken + `
+`)
+	findings := Scan(input)
+	if len(findings) == 0 {
+		t.Fatal("секреты не обнаружены")
+	}
+	reasons := map[string]bool{}
+	for _, f := range findings {
+		reasons[f.Reason] = true
+	}
+	for _, want := range []string{"private key", "aws access key", "github token",
+		"openai key", "slack token", "basic auth url", "secret assignment"} {
+		if !reasons[want] {
+			t.Errorf("не найдено правило %q", want)
+		}
+	}
+}
+
+func TestScanIgnoresBenignText(t *testing.T) {
+	input := []byte(`The password manager is configured.
+value=some-value
+count=12
+# PASSWORD=example
+PASSWORD=<from-vault>
+TOKEN=your-token-here
+api_key = "changeme"
+`)
+	findings := Scan(input)
+	for _, f := range findings {
+		if f.Reason == "secret assignment" {
+			t.Errorf("ложное срабатывание secret assignment: %+v (line %d)", f, f.Line)
+		}
+	}
+}
+
+func TestRedactReplacesFindings(t *testing.T) {
+	ghToken := "ghp_" + strings.Repeat("7", 36)
+	input := []byte("token=" + ghToken + "\nkeep normal text\n")
+	redacted := RedactFile(input)
+	if strings.Contains(string(redacted), "ghp_") {
+		t.Fatalf("секрет не вырезан: %s", redacted)
+	}
+	if !strings.Contains(string(redacted), "[REDACTED:github token]") {
+		t.Fatalf("нет маркера redaction: %s", redacted)
+	}
+	if !strings.Contains(string(redacted), "keep normal text") {
+		t.Fatalf("обычный текст повреждён: %s", redacted)
+	}
+}
+
+func TestClassifyField(t *testing.T) {
+	for name, want := range map[string]FieldClass{
+		"run_id":           FieldPublic,
+		"password":         FieldSecret,
+		"db_password":      FieldSecret,
+		"access_key":       FieldSecret,
+		"client_secret":    FieldSecret,
+		"apiToken":         FieldSecret,
+		"commit_sha":       FieldPublic,
+		"signing_key_path": FieldSecret,
+	} {
+		if got := ClassifyField(name); got != want {
+			t.Errorf("ClassifyField(%q) = %s, want %s", name, got, want)
+		}
+	}
+}

--- a/pkg/redact/scanner_test.go
+++ b/pkg/redact/scanner_test.go
@@ -103,6 +103,12 @@ func TestRedactBlanksPrivateKeyBody(t *testing.T) {
 	if strings.Count(redacted, "[REDACTED:private key]") < 3 {
 		t.Errorf("ожидались 3+ маркера (begin/body/end): %q", redacted)
 	}
+	if strings.Count(redacted, "\n") != strings.Count(string(input), "\n") {
+		t.Errorf("число переводов строк не сохранилось: redacted=%q", redacted)
+	}
+	if strings.Contains(redacted, "]"+header) || strings.Contains(redacted, "]"+footer) {
+		t.Errorf("несколько маркеров склеены в одну строку (потерян \\n): %q", redacted)
+	}
 }
 
 func TestClassifyField(t *testing.T) {

--- a/pkg/redact/scanner_test.go
+++ b/pkg/redact/scanner_test.go
@@ -69,6 +69,42 @@ func TestRedactReplacesFindings(t *testing.T) {
 	}
 }
 
+// TestRedactAlignsWithScanFilter — RedactFile применяет тот же
+// likelySecretValue-фильтр к secret assignment, что и Scan: бенign-значение
+// не режется (иначе scan и redact расходились бы по контракту P1-6).
+func TestRedactAlignsWithScanFilter(t *testing.T) {
+	input := []byte("password=0123456789abcdef\npassword=A1b2C3d4E5f6G7h8\n")
+	redacted := string(RedactFile(input))
+	if !strings.Contains(redacted, "password=0123456789abcdef") {
+		t.Errorf("бенign-значение (без верхнего регистра) не должно резаться: %q", redacted)
+	}
+	if strings.Contains(redacted, "A1b2C3d4E5f6G7h8") {
+		t.Errorf("высокоэнтропийное значение должно быть вырезано: %q", redacted)
+	}
+}
+
+// TestRedactBlanksPrivateKeyBody — RedactFile вырезает ВЕСЬ PEM-блок private
+// key (BEGIN … тело base64 … END), а не только BEGIN-строку.
+func TestRedactBlanksPrivateKeyBody(t *testing.T) {
+	header := "-----BEGIN RSA " + "PRIVATE KEY-----"
+	footer := "-----END RSA " + "PRIVATE KEY-----"
+	body := "MIIEpAIBAAKCAQEA" + strings.Repeat("A", 40)
+	input := []byte("before\n" + header + "\n" + body + "\n" + footer + "\nafter\n")
+	redacted := string(RedactFile(input))
+	if strings.Contains(redacted, body) {
+		t.Errorf("тело private key осталось в redacted-копии: %q", redacted)
+	}
+	if strings.Contains(redacted, "MIIE") {
+		t.Errorf("BEGIN/тело блока не полностью вырезаны: %q", redacted)
+	}
+	if !strings.Contains(redacted, "before") || !strings.Contains(redacted, "after") {
+		t.Errorf("контекст повреждён: %q", redacted)
+	}
+	if strings.Count(redacted, "[REDACTED:private key]") < 3 {
+		t.Errorf("ожидались 3+ маркера (begin/body/end): %q", redacted)
+	}
+}
+
 func TestClassifyField(t *testing.T) {
 	for name, want := range map[string]FieldClass{
 		"run_id":           FieldPublic,

--- a/pkg/redact/verify.go
+++ b/pkg/redact/verify.go
@@ -177,13 +177,13 @@ func redactByLines(lines []string) []byte {
 			if endPrivateKeyRe().MatchString(line) {
 				inKeyBody = false
 			}
-			builder.WriteString(cleaned)
+			builder.WriteString(preserveEOL(line, cleaned))
 			continue
 		}
 		if beginPrivateKeyRe().MatchString(line) {
 			cleaned = "[REDACTED:private key]"
 			inKeyBody = !endPrivateKeyRe().MatchString(line)
-			builder.WriteString(cleaned)
+			builder.WriteString(preserveEOL(line, cleaned))
 			continue
 		}
 		for _, rule := range compileSecretRules() {
@@ -209,6 +209,16 @@ func redactByLines(lines []string) []byte {
 		builder.WriteString(cleaned)
 	}
 	return []byte(builder.String())
+}
+
+// preserveEOL восстанавливает завершающий \n строки, если вырезающий
+// маркер (например [REDACTED:private key]) заменил её и утерял перевод
+// строки — иначе маркеры блока склеивались бы в одну строку.
+func preserveEOL(original, replacement string) string {
+	if strings.HasSuffix(original, "\n") && !strings.HasSuffix(replacement, "\n") {
+		return replacement + "\n"
+	}
+	return replacement
 }
 
 // relPath проверяет, что full лежит внутри root, и возвращает относительный

--- a/pkg/redact/verify.go
+++ b/pkg/redact/verify.go
@@ -66,7 +66,9 @@ func ScanDir(root string, policy Policy) (found []FileResult, scanned int, total
 			if mode&(fs.ModeDevice|fs.ModeNamedPipe|fs.ModeSocket) != 0 {
 				return nil
 			}
-			rel, relErr := relFromRoot(absRoot, p)
+			// SF3: репозиторий-относительный путь для include/exclude —
+			// от policy.RepoRoot, если задан (иначе от корня сканирования).
+			rel, relErr := PolicyRel(policy.RepoRoot, absRoot, p)
 			if relErr != nil {
 				return relErr
 			}
@@ -90,6 +92,22 @@ func ScanDir(root string, policy Policy) (found []FileResult, scanned int, total
 	return found, scanned, total, err
 }
 
+// policyRel — путь файла для glob-матчинга: от RepoRoot, если задан и файл
+// лежит в нём; иначе от корня сканирования. Файлы вне RepoRoot не матчатся
+// include/exclude репозиторий-глобами (вне протокола — пропускаем).
+func PolicyRel(repoRoot, scanRoot, full string) (string, error) {
+	if repoRoot != "" {
+		absRepo, err := filepath.Abs(repoRoot)
+		if err != nil {
+			return "", err
+		}
+		if rel, err := relFromRoot(absRepo, full); err == nil {
+			return rel, nil
+		}
+	}
+	return relFromRoot(scanRoot, full)
+}
+
 // Verify — обязательный блокер (P1-6): при fail-closed политике любая находка
 // приводит к ошибке. Report всегда детерминирован и машиночитаем.
 func Verify(root string, policy Policy) (*Report, error) {
@@ -101,6 +119,12 @@ func Verify(root string, policy Policy) (*Report, error) {
 		return nil, err
 	}
 	report := buildReport(found, scanned, total)
+	// SF3: guard «included-файлов 0» — include-политика не должна молча
+	// выключать блокер (ноль сканированных файлов при непустом include =
+	// либо неверный glob, либо политика завела нас в пустоту).
+	if len(policy.Include) > 0 && scanned == 0 {
+		return report, fmt.Errorf("redaction: include-глобы %q не совпали ни с одним файлом — скан пуст, блокер не может быть подтверждён", policy.Include)
+	}
 	if len(report.Violations) > 0 && policy.FailOnSecrets {
 		return report, fmt.Errorf("redaction: %s", report.Verdict)
 	}
@@ -136,12 +160,50 @@ func splitLines(data []byte) []string {
 	return lines
 }
 
-// redactByLines применяет правила построчно и возвращает результат.
+// redactByLines применяет правила построчно и возвращает результат. Для
+// правил с value-группой (secret assignment) применяется тот же фильтр
+// likelySecretValue, что и в Scan — иначе scan и redact расходились бы.
+//
+// Private key обрабатывается как МНОГОСТРОЧНЫЙ блок: тело (base64) между
+// BEGIN и END PRIVATE KEY тоже вырезается — иначе в redacted-копии оставался
+// бы ключ и создавал false sense of security.
 func redactByLines(lines []string) []byte {
 	var builder strings.Builder
+	inKeyBody := false
 	for _, line := range lines {
 		cleaned := line
+		if inKeyBody {
+			cleaned = "[REDACTED:private key]"
+			if endPrivateKeyRe().MatchString(line) {
+				inKeyBody = false
+			}
+			builder.WriteString(cleaned)
+			continue
+		}
+		if beginPrivateKeyRe().MatchString(line) {
+			cleaned = "[REDACTED:private key]"
+			inKeyBody = !endPrivateKeyRe().MatchString(line)
+			builder.WriteString(cleaned)
+			continue
+		}
 		for _, rule := range compileSecretRules() {
+			if rule.name == "private key" {
+				continue // обрабатывается как блок выше
+			}
+			if rule.valueGroup >= 0 {
+				cleaned = rule.regex.ReplaceAllStringFunc(cleaned, func(m string) string {
+					loc := rule.regex.FindStringSubmatchIndex(m)
+					if loc == nil || len(loc) < rule.valueGroup+2 {
+						return m
+					}
+					value := m[loc[rule.valueGroup]:loc[rule.valueGroup+1]]
+					if !likelySecretValue(value) {
+						return m
+					}
+					return "[REDACTED:" + rule.name + "]"
+				})
+				continue
+			}
 			cleaned = rule.regex.ReplaceAllString(cleaned, "[REDACTED:"+rule.name+"]")
 		}
 		builder.WriteString(cleaned)

--- a/pkg/redact/verify.go
+++ b/pkg/redact/verify.go
@@ -1,0 +1,172 @@
+package redact
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/arturpanteleev/ai-team/pkg/safeio"
+)
+
+// Violation — fail-closed причина блокировки внешней публикации.
+type Violation struct {
+	Path     string    `json:"path"`
+	Findings []Finding `json:"findings"`
+}
+
+func (v Violation) Error() string {
+	kinds := make([]string, 0, len(v.Findings))
+	seen := map[string]bool{}
+	for _, f := range v.Findings {
+		if !seen[f.Reason] {
+			kinds = append(kinds, f.Reason)
+			seen[f.Reason] = true
+		}
+	}
+	return fmt.Sprintf("%d secret-находок (%s)", len(v.Findings), strings.Join(kinds, ", "))
+}
+
+// FileResult — находки в одном файле относительно корня сканирования.
+type FileResult struct {
+	Path     string    `json:"path"`
+	Findings []Finding `json:"findings"`
+}
+
+// Report — детерминированный (стабильно упорядоченный) результат проверки.
+type Report struct {
+	Verdict    string      `json:"verdict"`
+	Files      int         `json:"files_scanned"`
+	Bytes      int64       `json:"bytes_scanned"`
+	Violations []Violation `json:"violations,omitempty"`
+}
+
+// ScanDir обходит regular файлы под root (без симлинков, без special files;
+// бинарные пропускаются) и собирает находки по policy. Символьные ссылки не
+// разыменовываются и не обходятся (WalkDir не следует ссылкам).
+func ScanDir(root string, policy Policy) (found []FileResult, scanned int, total int64, err error) {
+	policy = policy.withDefaults()
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if _, err := safeio.ExistingDir(absRoot); err != nil {
+		return nil, 0, 0, fmt.Errorf("redact: %w", err)
+	}
+	err = filepath.WalkDir(absRoot, func(p string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		mode := entry.Type()
+		if mode&fs.ModeSymlink != 0 {
+			return nil
+		}
+		if !entry.IsDir() {
+			if mode&(fs.ModeDevice|fs.ModeNamedPipe|fs.ModeSocket) != 0 {
+				return nil
+			}
+			rel, relErr := relFromRoot(absRoot, p)
+			if relErr != nil {
+				return relErr
+			}
+			if !policy.Applies(rel) {
+				return nil
+			}
+			findings, scanErr := ScanFile(p, policy.MaxBytes)
+			if scanErr != nil {
+				return fmt.Errorf("redact scan %s: %w", p, scanErr)
+			}
+			if len(findings) > 0 {
+				found = append(found, FileResult{Path: rel, Findings: findings})
+			}
+			scanned++
+			if info, infoErr := entry.Info(); infoErr == nil {
+				total += info.Size()
+			}
+		}
+		return nil
+	})
+	return found, scanned, total, err
+}
+
+// Verify — обязательный блокер (P1-6): при fail-closed политике любая находка
+// приводит к ошибке. Report всегда детерминирован и машиночитаем.
+func Verify(root string, policy Policy) (*Report, error) {
+	if err := policy.Validate(); err != nil {
+		return nil, err
+	}
+	found, scanned, total, err := ScanDir(root, policy)
+	if err != nil {
+		return nil, err
+	}
+	report := buildReport(found, scanned, total)
+	if len(report.Violations) > 0 && policy.FailOnSecrets {
+		return report, fmt.Errorf("redaction: %s", report.Verdict)
+	}
+	return report, nil
+}
+
+func buildReport(found []FileResult, scanned int, total int64) *Report {
+	violations := make([]Violation, 0, len(found))
+	totalFindings := 0
+	for _, f := range found {
+		violations = append(violations, Violation{Path: f.Path, Findings: f.Findings})
+		totalFindings += len(f.Findings)
+	}
+	verdict := "clean"
+	if totalFindings > 0 {
+		verdict = fmt.Sprintf("%d violations в %d файлах", totalFindings, len(violations))
+	}
+	return &Report{Verdict: verdict, Files: scanned, Bytes: total, Violations: violations}
+}
+
+// RedactFile возвращает копию data, где каждая находка заменена на
+// [REDACTED:<reason>]. Изменения детерминированы (replace all по правилам).
+func RedactFile(data []byte) []byte {
+	return redactByLines(splitLines(data))
+}
+
+// splitLines разбивает data на строки, сохраняя trailing '\n'.
+func splitLines(data []byte) []string {
+	lines := strings.SplitAfter(string(data), "\n")
+	if last := lines[len(lines)-1]; last == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// redactByLines применяет правила построчно и возвращает результат.
+func redactByLines(lines []string) []byte {
+	var builder strings.Builder
+	for _, line := range lines {
+		cleaned := line
+		for _, rule := range compileSecretRules() {
+			cleaned = rule.regex.ReplaceAllString(cleaned, "[REDACTED:"+rule.name+"]")
+		}
+		builder.WriteString(cleaned)
+	}
+	return []byte(builder.String())
+}
+
+// relPath проверяет, что full лежит внутри root, и возвращает относительный
+// путь с '/' разделителями.
+func relPath(root, full string) (string, error) {
+	rel, err := filepath.Rel(root, full)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("path %s вне root %s", full, root)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+// relFromRoot нормализует путь относительно корня в slash-separated вид.
+func relFromRoot(root, full string) (string, error) {
+	rel, err := relPath(root, full)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(path.Clean(rel), "./"), nil
+}

--- a/pkg/redact/verify_test.go
+++ b/pkg/redact/verify_test.go
@@ -1,0 +1,81 @@
+package redact
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPolicyAppliesIncludeExclude(t *testing.T) {
+	p := Policy{
+		Include: []string{"runs/**"},
+		Exclude: []string{"**/reports/**"},
+	}
+	if !p.Applies("runs/abc/events.jsonl") {
+		t.Error("runs/** должно включать events.jsonl")
+	}
+	if p.Applies("reports/foo.html") {
+		t.Error("вне include должен быть исключён")
+	}
+	if p.Applies("runs/abc/reports/x.html") {
+		t.Error("exclude **/reports/** должен исключать")
+	}
+}
+
+func TestPolicyValidateRejectsTraversal(t *testing.T) {
+	p := Policy{Include: []string{"../escape"}}
+	if err := p.Validate(); err == nil {
+		t.Error("glob с выходом из workspace должен быть отвергнут")
+	}
+}
+
+func TestVerifyFailClosedOnSecrets(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "runs", "x"), 0755)
+	if err := os.WriteFile(filepath.Join(dir, "runs", "x", "events.jsonl"),
+		[]byte("GITHUB_TOKEN="+"ghp_"+strings.Repeat("2", 36)+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := Policy{FailOnSecrets: true}
+	report, err := Verify(dir, p)
+	if err == nil {
+		t.Fatalf("fail-closed: ожидалась ошибка, report=%+v", report)
+	}
+	if report == nil || len(report.Violations) != 1 {
+		t.Fatalf("ожидалась 1 violation, got %+v", report)
+	}
+	if report.Violations[0].Path != "runs/x/events.jsonl" {
+		t.Fatalf("путь нарушения: %s", report.Violations[0].Path)
+	}
+}
+
+func TestVerifyCleanPasses(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "runs", "x"), 0755)
+	if err := os.WriteFile(filepath.Join(dir, "runs", "x", "events.jsonl"),
+		[]byte("{\"stage\":\"review\",\"verdict\":\"APPROVED\"}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	report, err := Verify(dir, Policy{FailOnSecrets: true})
+	if err != nil {
+		t.Fatalf("чистый каталог не должен фейлить: %v", err)
+	}
+	if report.Verdict != "clean" {
+		t.Fatalf("verdict = %s", report.Verdict)
+	}
+}
+
+func TestVerifyExcludeSkipsFile(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "meta"), 0755)
+	if err := os.WriteFile(filepath.Join(dir, "meta", "tokens.txt"),
+		[]byte("GITHUB_TOKEN="+"ghp_"+strings.Repeat("3", 36)+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	p := Policy{FailOnSecrets: true, Exclude: []string{"meta/**"}}
+	if _, err := Verify(dir, p); err != nil {
+		t.Fatalf("excluded-файл должен быть проигнорирован: %v", err)
+	}
+}


### PR DESCRIPTION
## P1-6 redaction contract (PR #91)

Восстановление P1-6 на базе master: черри-пик фича-ветки + два свежих фикса от независимого R2-ревью.

### Коммиты
- `514ba7f` feat — redact/scan/verify CLI, fail-closed export block, configurable retention
- `408c24f` fix — review feedback P1-6 PR #69 (все блокеры + should-fix)
- `49761d8` docs — scan_sensitive_fields/raw_logs как reserved future knobs
- `db2a2d6` fix — R2 независимое ревью: newline-сохранение в PEM-redaction + `--path` containment guard

### R2-фиксы (два независимых ревизора + owner)
1. **PEM newline-loss (REAL BUG, найден Reviewer B)**: `redactByLines` терял `\n` при замене блока private key — маркеры BEGIN/тело/END склеивались в одну строку. `preserveEOL` восстанавливает перевод строки; тест проверяет сохранение числа `\n`.
2. **`--path` traversal (оба ревизора)**: `resolveScanPath` + контентный guard против `../..`-обхода (аналог `validRunID` для `--run`); тест на выход за корень.

### Owner-вердикт по спорным пунктам
- basic-auth over-match → fail-closed by design, не баг (требует `scheme://user:pass@`)
- `Finding.RedactedValue()` → public API контракт, оставлен
- `raw_logs`/`scan_sensitive_fields` → документированные reserved future knobs