### PR TITLE
docs(readme,changelog): external-facing README and CHANGELOG v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-04
+
+Второй публичный релиз. Фокус — runtime-адаптеры, происхождение и безопасность,
+детерминированный gate, приватность и подготовка к публичному open-source.
+
+### Added
+
+- **Runtime-адаптеры** поверх тонкого контракта `RuntimeAdapter` с registry
+  (P1-1): OpenCode (P1-1), Codex (`codex exec`, launch-carrying `Command`
+  contract, ADP-1) и Claude Code (`claude -p`, JSON usage, deny-list policy,
+  ADP-2).
+- **Происхождение и доверие:** authority-bearing provenance manifest v1 с
+  обнаружением drift при resume (V0-2), in-toto-совместимый attestation
+  predicate v1 (V0-3), test-mutation provenance и policy (V0-1) и
+  DSSE-signed bundle (ed25519, stdlib-only, PAE по спецификации in-toto; P1-5).
+- **Контейнерная политика:** containment profile v1 c per-axis receipt
+  (fs/net/proc/env; P1-4) и детерминированный diff-policy gate MVP (V0-5) с
+  typed checks, attestation bundle и риск-сигналами (V0-8).
+- **Самодостаточные артефакты:** экспорт проверенного run/gate-bundle с
+  fail-closed гарантиями (V0-4, V0-7, V0-0) и generic junit-xml typed adapter
+  (V0-6).
+- **Приватность (P1-6):** privacy-контракт — secrets-скан evidence, fail-closed
+  export verify и detached-копия с заменой секретов на `[REDACTED:...]`.
+- **Жёсткий бюджет и честность:** hard run budget + attested usage truthfulness
+  (P1-7) и fail-closed evidence verification on resume (OPS-3).
+- **CLI/UX:** структурированный JSON/quiet вывод + `pkg/logging` (OPS-6).
+- **CI/infra:** импорт ограниченного объяснимого набора checks из GitHub Actions
+  без исполнения произвольного YAML (P1-8), конфигурируемый tree-hash ignore
+  list (OPS-2), Dependabot для SHA-pinned Actions (OPS-10).
+- **Open-source:** публичный сайт документации (docsgen → GitHub Pages), release
+  workflow (multi-platform бинарники), SECURITY, CODE_OF_CONDUCT, issue/PR
+  шаблоны, Dependabot.
+
+### Changed
+
+- Консолидированный gate delivery, deferred gate approvals и повторное
+  использование на re-traversal (APF-1): `verifier` и `deployer` переработаны.
+- Evidence-цепочка и approve-модель: канонический delivery plan подтверждается
+  исключительно по точному SHA-256 (роль `release_manager`).
+
+### Removed
+
+- Легаси-пути approvals и внутренние планировочные артефакты (plans/,
+  BACKLOG, TASKLOG, AUDIT, kimi-review) — трекинг задач перенесён в GitHub
+  Issues.
+
 ## [0.1.0] - 2026-08-23
 
 Первый публичный релиз ai-team — строгого workflow-контроллера AI-агентов.
@@ -28,5 +74,6 @@
 - CLI: `ai-team version`, exit-коды run (OK/FAILED/BLOCKED/USER_STOPPED),
   E2E-тесты на mock-opencode.
 
-[Unreleased]: https://github.com/arturpanteleev/ai-team/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/arturpanteleev/ai-team/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/arturpanteleev/ai-team/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/arturpanteleev/ai-team/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # ai-team
 
 [![CI](https://github.com/arturpanteleev/ai-team/actions/workflows/ci.yaml/badge.svg)](https://github.com/arturpanteleev/ai-team/actions/workflows/ci.yaml)
+[![Docs](https://img.shields.io/badge/docs-site-blue)](https://arturpanteleev.github.io/ai-team/)
+[![Release](https://img.shields.io/github/v/release/arturpanteleev/ai-team)](https://github.com/arturpanteleev/ai-team/releases/latest)
+[![Go](https://img.shields.io/github/go-mod/go-version/arturpanteleev/ai-team)](https://go.dev/dl/)
+[![License](https://img.shields.io/github/license/arturpanteleev/ai-team)](LICENSE)
 
 Локальный control plane для решения IT-задач цепочкой AI-агентов. LLM создаёт
 артефакты (proposal, design, код, тесты, review) и предлагает вердикты;
 переходы между этапами, проверки, mutation scopes, evidence и delivery
-исполняет детерминированный Go-контроллер — не LLM.
+исполняет детерминированный Go-контроллер — **не LLM**.
+
+AI-агенты — это «мозг», но не «руки»: всё, что меняет репозиторий или выходит
+за его пределы (commit, push, PR), выполняется только после детерминированных
+проверок и явного подтверждения человеком точного delivery-плана.
+
+Публичный сайт документации: **<https://arturpanteleev.github.io/ai-team/>**
 
 Если вы новый читатель, читайте разделы по порядку: этот README проведёт вас
 от установки до первой поставленной фичи. Глубокое описание внутреннего
@@ -50,6 +60,8 @@ go install github.com/arturpanteleev/ai-team/cmd/ai-team@latest
 
 ## Быстрый старт
 
+Подготовка проекта — **один вызов**:
+
 ```bash
 cd /my-project
 ai-team init
@@ -65,14 +77,28 @@ Node, неизвестный) `init` выводит warning: delivery остаё
 вы не настроите required unit/integration check вручную (см.
 [«Конфигурация»](#конфигурация)).
 
+Запустите фичу: от идеи до готового к доставке кода — **два запуска**, и между
+ними вы осознанно читаете и подтверждаете план.
+
 ```bash
+# 1. Провести фичу по конвейеру: аналитик → архитектор → кодер → ревьюер →
+#    тестер → верификатор → deployer. Контроллер останавливается перед
+#    delivery и печатает canonical plan + его SHA-256 (exit code 3).
 ai-team run --feature add-jwt-auth --task "Реализовать JWT авторизацию"
 ```
 
-Это самый частый способ запуска. Переходы между смысловыми AI-этапами требуют
-решения человека с подходящей ролью. В TTY контроллер спрашивает решение
-сразу; без TTY сохраняет pending approval и тот же run можно продолжить после
-записи решения.
+```bash
+# 2. Подтвердить именно тот план, который показал контроллер (другой SHA-256
+#    не подойдёт), — и только тогда будет создан commit/push/PR.
+ai-team run --resume <run_id> --approve-plan <sha256-из-шага-1>
+```
+
+В интерактивном терминале checkpoints спрашивают ваше решение сами, без
+флагов `--approve-*`. После доставки результат виден на дашборде
+(`ai-team web`) или в директории `.ai-team/runs/<run_id>/`.
+
+Полный путь с пояснением каждого шага — в разделе
+[«Как поставить фичу от начала до конца»](#как-поставить-фичу-от-начала-до-конца).
 
 ## Как поставить фичу от начала до конца
 


### PR DESCRIPTION
## Что

Priority 1 по подготовке к публичному open-source: README, ориентированный на внешнего читателя, и зафиксированный CHANGELOG v0.2.0.

## Изменения

- **README**: бейджи (CI, Docs, Release, Go, License), позиционирование «агенты — мозг, но не руки», ссылка на публичный сайт, сверхкомпактный quickstart «два запуска до первой фичи». Убран дубль go install (остался один, в «Предварительных требованиях»).
- **CHANGELOG**: заполнена секция [0.2.0] - 2026-09-04 (Added/Changed/Removed) по коммитам с v0.1.0; обновлены нижние ссылки сравнения.

## Проверки

- go test ./docs/... — зелёные (docs-контракты на README сохранены).
- make docs — сайт пересобрался из обновлённого README.
- Кириллические термины глоссария и все 11 required-заголовков сохранены.