### PR TITLE
Audit P0 fixes: AUD-01..04

### DIFF
--- a/pkg/containment/containment.go
+++ b/pkg/containment/containment.go
@@ -38,6 +38,13 @@ var ValidLevels = map[Level]bool{
 	LevelENFORCED: true, LevelPARTIAL: true, LevelUNAVAILABLE: true,
 }
 
+// ValidProfiles — распознаваемые containment profiles (AUD-02). "unknown" —
+// честный маркер UnavailableReceipt() для legacy-ранов/отсутствующего backend,
+// а не доверенный профиль исполнения.
+var ValidProfiles = map[string]bool{
+	"trusted-local": true, "strict": true, "unknown": true,
+}
+
 // Receipt — per-axis containment status for a run. Profile determines which
 // mitigations are applied; Receipt captures the actual outcome.
 type Receipt struct {
@@ -57,6 +64,9 @@ func (r Receipt) Validate() error {
 	}
 	if r.Profile == "" {
 		return errors.New("containment receipt: пустой profile")
+	}
+	if !ValidProfiles[r.Profile] {
+		return fmt.Errorf("containment receipt: неизвестный profile %q", r.Profile)
 	}
 	for _, axis := range AllAxes {
 		level, ok := r.Axes[axis]
@@ -82,6 +92,17 @@ func (r Receipt) Validate() error {
 		}
 	}
 	return nil
+}
+
+// IsEnforced — true, только если все четыре оси реально ENFORCED (AUD-02).
+// PARTIAL/UNAVAILABLE/legacy-семантика не считается fail-closed исполнением.
+func (r Receipt) IsEnforced() bool {
+	for _, axis := range AllAxes {
+		if r.Axes[axis] != LevelENFORCED {
+			return false
+		}
+	}
+	return true
 }
 
 // UnmarshalJSON implements json.Unmarshaler with unknown field rejection.

--- a/pkg/containment/containment_test.go
+++ b/pkg/containment/containment_test.go
@@ -93,3 +93,43 @@ func TestReceiptPartialDetails(t *testing.T) {
 		t.Fatal("should detect UNAVAILABLE on proc axis")
 	}
 }
+
+// AUD-02: неизвестный profile обязан валидироваться в ошибку (fail-closed).
+func TestReceiptValidationRejectsUnknownProfile(t *testing.T) {
+	r := UnavailableReceipt()
+	r.Profile = "paranoid"
+	if err := r.Validate(); err == nil {
+		t.Fatal("unknown profile must be rejected (AUD-02)")
+	}
+}
+
+// AUD-02: IsEnforced истинно только при ENFORCED по всем осям; ONE
+// PARTIAL/UNAVAILABLE axis достаточен для блокировки untrusted.
+func TestReceiptIsEnforced(t *testing.T) {
+	unavailable := UnavailableReceipt()
+	if unavailable.IsEnforced() {
+		t.Fatal("UNAVAILABLE receipt не может быть enforced")
+	}
+	trustedLocal := DefaultTrustedLocalReceipt()
+	if trustedLocal.IsEnforced() {
+		t.Fatal("PARTIAL receipt не может быть enforced")
+	}
+	mixed := Receipt{
+		Profile: "strict",
+		Axes: map[Axis]Level{
+			AxisFS: LevelENFORCED, AxisNet: LevelENFORCED, AxisProc: LevelPARTIAL, AxisEnv: LevelENFORCED,
+		},
+	}
+	if mixed.IsEnforced() {
+		t.Fatal("одна PARTIAL ось ломает IsEnforced")
+	}
+	allEnforced := Receipt{
+		Profile: "strict",
+		Axes: map[Axis]Level{
+			AxisFS: LevelENFORCED, AxisNet: LevelENFORCED, AxisProc: LevelENFORCED, AxisEnv: LevelENFORCED,
+		},
+	}
+	if !allEnforced.IsEnforced() {
+		t.Fatal("все четыре ENFORCED оси должны давать IsEnforced=true")
+	}
+}

--- a/pkg/dsse/dsse.go
+++ b/pkg/dsse/dsse.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/arturpanteleev/ai-team/pkg/safeio"
 )
 
 // Pre-Authentication Encoding prefix per DSSE spec.
@@ -103,7 +105,9 @@ const EnvelopeFileName = "dsse.json"
 // BundleDigest (hex-строка) run- или gate-bundle.
 const SignaturePayloadType = "application/vnd.ai-team.bundle+hex"
 
-// SignBundleFile подписывает bundle digest и пишет EnvelopeFileName в bundleDir.
+// SignBundleFile подписывает bundle digest и пишет EnvelopeFileName в bundleDir
+// через no-follow примитив safeio (AUD-04): существующий dsse.json или symlink
+// на его месте отвергается, запись вне bundle невозможна.
 // Errors оставляют каталог без частичного файла при ошибке записи.
 func SignBundleFile(bundleDir string, priv ed25519.PrivateKey, payloadType string, payload []byte) error {
 	env := SignEnvelope(priv, payloadType, payload)
@@ -113,8 +117,8 @@ func SignBundleFile(bundleDir string, priv ed25519.PrivateKey, payloadType strin
 	}
 	data = append(data, '\n')
 	path := filepath.Join(bundleDir, EnvelopeFileName)
-	if err := os.WriteFile(path, data, 0444); err != nil {
-		return err
+	if err := safeio.WriteRegularFileNoFollow(path, data, 0444); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
 	}
 	return nil
 }

--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -473,11 +473,18 @@ func isWorkTree(ctx context.Context, target string) (bool, error) {
 	return strings.TrimSpace(string(output)) == "true", nil
 }
 
-// workingTreeMatchesCommit проверяет, что tracked содержимое рабочего дерева
-// равно candidate-коммиту. Используется `git diff` (в т.ч. --cached), а не
-// status --porcelain: untracked-каталоги (например, .ai-team) не считаются
-// изменением checkout'а. Возвращает (false, nil) при наличии отличий и
-// BLOCKED-ошибку для инфраструктурных проблем.
+// workingTreeMatchesCommit проверяет, что рабочее дерево равно
+// candidate-коммиту:
+//   - tracked содержимое — `git diff` и `git diff --cached` (exit 1 = отличия);
+//   - untracked НЕ-ignored содержимое — `git ls-files --others
+//     --exclude-standard`. Такие файлы не входят в candidate-коммит, но
+//     выполняются в живом рабочем дереве и могут влиять на PASS, поэтому
+//     для commit-кандидата они тоже считаются несовпадением (AUD-01, F-4).
+//     Служебные untracked-каталоги (например, .ai-team) остаются разрешены:
+//     они покрыты .gitignore и отсекаются --exclude-standard.
+//
+// Возвращает (false, nil) при наличии отличий, BLOCKED-ошибку для
+// инфраструктурных проблем и (true, nil) при полном совпадении.
 func workingTreeMatchesCommit(ctx context.Context, target, commit string) (bool, error) {
 	for _, extra := range [][]string{
 		{"--quiet", commit},
@@ -498,6 +505,20 @@ func workingTreeMatchesCommit(ctx context.Context, target, commit string) (bool,
 			}
 			return false, errors.New(strings.TrimSpace(buffer.String()))
 		}
+	}
+	// untracked-файлы вне .gitignore: они не в candidate, но видны checks.
+	command := exec.CommandContext(ctx, "git", "-C", target, "ls-files", "--others", "--exclude-standard")
+	var buffer bytes.Buffer
+	command.Stdout, command.Stderr = &buffer, &buffer
+	if err := command.Run(); err != nil {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		return false, errors.New("не удалось перечислить untracked-файлы: " + strings.TrimSpace(buffer.String()))
+	}
+	if untracked := strings.Fields(buffer.String()); len(untracked) > 0 {
+		sort.Strings(untracked)
+		return false, fmt.Errorf("Git working tree содержит untracked-файлы вне .gitignore (их нет в candidate %q, но они видны checks): %s", commit, strings.Join(untracked[:min(len(untracked), 8)], ", "))
 	}
 	return true, nil
 }

--- a/pkg/gate/gate.go
+++ b/pkg/gate/gate.go
@@ -228,6 +228,10 @@ type Result struct {
 	Status           string          `json:"status"`
 	FinishedAt       time.Time       `json:"finished_at"`
 	BundleSHA256     string          `json:"bundle_sha256,omitempty"`
+	// WorkspaceDigest — fingerprint рабочего дерева, против которого реально
+	// выполнялись checks (AUD-01). Привязывает результат проверок к фактически
+	// просканированному checkout, а не только к заявленному candidate.
+	WorkspaceDigest string `json:"workspace_digest,omitempty"`
 }
 
 // Signals (V0-8) — измеренные risk-signals diff: размер/тип изменений,
@@ -270,8 +274,10 @@ func Run(ctx context.Context, opt Options) (*Result, int, error) {
 		if validateErr := opt.Receipt.Validate(); validateErr != nil {
 			return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode: невалидный containment receipt: " + validateErr.Error()}
 		}
-		if opt.Receipt.HasUnavailable() {
-			return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode запрещён: оси containment UNAVAILABLE"}
+		// AUD-02: untrusted требует fail-closed исполнения по всем осям. Один
+		// PARTIAL/UNAVAILABLE axis переводит режим в blocked.
+		if !opt.Receipt.IsEnforced() {
+			return nil, ExitBlocked, &BlockedError{Reason: "untrusted mode запрещён: containment оси не полностью ENFORCED"}
 		}
 	}
 	cfg := opt.Config
@@ -301,6 +307,20 @@ func Run(ctx context.Context, opt Options) (*Result, int, error) {
 		candidateCommit, err = resolveCommit(ctx, opt.TargetDir, candidate)
 		if err != nil {
 			return nil, ExitBlocked, &BlockedError{Reason: err.Error()}
+		}
+		// AUD-01: commit-кандидат требует, чтобы рабочее дерево совпадало с ним
+		// по tracked-содержимому. Иначе checks выполнялись бы над другим
+		// checkout, а PASS/подписанный bundle приписывались бы непроверенному
+		// candidate. Проверка обязательна и для WORKTREE-кандидатов не нужна —
+		// там рабочее дерево и есть candidate.
+		match, matchErr := workingTreeMatchesCommit(ctx, opt.TargetDir, candidateCommit)
+		if matchErr != nil {
+			return nil, ExitBlocked, &BlockedError{Reason: matchErr.Error()}
+		}
+		if !match {
+			return nil, ExitBlocked, &BlockedError{
+				Reason: fmt.Sprintf("Git working tree не совпадает с candidate %q (%s): checks выполнялись бы над другим содержимым, чем заявленный candidate (fail-closed; используйте чистый checkout candidate или WORKTREE)", opt.Candidate, candidateCommit),
+			}
 		}
 	}
 	baseTree, err := treeSHA(ctx, opt.TargetDir, baseCommit)
@@ -370,6 +390,14 @@ func Run(ctx context.Context, opt Options) (*Result, int, error) {
 	if len(cfg.Checks) > 0 {
 		results, checkErr := (checks.Runner{TargetDir: opt.TargetDir}).RunAll(ctx, cfg.Checks)
 		result.Checks = results
+		// AUD-01: workspace identity вычисляется в post-состоянии — ровно в том
+		// же виде, в котором каждый check записал WorkspaceDigestAfter
+		// (адаптеры могут легально создавать report-артефакты в дереве).
+		workspaceDigest, digestErr := checks.WorkspaceDigest(opt.TargetDir)
+		if digestErr != nil {
+			return nil, ExitBlocked, &BlockedError{Reason: "не удалось вычислить workspace identity: " + digestErr.Error()}
+		}
+		result.WorkspaceDigest = workspaceDigest
 		result.Signals.ChecksRun = len(results)
 		for _, check := range results {
 			if check.Status == checks.StatusFailed {
@@ -443,6 +471,35 @@ func isWorkTree(ctx context.Context, target string) (bool, error) {
 		return false, &BlockedError{Reason: fmt.Sprintf("не удалось инициализировать Git: %v", err)}
 	}
 	return strings.TrimSpace(string(output)) == "true", nil
+}
+
+// workingTreeMatchesCommit проверяет, что tracked содержимое рабочего дерева
+// равно candidate-коммиту. Используется `git diff` (в т.ч. --cached), а не
+// status --porcelain: untracked-каталоги (например, .ai-team) не считаются
+// изменением checkout'а. Возвращает (false, nil) при наличии отличий и
+// BLOCKED-ошибку для инфраструктурных проблем.
+func workingTreeMatchesCommit(ctx context.Context, target, commit string) (bool, error) {
+	for _, extra := range [][]string{
+		{"--quiet", commit},
+		{"--quiet", "--cached", commit},
+	} {
+		args := append([]string{"-C", target, "--no-pager", "diff"}, extra...)
+		command := exec.CommandContext(ctx, "git", args...)
+		var buffer bytes.Buffer
+		command.Stdout, command.Stderr = &buffer, &buffer
+		if err := command.Run(); err != nil {
+			if ctx.Err() != nil {
+				return false, ctx.Err()
+			}
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+				// git diff --quiet: exit 1 означает «есть отличия».
+				return false, nil
+			}
+			return false, errors.New(strings.TrimSpace(buffer.String()))
+		}
+	}
+	return true, nil
 }
 
 func resolveCommit(ctx context.Context, target, ref string) (string, error) {
@@ -742,6 +799,18 @@ func VerifyBundle(bundleDir string, keyVerify ...ed25519.PublicKey) (string, err
 		return "", fmt.Errorf("verify gate bundle: заявленный bundle_sha256 %q не равен digest %q",
 			verdict.BundleSHA256, digest)
 	}
+	// AUD-01: verify связывает check workspace identity с candidate workspace.
+	// gate.json фиксирует digest рабочего дерева, против которого выполнялись
+	// проверки; каждый check обязан быть привязан к тому же workspace, иначе
+	// PASS/подпись относятся к непроверенному содержимому.
+	if verdict.WorkspaceDigest != "" {
+		for i, check := range verdict.Checks {
+			if check.WorkspaceDigestAfter != verdict.WorkspaceDigest {
+				return "", fmt.Errorf("verify gate bundle: check %d (%s) workspace identity %q не совпадает с candidate workspace %q",
+					i+1, check.Name, check.WorkspaceDigestAfter, verdict.WorkspaceDigest)
+			}
+		}
+	}
 	if err := verifyDSSeSignature(dir, digest, keyVerify...); err != nil {
 		return "", fmt.Errorf("verify gate bundle: %w", err)
 	}
@@ -805,11 +874,12 @@ func WriteBundle(outDir string, result *Result) error {
 	if result == nil {
 		return errors.New("gate: нет вердикта для bundle")
 	}
-	if err := os.MkdirAll(outDir, 0755); err != nil {
-		return err
-	}
-	if _, err := safeio.ExistingDir(outDir); err != nil {
-		return err
+	// AUD-04: outDir создаётся компонентно без follow симлинков, а каждый
+	// файл пишется через safeio.WriteRegularFileNoFollow (O_EXCL). Повторная
+	// запись в существующий bundle и symlink-подмена на месте любых output
+	// файлов (gate.json, checks/*.json, index.json) отвергаются.
+	if err := safeio.EnsureDirPath(outDir); err != nil {
+		return fmt.Errorf("gate bundle output: %w", err)
 	}
 	records := make([]Record, 0, len(result.Checks)+1)
 	result.BundleSHA256 = ""
@@ -818,12 +888,12 @@ func WriteBundle(outDir string, result *Result) error {
 		return err
 	}
 	gateData = append(gateData, '\n')
-	if err := os.WriteFile(filepath.Join(outDir, "gate.json"), gateData, 0444); err != nil {
-		return err
+	if err := safeio.WriteRegularFileNoFollow(filepath.Join(outDir, "gate.json"), gateData, 0444); err != nil {
+		return fmt.Errorf("gate bundle gate.json: %w", err)
 	}
 	records = append(records, Record{Type: "gate_result", Path: "gate.json", SHA256: sha256Bytes(gateData)})
 	if len(result.Checks) > 0 {
-		if err := os.MkdirAll(filepath.Join(outDir, "checks"), 0755); err != nil {
+		if err := safeio.EnsureDirPath(filepath.Join(outDir, "checks")); err != nil {
 			return err
 		}
 		for i, check := range result.Checks {
@@ -834,7 +904,7 @@ func WriteBundle(outDir string, result *Result) error {
 				return err
 			}
 			data = append(data, '\n')
-			if err := os.WriteFile(filepath.Join(outDir, rel), data, 0444); err != nil {
+			if err := safeio.WriteRegularFileNoFollow(filepath.Join(outDir, rel), data, 0444); err != nil {
 				return err
 			}
 			records = append(records, Record{Type: "check_result", Path: filepath.ToSlash(rel), SHA256: sha256Bytes(data)})
@@ -858,7 +928,7 @@ func WriteBundle(outDir string, result *Result) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(outDir, indexFileName), append(data, '\n'), 0644); err != nil {
+	if err := safeio.WriteRegularFileNoFollow(filepath.Join(outDir, indexFileName), append(data, '\n'), 0644); err != nil {
 		return err
 	}
 	result.BundleSHA256 = BundleDigest(index)

--- a/pkg/gate/gate_test.go
+++ b/pkg/gate/gate_test.go
@@ -203,12 +203,29 @@ func TestBlockedOnUnknownRefAndUntrusted(t *testing.T) {
 		t.Fatalf("untrusted flag: code=%d err=%v", code, err)
 	}
 
-	// untrusted + валидный receipt без UNAVAILABLE осей → не блокируется.
-	receipt := containment.DefaultTrustedLocalReceipt()
+	// untrusted + receipt с PARTIAL осями (trusted-local) → блокируется:
+	// AUD-02 требует ENFORCED по всем осям, а не только отсутствия UNAVAILABLE.
+	partial := containment.DefaultTrustedLocalReceipt()
 	if _, code, err = Run(context.Background(), Options{TargetDir: repo, Base: "HEAD", Candidate: "HEAD",
 		Config:         &Config{SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyOff}},
-		AllowUntrusted: true, Receipt: &receipt}); code == ExitBlocked || err != nil {
-		t.Fatalf("untrusted с receipt: code=%d err=%v", code, err)
+		AllowUntrusted: true, Receipt: &partial}); code != ExitBlocked || err == nil {
+		t.Fatalf("untrusted с PARTIAL receipt: code=%d err=%v", code, err)
+	}
+
+	// untrusted + полностью ENFORCED receipt → разрешено (AUD-02).
+	enforced := containment.Receipt{
+		Profile: "strict",
+		Axes: map[containment.Axis]containment.Level{
+			containment.AxisFS:   containment.LevelENFORCED,
+			containment.AxisNet:  containment.LevelENFORCED,
+			containment.AxisProc: containment.LevelENFORCED,
+			containment.AxisEnv:  containment.LevelENFORCED,
+		},
+	}
+	if _, code, err = Run(context.Background(), Options{TargetDir: repo, Base: "HEAD", Candidate: "HEAD",
+		Config:         &Config{SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyOff}},
+		AllowUntrusted: true, Receipt: &enforced}); code == ExitBlocked || err != nil {
+		t.Fatalf("untrusted с ENFORCED receipt: code=%d err=%v", code, err)
 	}
 
 	// untrusted + receipt с UNAVAILABLE осью → блокируется.
@@ -518,5 +535,200 @@ func TestGateBundleSignAndVerify(t *testing.T) {
 	wrongPub, _, _ := ed25519.GenerateKey(rand.Reader)
 	if _, err := VerifyBundle(signed, wrongPub); err == nil {
 		t.Fatal("signed wrong key должен FAIL")
+	}
+}
+
+// AUD-01: commit-кандидат должен совпадать с рабочим деревом, иначе checks
+// выполнялись бы над другим checkout'ом, а вердикт приписывался бы candidate.
+func TestRunBlocksWhenCheckoutDoesNotMatchCandidate(t *testing.T) {
+	repo := newRepo(t, map[string]string{"src/app.go": "package app\n// v1\n"})
+	base := gitCmd(t, repo, "rev-parse", "HEAD")
+	feature := commitChange(t, repo, "feature", map[string]string{"src/app.go": "package app\n// v2\n"})
+	// Чистый checkout base: рабочее дерево != candidate feature.
+	gitCmd(t, repo, "checkout", "-q", "-b", "clean", base)
+
+	result, code, err := Run(context.Background(), Options{TargetDir: repo, Base: base, Candidate: feature, Config: &Config{
+		SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyRequired},
+	}})
+	if code != ExitBlocked || err == nil {
+		t.Fatalf("ожидался blocked (checkout != candidate), code=%d err=%v", code, err)
+	}
+	if !strings.Contains(err.Error(), "не совпадает с candidate") {
+		t.Fatalf("сообщение не объясняет mismatch: %v", err)
+	}
+	if result != nil && len(result.Checks) != 0 {
+		t.Fatalf("checks не должны выполняться при mismatch checkout: %+v", result.Checks)
+	}
+}
+
+func TestRunBlocksDirtyCheckoutForCommitCandidate(t *testing.T) {
+	repo := newRepo(t, map[string]string{"src/app.go": "package app\n"})
+	head := gitCmd(t, repo, "rev-parse", "HEAD")
+	writeFiles(t, repo, map[string]string{"src/app.go": "package app\n// dirty\n"})
+	result, code, err := Run(context.Background(), Options{TargetDir: repo, Base: head, Candidate: "HEAD", Config: &Config{
+		SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyRequired},
+	}})
+	if code != ExitBlocked || err == nil {
+		t.Fatalf("ожидался blocked (dirty checkout), code=%d err=%v", code, err)
+	}
+	if !strings.Contains(err.Error(), "не совпадает с candidate") {
+		t.Fatalf("сообщение не объясняет mismatch: %v", err)
+	}
+	if result != nil && len(result.Checks) != 0 {
+		t.Fatalf("checks не должны выполняться при dirty checkout: %+v", result.Checks)
+	}
+}
+
+// AUD-01: при совпадающем checkout собственно candidate проходит checks,
+// результат привязан к workspace digest, и bundle verify согласован.
+func TestRunChecksExactlyAgainstCommitCandidate(t *testing.T) {
+	repo := newRepo(t, map[string]string{"src/app.go": "package app\n// v1\n"})
+	base := gitCmd(t, repo, "rev-parse", "HEAD")
+	feature := commitChange(t, repo, "feature", map[string]string{"src/app.go": "package app\n// v2\n"})
+
+	cfg := &Config{
+		SchemaVersion: SchemaVersion,
+		DiffPolicy:    DiffPolicy{TestModify: TestModifyOff},
+		Checks: []checks.Definition{{
+			Name: "must-fail", Class: "unit", Adapter: checks.AdapterCommand, Policy: checks.PolicyRequired,
+			Command: []string{"sh", "-c", "exit 1"},
+		}},
+	}
+	result, code, err := Run(context.Background(), Options{TargetDir: repo, Base: base, Candidate: feature, Config: cfg})
+	if err != nil || code != ExitFail {
+		t.Fatalf("clean checkout у feature-кандидата: code=%d err=%v", code, err)
+	}
+	wantDigest, digestErr := checks.WorkspaceDigest(repo)
+	if digestErr != nil {
+		t.Fatal(digestErr)
+	}
+	if result.WorkspaceDigest == "" || result.WorkspaceDigest != wantDigest {
+		t.Fatalf("workspace digest %q != просканированный checkout %q", result.WorkspaceDigest, wantDigest)
+	}
+	if len(result.Checks) != 1 || result.Checks[0].WorkspaceDigestAfter != result.WorkspaceDigest {
+		t.Fatalf("check workspace binding: digest=%q checks=%+v", result.WorkspaceDigest, result.Checks)
+	}
+
+	dir := t.TempDir()
+	if err := WriteBundle(dir, result); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := VerifyBundle(dir)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if digest != result.BundleSHA256 {
+		t.Fatalf("digest %s != bundle_sha256 %s", digest, result.BundleSHA256)
+	}
+}
+
+// AUD-01: VerifyBundle обязан отклонять проверки, привязанные к другому
+// workspace identity, чем заявлен в gate.json.
+func TestVerifyBundleRejectsCheckWorkspaceMismatch(t *testing.T) {
+	fixed := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	result := &Result{
+		SchemaVersion: SchemaVersion, Base: "HEAD", Candidate: "HEAD",
+		BaseCommit: "aabb", CandidateCommit: "ccdd",
+		BaseTree: "tree-a", CandidateTree: "tree-b",
+		DiffPolicy: TestModifyRequired, PolicyVerdict: VerdictPassed,
+		Status: "passed", FinishedAt: fixed, WorkspaceDigest: "digest-A",
+		Checks: []checks.Result{{
+			Name: "go-test", Class: "unit", Adapter: checks.AdapterGoTest,
+			Command: []string{"go", "test", "-json", "./..."}, Policy: checks.PolicyRequired,
+			ExitCode: 0, Status: checks.StatusPassed,
+			StartedAt: fixed, FinishedAt: fixed,
+			WorkspaceDigestAfter: "digest-B",
+		}},
+	}
+	dir := t.TempDir()
+	if err := WriteBundle(dir, result); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyBundle(dir); err == nil || !strings.Contains(err.Error(), "workspace identity") {
+		t.Fatalf("mismatch workspace identity: должен FAIL, got %v", err)
+	}
+}
+
+func TestVerifyBundleAcceptsCheckWorkspaceBinding(t *testing.T) {
+	fixed := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+	result := &Result{
+		SchemaVersion: SchemaVersion, Base: "HEAD", Candidate: "HEAD",
+		BaseCommit: "aabb", CandidateCommit: "ccdd",
+		BaseTree: "tree-a", CandidateTree: "tree-b",
+		DiffPolicy: TestModifyRequired, PolicyVerdict: VerdictPassed,
+		Status: "passed", FinishedAt: fixed, WorkspaceDigest: "digest-X",
+		Checks: []checks.Result{{
+			Name: "go-test", Class: "unit", Adapter: checks.AdapterGoTest,
+			Command: []string{"go", "test", "-json", "./..."}, Policy: checks.PolicyRequired,
+			ExitCode: 0, Status: checks.StatusPassed,
+			StartedAt: fixed, FinishedAt: fixed,
+			WorkspaceDigestAfter: "digest-X",
+		}},
+	}
+	dir := t.TempDir()
+	if err := WriteBundle(dir, result); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyBundle(dir); err != nil {
+		t.Fatalf("привязанные checks: verify должен пройти, got %v", err)
+	}
+}
+
+// AUD-04: WriteBundle пишет immutable-артефакты no-follow — повторная запись,
+// листовой symlink и symlink-каталог отклоняются без изменения цели.
+func TestWriteBundleRejectsExistingAndSymlinks(t *testing.T) {
+	base := func() *Result {
+		fixed := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+		return &Result{
+			SchemaVersion: SchemaVersion, Base: "HEAD", Candidate: "HEAD",
+			BaseCommit: "aabb", CandidateCommit: "ccdd",
+			BaseTree: "tree-a", CandidateTree: "tree-b",
+			DiffPolicy: TestModifyRequired, PolicyVerdict: VerdictPassed,
+			Status: "passed", FinishedAt: fixed,
+			Checks: []checks.Result{{
+				Name: "go-test", Class: "unit", Adapter: checks.AdapterGoTest,
+				Command: []string{"go", "test", "-json", "./..."}, Policy: checks.PolicyRequired,
+				ExitCode: 0, Status: checks.StatusPassed, StartedAt: fixed, FinishedAt: fixed,
+			}},
+		}
+	}
+
+	// Повторная запись bundle не перезаписывает существующие файлы.
+	first := t.TempDir()
+	if err := WriteBundle(first, base()); err != nil {
+		t.Fatal(err)
+	}
+	original, _ := os.ReadFile(filepath.Join(first, "gate.json"))
+	if err := WriteBundle(first, base()); err == nil {
+		t.Fatal("повторная WriteBundle должна FAIL (immutable)")
+	}
+	after, _ := os.ReadFile(filepath.Join(first, "gate.json"))
+	if !bytes.Equal(original, after) {
+		t.Fatal("gate.json перезаписан второй записью")
+	}
+
+	// Листовой symlink gate.json: write должен FAIL, sentinel не меняется.
+	leaf := t.TempDir()
+	sentinel := filepath.Join(leaf, "sentinel.json")
+	os.WriteFile(sentinel, []byte("keep"), 0644)
+	os.Symlink(sentinel, filepath.Join(leaf, "gate.json"))
+	if err := WriteBundle(leaf, base()); err == nil {
+		t.Fatal("gate.json-symlink: WriteBundle должен FAIL")
+	}
+	if data, _ := os.ReadFile(sentinel); !bytes.Equal(data, []byte("keep")) {
+		t.Fatal("sentinel изменён через leaf symlink")
+	}
+
+	// Symlink-каталог checks: write должен FAIL без записи вне bundle.
+	parent := t.TempDir()
+	os.Mkdir(filepath.Join(parent, "checks"), 0755)
+	victim := t.TempDir()
+	os.Remove(filepath.Join(parent, "checks"))
+	os.Symlink(victim, filepath.Join(parent, "checks"))
+	if err := WriteBundle(parent, base()); err == nil {
+		t.Fatal("checks-symlink: WriteBundle должен FAIL")
+	}
+	if entries, _ := os.ReadDir(victim); len(entries) != 0 {
+		t.Fatalf("запись ушла через symlink в %s: %v", victim, entries)
 	}
 }

--- a/pkg/gate/gate_test.go
+++ b/pkg/gate/gate_test.go
@@ -579,6 +579,54 @@ func TestRunBlocksDirtyCheckoutForCommitCandidate(t *testing.T) {
 	}
 }
 
+// AUD-01 / F-4: commit-кандидат требует ровно candidate-дерево. Untracked
+// non-ignored файл не входит в candidate, но виден checks в живом рабочем
+// дереве и мог бы влиять на PASS, поэтому такой checkout блокируется.
+func TestRunBlocksUntrackedContentForCommitCandidate(t *testing.T) {
+	repo := newRepo(t, map[string]string{"src/app.go": "package app\n"})
+	head := gitCmd(t, repo, "rev-parse", "HEAD")
+	writeFiles(t, repo, map[string]string{"extra/secrets.txt": "secret-data\n"})
+	result, code, err := Run(context.Background(), Options{TargetDir: repo, Base: head, Candidate: head, Config: &Config{
+		SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyRequired},
+	}})
+	if code != ExitBlocked || err == nil {
+		t.Fatalf("ожидался blocked (untracked non-ignored содержимое), code=%d err=%v", code, err)
+	}
+	if !strings.Contains(err.Error(), "untracked") {
+		t.Fatalf("сообщение должно называть untracked-файлы: %v", err)
+	}
+	if result != nil && len(result.Checks) != 0 {
+		t.Fatalf("checks не должны выполняться при untracked содержимом: %+v", result.Checks)
+	}
+}
+
+// AUD-01 / F-4: .ai-team (gitignored untracked service-каталог) НЕ должен
+// блокировать commit-кандидат — служебное содержимое разрешено.
+func TestRunAllowGitignoredServiceDirForCommitCandidate(t *testing.T) {
+	repo := newRepo(t, map[string]string{"src/app.go": "package app\n"})
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte(".ai-team/\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, repo, "add", ".gitignore")
+	gitCmd(t, repo, "commit", "-q", "-m", "add .gitignore")
+	head := gitCmd(t, repo, "rev-parse", "HEAD")
+	if err := os.MkdirAll(filepath.Join(repo, ".ai-team"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".ai-team", "meta.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	result, code, err := Run(context.Background(), Options{TargetDir: repo, Base: head, Candidate: head, Config: &Config{
+		SchemaVersion: SchemaVersion, DiffPolicy: DiffPolicy{TestModify: TestModifyRequired},
+	}})
+	if err != nil || code != ExitPass {
+		t.Fatalf(".ai-team (gitignored) не должен блокировать commit-кандидат: code=%d err=%v", code, err)
+	}
+	if result == nil || result.Status != "passed" {
+		t.Fatalf("ожидался PASS, получено: %+v", result)
+	}
+}
+
 // AUD-01: при совпадающем checkout собственно candidate проходит checks,
 // результат привязан к workspace digest, и bundle verify согласован.
 func TestRunChecksExactlyAgainstCommitCandidate(t *testing.T) {

--- a/pkg/pipeline/finalize.go
+++ b/pkg/pipeline/finalize.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/arturpanteleev/ai-team/pkg/attest"
+	"github.com/arturpanteleev/ai-team/pkg/config"
 	"github.com/arturpanteleev/ai-team/pkg/containment"
 	"github.com/arturpanteleev/ai-team/pkg/evidence"
 	"github.com/arturpanteleev/ai-team/pkg/lifecycle"
@@ -153,20 +154,33 @@ func (rs *runState) writeContainmentReceipt() error {
 
 // containmentReceipt строит receipt для текущего run. trusted-local профиль —
 // все оси PARTIAL (application-level mitigations). strict без OS backend в V1
-// не поддерживается: отсутствующий/иной профиль → честный UNAVAILABLE.
+// не поддерживается (RunWithResult блокирует fail-closed); незнакомый/legacy
+// профиль → честный UNAVAILABLE.
 func (rs *runState) containmentReceipt() containment.Receipt {
-	profile := "trusted-local"
-	if rs.runCfg.ContainmentProfile != "" {
-		profile = rs.runCfg.ContainmentProfile
+	profile := effectiveContainmentProfile(rs.runCfg, rs.p.cfg)
+	if profile != "trusted-local" {
+		// strict недостижим (fail-closed), незнакомый профиль → UNAVAILABLE.
+		base := containment.UnavailableReceipt()
+		base.Profile = profile
+		return base
 	}
 	base := containment.DefaultTrustedLocalReceipt()
-	base.Profile = profile
-	if profile != "trusted-local" {
-		// strict (или незнакомый) без OS backend V1 → все оси UNAVAILABLE.
-		base = containment.UnavailableReceipt()
-		base.Profile = profile
-	}
+	base.Profile = "trusted-local"
 	return base
+}
+
+// effectiveContainmentProfile возвращает фактический профиль исполнения:
+// RunConfig.ContainmentProfile (run-level override) → p.cfg.Containment.Profile
+// → trusted-local. Единственный источник истины для run-уровневого решения в
+// RunWithResult и финализирующего receipt'а.
+func effectiveContainmentProfile(runCfg RunConfig, cfg *config.Config) string {
+	if runCfg.ContainmentProfile != "" {
+		return runCfg.ContainmentProfile
+	}
+	if cfg != nil && cfg.Containment != nil && cfg.Containment.Profile != "" {
+		return cfg.Containment.Profile
+	}
+	return "trusted-local"
 }
 
 // writeAttestation публикует in-toto compatible attestation statement v1

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -205,6 +205,16 @@ func (p *Pipeline) RunWithResult(ctx context.Context, runCfg RunConfig) (RunResu
 	if err := p.cfg.Validate(p.reg); err != nil {
 		return RunResult{}, err
 	}
+	// AUD-02 fail-closed: strict-контракт не реализован, поэтому запрос
+	// strict-профиля блокируется ДО первого обращения к runtime/checks —
+	// единая точка входа (Start и Resume идут через RunWithResult). Никакого
+	// misleading receipt в evidence не создаётся.
+	if effectiveContainmentProfile(runCfg, p.cfg) == "strict" {
+		return RunResult{}, &RunError{
+			Outcome: workflow.RunBlocked,
+			Err:     fmt.Errorf("strict containment профиль недоступен: run отклонён fail-closed (AUD-02); используйте trusted-local"),
+		}
+	}
 	compiledGraph, err := p.cfg.CompiledGraph()
 	if err != nil {
 		return RunResult{}, err

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -493,31 +493,30 @@ func TestRun_HappyPath(t *testing.T) {
 	}
 }
 
-func TestRun_StrictProfileReceiptIsUnavailable(t *testing.T) {
+func TestRun_StrictProfileBlockedBeforeExecution(t *testing.T) {
+	// AUD-02 fail-closed: strict-контракт в V1 не реализован, поэтому запрос
+	// strict-профиля блокируется ДО первого обращения к runtime и ДО записи
+	// какого-либо evidence (никакого misleading UNAVAILABLE receipt).
 	dir := env(t)
 	rt := newScripted()
 	rt.content["reviewer"] = map[string]string{"review": "# Ревью\n\nвсё ок\n\n**Verdict:** APPROVED\n"}
 
 	p := New(cfgFor(config.AgentConfig{Name: "analyst"}, config.AgentConfig{Name: "reviewer"}, config.AgentConfig{Name: "deployer"}),
 		testRegistry(), WithRuntimeFactory(rt.factory), WithPrompter(&scriptedPrompter{}))
-	err := p.Run(context.Background(), RunConfig{
+	result, err := p.RunWithResult(context.Background(), RunConfig{
 		Feature: "feat", TaskDesc: "тестовая задача", TargetDir: dir, ContainmentProfile: "strict", ApproveGates: true,
 	})
-	if err != nil {
-		t.Fatalf("ожидался успех, got: %v", err)
+	var runErr *RunError
+	if !errors.As(err, &runErr) || runErr.Outcome != workflow.RunBlocked {
+		t.Fatalf("strict: ожидался RunBlocked (fail-closed), result=%+v err=%v", result, err)
 	}
-	runDir := onlyRunDir(t, dir)
-	receiptData, readErr := os.ReadFile(filepath.Join(runDir, "containment.json"))
-	if readErr != nil {
-		t.Fatalf("containment.json не записан: %v", readErr)
+	if len(rt.calls) != 0 {
+		t.Fatalf("strict: runtime не должен вызываться, calls=%+v", rt.calls)
 	}
-	var receipt containment.Receipt
-	if err := json.Unmarshal(receiptData, &receipt); err != nil {
-		t.Fatalf("повреждённый containment.json: %v", err)
-	}
-	// strict без OS backend (V1) → все оси UNAVAILABLE (fail-closed).
-	if receipt.Profile != "strict" || !receipt.HasUnavailable() {
-		t.Fatalf("strict receipt: profile=%q unavailable=%v", receipt.Profile, receipt.HasUnavailable())
+	if _, listErr := os.Stat(filepath.Join(dir, ".ai-team", "runs")); listErr == nil {
+		if dirs, _ := os.ReadDir(filepath.Join(dir, ".ai-team", "runs")); len(dirs) != 0 {
+			t.Fatalf("strict: run evidence не должен писаться, найден: %v", dirs)
+		}
 	}
 }
 

--- a/pkg/redact/scanner.go
+++ b/pkg/redact/scanner.go
@@ -7,13 +7,31 @@ package redact
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/arturpanteleev/ai-team/pkg/safeio"
+)
+
+// jsonSecretReason — причина находки для секретных полей в JSON/JSONL.
+const jsonSecretReason = "json secret field"
+
+// jsonSecretRedacted — immutable redaction evidence (AUD-03: "password",
+// "secret", "token", "api_key", "private_key" и пр. поля, чьи значения похожи
+// на реальные секреты, должны обнаруживаться в JSON/JSONL-структурах также,
+// как и в plain-тексте).
+const jsonSecretRedacted = "[REDACTED:json secret field]"
+
+// Лимиты JSON-примеси для сканера (AUD-03): защита от злонамеренно глубоких/
+// больших JSON-документов при детерминированной сортировке evidence.
+const (
+	maxJSONScanBytes = 4 << 20 // 4 MiB
+	maxJSONDepth     = 16
 )
 
 // FieldClass — класс чувствительности поля (документированный контракт).
@@ -185,8 +203,108 @@ func likelySecretValue(value string) bool {
 	return hasUpper && hasDigit
 }
 
+// jsonFrame — контейнер в стеке dexдере. keySecret/expectKey используются
+// только для object-фреймов; для array-фреймов значим только факт вложенности.
+type jsonFrame struct {
+	isObject  bool
+	expectKey bool // в object контексте следующий string — имя ключа
+	keySecret bool // последний ключ object'а классифицирован как secret
+	keyOffset int64
+}
+
+// scanJSON детектирует секретные JSON-поля через токенную экскурсию по
+// документу (AUD-03). Finder работает структурно и не зависит от того,
+// в одну ли строку записан документ. Для не-JSON содержимого (и данных вне
+// bounds) возвращается nil — plain-сканер покрывает остальное.
+func scanJSON(data []byte) []Finding {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	var stack []jsonFrame
+	var findings []Finding
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return findings
+		}
+		offset := decoder.InputOffset()
+		switch value := token.(type) {
+		case string:
+			if len(stack) > 0 && stack[len(stack)-1].isObject && !stack[len(stack)-1].expectKey {
+				// value: значение ключа top-объекта (или следующий ключ утерян —
+				// фрейм всегда хранит последний ключ до прихода его значения).
+				top := &stack[len(stack)-1]
+				if top.keySecret && top.keyOffset >= 0 && top.keyOffset < int64(len(data)) {
+					if likelySecretValue(value) {
+						findings = append(findings, Finding{
+							Reason:   jsonSecretReason,
+							Matched:  value,
+							Redacted: jsonSecretRedacted,
+							Line:     lineAt(data, top.keyOffset),
+						})
+					}
+				}
+				top.keySecret = false
+				top.expectKey = true
+			} else if len(stack) > 0 && stack[len(stack)-1].isObject {
+				// string в роли ключа: фиксируем классификацию имени поля.
+				top := &stack[len(stack)-1]
+				top.expectKey = false
+				top.keySecret = ClassifyField(value) == FieldSecret
+				top.keyOffset = offset
+			}
+		case json.Delim:
+			switch value {
+			case '{':
+				if len(stack) > 0 {
+					stack[len(stack)-1].keySecret = false
+					stack[len(stack)-1].expectKey = true
+				}
+				stack = append(stack, jsonFrame{isObject: true, expectKey: true})
+			case '[':
+				if len(stack) > 0 {
+					stack[len(stack)-1].keySecret = false
+				}
+				stack = append(stack, jsonFrame{})
+			case '}', ']':
+				if len(stack) > 0 {
+					stack = stack[:len(stack)-1]
+				}
+				if len(stack) > 0 && stack[len(stack)-1].isObject {
+					stack[len(stack)-1].expectKey = true
+				}
+			}
+		default:
+			// bool/number/null — значение нестроковое, секрета нет.
+			if len(stack) > 0 {
+				stack[len(stack)-1].keySecret = false
+				if stack[len(stack)-1].isObject {
+					stack[len(stack)-1].expectKey = true
+				}
+			}
+		}
+		if len(stack) > maxJSONDepth {
+			return findings
+		}
+	}
+	return findings
+}
+
+// lineAt возвращает 1-based номер строки для byte offset (AUD-03).
+func lineAt(data []byte, offset int64) int {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > int64(len(data)) {
+		offset = int64(len(data))
+	}
+	return 1 + bytes.Count(data[:int(offset)], []byte("\n"))
+}
+
 // Scan возвращает все подтверждённые секретные вхождения в data. Результат
 // стабильно упорядочен (по правилу, затем по позиции) для детерминизма.
+// Помимо line-based правил сканируются структурные JSON-поля (AUD-03).
 func Scan(data []byte) []Finding {
 	var findings []Finding
 	for lineNumber, rawLine := range bytes.Split(data, []byte("\n")) {
@@ -221,6 +339,9 @@ func Scan(data []byte) []Finding {
 				})
 			}
 		}
+	}
+	if len(data) > 0 && int64(len(data)) <= maxJSONScanBytes {
+		findings = append(findings, scanJSON(data)...)
 	}
 	sort.SliceStable(findings, func(i, j int) bool {
 		if findings[i].Line != findings[j].Line {

--- a/pkg/redact/scanner.go
+++ b/pkg/redact/scanner.go
@@ -174,8 +174,10 @@ func endPrivateKeyRe() *regexp.Regexp {
 }
 
 // likelySecretValue фильтрует ложные срабатывания secret assignment:
-// значения-плейсхолдеры, vault/env-ссылки и короткие слова без верхнего
-// регистра и цифр не считаются секретом.
+// значения-плейсхолдеры, vault/env-ссылки и обычные слова без цифр не
+// считаются секретом. Токен обязан содержать и букву, и цифру (покрывает
+// hex/base64/lower-токены, которые раньше терялись из-за требования верхнего
+// регистра — F-7); чистые слова остаются benign.
 func likelySecretValue(value string) bool {
 	value = strings.Trim(value, "\"' ")
 	if len(value) < 16 {
@@ -191,25 +193,31 @@ func likelySecretValue(value string) bool {
 			return false
 		}
 	}
-	var hasUpper, hasDigit bool
+	var hasLetter, hasDigit bool
 	for _, r := range value {
 		switch {
 		case r >= 'A' && r <= 'Z':
-			hasUpper = true
+			hasLetter = true
+		case r >= 'a' && r <= 'z':
+			hasLetter = true
 		case r >= '0' && r <= '9':
 			hasDigit = true
 		}
 	}
-	return hasUpper && hasDigit
+	return hasLetter && hasDigit
 }
 
-// jsonFrame — контейнер в стеке dexдере. keySecret/expectKey используются
+// jsonFrame — контейнер в стеке декодера. keySecret/expectKey используются
 // только для object-фреймов; для array-фреймов значим только факт вложенности.
+// secretCtx наследуется родителем и означает, что значения этого контейнера
+// находятся в секретном дереве (значение секретного ключа или элемент
+// секретного массива) — позволяет не терять контекст на массивах (F-7).
 type jsonFrame struct {
 	isObject  bool
 	expectKey bool // в object контексте следующий string — имя ключа
 	keySecret bool // последний ключ object'а классифицирован как secret
 	keyOffset int64
+	secretCtx bool
 }
 
 // scanJSON детектирует секретные JSON-поля через токенную экскурсию по
@@ -231,11 +239,13 @@ func scanJSON(data []byte) []Finding {
 		offset := decoder.InputOffset()
 		switch value := token.(type) {
 		case string:
-			if len(stack) > 0 && stack[len(stack)-1].isObject && !stack[len(stack)-1].expectKey {
-				// value: значение ключа top-объекта (или следующий ключ утерян —
-				// фрейм всегда хранит последний ключ до прихода его значения).
-				top := &stack[len(stack)-1]
-				if top.keySecret && top.keyOffset >= 0 && top.keyOffset < int64(len(data)) {
+			if len(stack) == 0 {
+				continue
+			}
+			top := &stack[len(stack)-1]
+			if top.isObject && !top.expectKey {
+				// value: значение ключа top-объекта.
+				if (top.keySecret || top.secretCtx) && top.keyOffset >= 0 && top.keyOffset < int64(len(data)) {
 					if likelySecretValue(value) {
 						findings = append(findings, Finding{
 							Reason:   jsonSecretReason,
@@ -247,26 +257,46 @@ func scanJSON(data []byte) []Finding {
 				}
 				top.keySecret = false
 				top.expectKey = true
-			} else if len(stack) > 0 && stack[len(stack)-1].isObject {
+			} else if top.isObject {
 				// string в роли ключа: фиксируем классификацию имени поля.
-				top := &stack[len(stack)-1]
 				top.expectKey = false
 				top.keySecret = ClassifyField(value) == FieldSecret
 				top.keyOffset = offset
+			} else {
+				// элемент массива: секретный контекст наследован от ключа.
+				if top.secretCtx {
+					if likelySecretValue(value) {
+						findings = append(findings, Finding{
+							Reason:   jsonSecretReason,
+							Matched:  value,
+							Redacted: jsonSecretRedacted,
+							Line:     lineAt(data, offset),
+						})
+					}
+				}
 			}
 		case json.Delim:
 			switch value {
 			case '{':
+				inherited := false
 				if len(stack) > 0 {
-					stack[len(stack)-1].keySecret = false
-					stack[len(stack)-1].expectKey = true
+					top := &stack[len(stack)-1]
+					// объект как значение ключа или элемент объекта/массива
+					// наследует секретный контекст родителя.
+					inherited = top.keySecret || top.secretCtx
+					top.keySecret = false
+					top.expectKey = true
 				}
-				stack = append(stack, jsonFrame{isObject: true, expectKey: true})
+				stack = append(stack, jsonFrame{isObject: true, expectKey: true, secretCtx: inherited})
 			case '[':
+				inherited := false
 				if len(stack) > 0 {
-					stack[len(stack)-1].keySecret = false
+					top := &stack[len(stack)-1]
+					inherited = top.keySecret || top.secretCtx
+					top.keySecret = false
+					top.expectKey = true
 				}
-				stack = append(stack, jsonFrame{})
+				stack = append(stack, jsonFrame{secretCtx: inherited})
 			case '}', ']':
 				if len(stack) > 0 {
 					stack = stack[:len(stack)-1]

--- a/pkg/redact/scanner_test.go
+++ b/pkg/redact/scanner_test.go
@@ -127,3 +127,96 @@ func TestClassifyField(t *testing.T) {
 		}
 	}
 }
+
+func hasFindingReason(findings []Finding, reason string) bool {
+	for _, f := range findings {
+		if f.Reason == reason {
+			return true
+		}
+	}
+	return false
+}
+
+// AUD-03: секретные JSON-поля обнаруживаются структурно независимо от того,
+// в одну ли строку записан документ.
+func TestScanJSONSecretFields(t *testing.T) {
+	secret := "s3cReTValX9zW8qK2nM4pR7t"
+	input := []byte(`{
+  "service": {
+    "name": "billing",
+    "credentials": {
+      "password": "` + secret + `"
+    },
+    "client_secret": "` + secret + `",
+    "owner": "team-core"
+  }
+}`)
+	findings := Scan(input)
+	if !hasFindingReason(findings, jsonSecretReason) {
+		t.Fatalf("json secret field не обнаружен: %+v", findings)
+	}
+	for _, f := range findings {
+		if f.Reason == jsonSecretReason && f.Redacted != jsonSecretRedacted {
+			t.Fatalf("неверный redaction-маркер: %+v", f)
+		}
+	}
+}
+
+// AUD-03: плейсхолдеры/известные benign-значения в JSON-полях секретным
+// evidence НЕ являются (тот же likelySecretValue-фильтр, что у assignment).
+func TestScanJSONIgnoresPlaceholders(t *testing.T) {
+	input := []byte(`{"password": "your-password", "token": "changeme", "api_key": "placeholder"}`)
+	findings := Scan(input)
+	if hasFindingReason(findings, jsonSecretReason) {
+		t.Fatalf("placeholder-значение посчитано секретом: %+v", findings)
+	}
+}
+
+// AUD-03: один и тот же синтетический секрет обнаруживается в plain-тексте,
+// JSON, JSONL и nested JSON с корректной привязкой к строке.
+func TestScanDetectsSecretAcrossFormats(t *testing.T) {
+	secret := "T0pSecretValue21k9XzW8qK2nM4"
+	cases := []struct {
+		name string
+		data string
+		line int
+	}{
+		{"plain", "api_key = " + secret + "\n", 1},
+		{"json", "{\"api_key\":\"" + secret + "\"}\n", 1},
+		{"nested json", "{\"k8s\":{\"deploy\":{\"token\":\"" + secret + "\"}}}\n", 1},
+		{"jsonl", "{\"stage\":1}\n{\"credentials\":{\"password\":\"" + secret + "\"},\"ok\":1}\n", 2},
+	}
+	for _, tc := range cases {
+		findings := Scan([]byte(tc.data))
+		if len(findings) == 0 {
+			t.Errorf("%s: секрет не обнаружен: %+v", tc.name, findings)
+			continue
+		}
+		var jsonFound bool
+		for _, f := range findings {
+			if f.Reason == jsonSecretReason {
+				jsonFound = true
+				if f.Line != tc.line {
+					t.Errorf("%s: line=%d, want %d (%+v)", tc.name, f.Line, tc.line, f)
+				}
+			}
+		}
+		if tc.name == "plain" {
+			continue // plain покрывается assignment-правилом, не JSON-им
+		}
+		if !jsonFound {
+			t.Errorf("%s: json secret field не обнаружен: %+v", tc.name, findings)
+		}
+	}
+}
+
+// AUD-03: не-JSON содержимое не даёт ложного json-finding, а JSON >= лимита
+// не сканируется структурно (plain-сканер остаётся источником evidence).
+func TestScanJSONSkipsNonJSONAndOverLimit(t *testing.T) {
+	if hasFindingReason(Scan([]byte("just text password = placeholder\n")), jsonSecretReason) {
+		t.Fatal("обычный текст не должен давать json finding")
+	}
+	if hasFindingReason(Scan([]byte("import x; x = 1\n")), jsonSecretReason) {
+		t.Fatal("встроенные строки без JSON-структуры не должны давать json finding")
+	}
+}

--- a/pkg/redact/scanner_test.go
+++ b/pkg/redact/scanner_test.go
@@ -72,11 +72,16 @@ func TestRedactReplacesFindings(t *testing.T) {
 // TestRedactAlignsWithScanFilter — RedactFile применяет тот же
 // likelySecretValue-фильтр к secret assignment, что и Scan: бенign-значение
 // не режется (иначе scan и redact расходились бы по контракту P1-6).
+// F-7: значение с буквой и цифрой (в т.ч. lowercase-hex/base64) — секрет;
+// чистое слово без цифр — benign.
 func TestRedactAlignsWithScanFilter(t *testing.T) {
-	input := []byte("password=0123456789abcdef\npassword=A1b2C3d4E5f6G7h8\n")
+	input := []byte("password=thequickbrownfoxjumpsover\npassword=0123456789abcdef\npassword=A1b2C3d4E5f6G7h8\n")
 	redacted := string(RedactFile(input))
-	if !strings.Contains(redacted, "password=0123456789abcdef") {
-		t.Errorf("бенign-значение (без верхнего регистра) не должно резаться: %q", redacted)
+	if !strings.Contains(redacted, "password=thequickbrownfoxjumpsover") {
+		t.Errorf("чистое слово без цифр не должно резаться: %q", redacted)
+	}
+	if strings.Contains(redacted, "0123456789abcdef") {
+		t.Errorf("lowercase-hex токен (буквы+цифры) должен быть вырезан: %q", redacted)
 	}
 	if strings.Contains(redacted, "A1b2C3d4E5f6G7h8") {
 		t.Errorf("высокоэнтропийное значение должно быть вырезано: %q", redacted)
@@ -169,6 +174,55 @@ func TestScanJSONIgnoresPlaceholders(t *testing.T) {
 	findings := Scan(input)
 	if hasFindingReason(findings, jsonSecretReason) {
 		t.Fatalf("placeholder-значение посчитано секретом: %+v", findings)
+	}
+}
+
+// F-7: секретный контекст не теряется на массивах и во вложенных значениях —
+// value-секреты в массивах секретных полей обнаруживаются, как и скалярные.
+func TestScanJSONSecretArrayContext(t *testing.T) {
+	secretA := "arraySecretV1x9Zq7kL4m8r"
+	secretB := "nestedValueQ2w8eR6t3y"
+	secretC := "deepTokenA5s9Df3gH"
+	input := []byte(`{
+  "issue": {
+    "tokens": ["` + secretA + `"],
+    "client_secret": [{"token": "` + secretB + `"}]
+  },
+  "api_key": ["` + secretC + `"]
+}`)
+	findings := Scan(input)
+	var jsonSec []string
+	for _, f := range findings {
+		if f.Reason == jsonSecretReason {
+			jsonSec = append(jsonSec, f.Matched)
+		}
+	}
+	for _, want := range []string{secretA, secretB, secretC} {
+		found := false
+		for _, m := range jsonSec {
+			if m == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("секрет %q внутри массива не обнаружен: %+v", want, jsonSec)
+		}
+	}
+}
+
+// F-7: теперь секретимы и lowercase"буквой+цифрой" токены (раньше требовался
+// верхний регистр): hex/base64-подобные токены в секретных полях режутся.
+func TestScanJSONDetectsLowerHexToken(t *testing.T) {
+	input := []byte(`{"api_key": "0123456789abcdef0123456789abcdef"}`)
+	findings := Scan(input)
+	if !hasFindingReason(findings, jsonSecretReason) {
+		t.Fatalf("lower-hex токен в секретном поле не обнаружен: %+v", findings)
+	}
+	for _, f := range findings {
+		if f.Reason == jsonSecretReason && f.Redacted != jsonSecretRedacted {
+			t.Fatalf("неверный redaction-маркер: %+v", f)
+		}
 	}
 }
 

--- a/pkg/redact/verify_test.go
+++ b/pkg/redact/verify_test.go
@@ -79,3 +79,26 @@ func TestVerifyExcludeSkipsFile(t *testing.T) {
 		t.Fatalf("excluded-файл должен быть проигнорирован: %v", err)
 	}
 }
+
+// AUD-03: секрет в JSON/JSONL поле блокирует export (fail-closed) так же, как
+// plain-текст.
+func TestVerifyBlocksJSONSecretFields(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "runs", "x"), 0755)
+	secret := "T0pSecretValue21k9XzW8qK2nM4"
+	payload := "{\"event\":\"created\",\"credentials\":{\"password\":\"" + secret + "\"}}\n"
+	if err := os.WriteFile(filepath.Join(dir, "runs", "x", "events.jsonl"),
+		[]byte(payload), 0644); err != nil {
+		t.Fatal(err)
+	}
+	report, err := Verify(dir, Policy{FailOnSecrets: true})
+	if err == nil {
+		t.Fatalf("fail-closed: JSON-секрет должен блокировать, report=%+v", report)
+	}
+	if report == nil || len(report.Violations) != 1 {
+		t.Fatalf("ожидалась 1 violation, got %+v", report)
+	}
+	if report.Violations[0].Path != "runs/x/events.jsonl" {
+		t.Fatalf("путь нарушения: %s", report.Violations[0].Path)
+	}
+}

--- a/pkg/safeio/dirs_test.go
+++ b/pkg/safeio/dirs_test.go
@@ -47,6 +47,50 @@ func TestValidateTreeRejectsNestedSymlink(t *testing.T) {
 	}
 }
 
+// F-5: поддельный вид `X -> private/X` (как у системного bootstrap redirect)
+// внутри рабочего дерева не должен пропускаться как системный redirect —
+// иначе атакующий сводит запись наружу через свой каталог private.
+func TestEnsureDirPathRejectsFakePrivateSymlinkRedirect(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	// inside/private -> outside (атакующий контролирует и inside, и private).
+	if err := os.MkdirAll(filepath.Join(root, "inside"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "inside", "private")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	// inside/out -> private/out: ровно та форма, что у системных /var,/tmp,/etc.
+	if err := os.Symlink("private/out", filepath.Join(root, "inside", "out")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := EnsureDirPath(filepath.Join(root, "inside", "out", "sink")); err == nil {
+		t.Fatal("fake private/<basename> redirect must be rejected (would escape workspace)")
+	}
+}
+
+// F-5: точный системный bootstrap redirect (корневой /var → private/var)
+// распознаётся как системный и НЕ отклоняется; внутренние копии — никогда.
+func TestSystemBootstrapRedirectOnlyRootLevel(t *testing.T) {
+	if _, ok := SystemBootstrapRedirectPaths["/var"]; !ok {
+		t.Fatal("/var должен быть в списке системных redirect-путей")
+	}
+	if _, ok := SystemBootstrapRedirectPaths["/tmp"]; !ok {
+		t.Fatal("/tmp должен быть в списке системных redirect-путей")
+	}
+	if _, ok := SystemBootstrapRedirectPaths["/etc"]; !ok {
+		t.Fatal("/etc должен быть в списке системных redirect-путей")
+	}
+	// Любой путь глубже корня не может быть системным redirect по контракту:
+	// map keyed только по корневым /var,/tmp,/etc.
+	if _, ok := SystemBootstrapRedirectPaths["/var/private/out"]; ok {
+		t.Fatal("вложенные пути не должны считаться системными redirect")
+	}
+	if _, ok := SystemBootstrapRedirectPaths["/inside/out"]; ok {
+		t.Fatal("каталоги рабочего дерева не должны считаться системными redirect")
+	}
+}
+
 func TestRejectSymlink(t *testing.T) {
 	root := t.TempDir()
 

--- a/pkg/safeio/dirs_test.go
+++ b/pkg/safeio/dirs_test.go
@@ -97,3 +97,90 @@ func TestReadRegularFileRejectsSymlinkAndLimit(t *testing.T) {
 		t.Fatal("symlink must fail")
 	}
 }
+
+func TestWriteRegularFileNoFollowRoundtrip(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "nested", "dir", "file")
+	if err := WriteRegularFileNoFollow(target, []byte("data"), 0644); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := ReadRegularFile(target, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "data" {
+		t.Fatalf("readback=%q", got)
+	}
+}
+
+func TestWriteRegularFileNoFollowRejectsExistingFile(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "file")
+	if err := os.WriteFile(target, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteRegularFileNoFollow(target, []byte("other"), 0444); err == nil {
+		t.Fatal("existing file: immutable write должен FAIL")
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "original" {
+		t.Fatalf("existing file перезаписан: %q", got)
+	}
+}
+
+func TestWriteRegularFileNoFollowRejectsLeafSymlink(t *testing.T) {
+	root := t.TempDir()
+	sentinel := filepath.Join(root, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "outfile")
+	if err := os.Symlink(sentinel, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := WriteRegularFileNoFollow(link, []byte("evil"), 0644); err == nil {
+		t.Fatal("leaf symlink: write должен FAIL (AUD-04)")
+	}
+	if got, _ := os.ReadFile(sentinel); string(got) != "keep" {
+		t.Fatalf("sentinel изменён через leaf symlink: %q", got)
+	}
+}
+
+func TestWriteRegularFileNoFollowRejectsParentSymlink(t *testing.T) {
+	root := t.TempDir()
+	sentinel := filepath.Join(root, "0-sentinel")
+	if err := os.Mkdir(sentinel, 0755); err != nil {
+		t.Fatal(err)
+	}
+	realDir := filepath.Join(root, "cyclic") // путь ниже следует не писать
+	os.Mkdir(realDir, 0755)
+	parent := filepath.Join(root, "sub")
+	if err := os.Symlink(realDir, parent); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := WriteRegularFileNoFollow(filepath.Join(parent, "file"), []byte("x"), 0644); err == nil {
+		t.Fatal("parent symlink: write должен FAIL (AUD-04)")
+	}
+	// Запись не ушла в реальный каталог за symlink.
+	if _, err := os.Lstat(filepath.Join(realDir, "file")); !os.IsNotExist(err) {
+		t.Fatal("write попал в каталог за symlink")
+	}
+}
+
+func TestWriteRegularFileNoFollowRejectsDeepSymlinkComponent(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	deep := filepath.Join(root, "bundle")
+	if err := os.Mkdir(deep, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(deep, "checks")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := WriteRegularFileNoFollow(filepath.Join(deep, "checks", "001-x"), []byte("x"), 0644); err == nil {
+		t.Fatal("deep symlink component: write должен FAIL (AUD-04)")
+	}
+	if entries, _ := os.ReadDir(outside); len(entries) != 0 {
+		t.Fatalf("write ушёл за deep symlink: %v", entries)
+	}
+}

--- a/pkg/safeio/files.go
+++ b/pkg/safeio/files.go
@@ -98,24 +98,49 @@ func EnsureDirPath(path string) error {
 	return ensureNoFollowDirChain(abs)
 }
 
+// SystemBootstrapRedirectPaths — штатные Darwin-редиректы корневых каталогов,
+// консолидируемых под /private (см. man hier, macOS): /var, /tmp, /etc и сам
+// /private на некоторых конфигурациях. Только эти пути (ровно один сегмент на
+// корневом уровне) разрешены как bootstrap redirect; любое другое вхождение
+// `X -> private/X` (например, поддельный symlink внутри рабочего дерева)
+// отклоняется как признак ухода за пределы доверенной зоны (F-5).
+var SystemBootstrapRedirectPaths = map[string]string{
+	"/var": "/private/var",
+	"/tmp": "/private/tmp",
+	"/etc": "/private/etc",
+}
+
 // isSystemBootstrapRedirect распознаёт штатные OS-редиректы начальных каталогов
 // (macOS: /var → private/var, /tmp → private/tmp, /etc → private/etc — Darwin
-// консолидирует их под /private). Такие редиректы находятся выше зоны доверия
-// контроллера (рабочего дерева/outDir) и разрешаются один раз: любое их
-// применение сводит содержимое в sibling-"private" каталог, который находится
-// внутри того же родительского дерева и не позволяет выйти на произвольный
-// целевой путь (атакуемый никогда не контролирует /var, /tmp или /etc).
-// Все остальные symlink в цепочке ниже trusted-prefix отклоняются.
+// консолидирует их под /private). Разрешается БЕЗУСЛОВНО только точный
+// системный redirect на корневом уровне: канонический префикс обязан быть
+// ровно /private/<basename>. Все копии такого вида глубже в цепочке (напр.
+// созданный атакуемым `out -> private/out` внутри рабочего дерева) НЕ
+// считаются системными и отклоняются ниже (F-5).
 func isSystemBootstrapRedirect(path string, info os.FileInfo) bool {
 	if info.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	canonical, ok := SystemBootstrapRedirectPaths[path]
+	if !ok {
 		return false
 	}
 	target, err := os.Readlink(path)
 	if err != nil {
 		return false
 	}
+	// Ссылка должна указывать ровно на канонический системный каталог
+	// (private/<base> либо /private/<base>), а не на какой-то промежуточный.
 	base := filepath.Base(path)
-	return target == filepath.Join("private", base) || target == filepath.Join(string(filepath.Separator)+"private", base)
+	expected := filepath.Join(string(filepath.Separator)+"private", base)
+	if target != filepath.Join("private", base) && target != expected {
+		return false
+	}
+	resolved, rerr := filepath.EvalSymlinks(path)
+	if rerr != nil {
+		return false
+	}
+	return filepath.Clean(resolved) == canonical
 }
 
 // ensureNoFollowDirChain проходит каждый компонент abs-каталога сверху вниз.

--- a/pkg/safeio/files.go
+++ b/pkg/safeio/files.go
@@ -1,9 +1,13 @@
 package safeio
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 // ReadRegularFile reads a bounded regular file and rejects symlinks, devices,
@@ -39,4 +43,122 @@ func ReadRegularFile(path string, maxBytes int64) ([]byte, error) {
 		return nil, fmt.Errorf("%s превышает лимит %d bytes", path, maxBytes)
 	}
 	return data, nil
+}
+
+// WriteRegularFileNoFollow пишет data в path, гарантируя no-follow на всей
+// цепочке пути (AUD-04): родительские каталоги проходятся по одному компоненту
+// (существующие обязаны быть обычными каталогами без symlink, отсутствующие
+// создаются os.Mkdir), листовой symlink отклоняется до создания, а сам файл
+// создаётся строго через O_CREATE|O_EXCL — существующий файл даёт ошибку,
+// разыменование невозможно. Иммутабельные контроллерные артефакты (bundle
+// records) не перезаписываются.
+func WriteRegularFileNoFollow(path string, data []byte, mode os.FileMode) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	if err := ensureNoFollowDirChain(filepath.Dir(abs)); err != nil {
+		return err
+	}
+	// Листовой symlink (или special файл) отвергается до создания файла:
+	// sentinel за целевой записью не изменяется.
+	if info, lerr := os.Lstat(abs); lerr == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("controller file %s является symlink: запись отклонена (AUD-04)", path)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("controller file %s не является regular file", path)
+		}
+		return fmt.Errorf("controller file %s уже существует: immutable-запись запрещена (AUD-04)", path)
+	} else if !os.IsNotExist(lerr) {
+		return lerr
+	}
+	file, err := os.OpenFile(abs, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return fmt.Errorf("controller file %s уже существует: immutable-запись запрещена (AUD-04)", path)
+		}
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+// EnsureDirPath создаёт каталог (и недостающие промежуточные) компонентно,
+// отклоняя symlink в любом компоненте цепочки. Отличается от os.MkdirAll:
+// никакой компонент не обходится как symlink.
+func EnsureDirPath(path string) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	return ensureNoFollowDirChain(abs)
+}
+
+// isSystemBootstrapRedirect распознаёт штатные OS-редиректы начальных каталогов
+// (macOS: /var → private/var, /tmp → private/tmp, /etc → private/etc — Darwin
+// консолидирует их под /private). Такие редиректы находятся выше зоны доверия
+// контроллера (рабочего дерева/outDir) и разрешаются один раз: любое их
+// применение сводит содержимое в sibling-"private" каталог, который находится
+// внутри того же родительского дерева и не позволяет выйти на произвольный
+// целевой путь (атакуемый никогда не контролирует /var, /tmp или /etc).
+// Все остальные symlink в цепочке ниже trusted-prefix отклоняются.
+func isSystemBootstrapRedirect(path string, info os.FileInfo) bool {
+	if info.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		return false
+	}
+	base := filepath.Base(path)
+	return target == filepath.Join("private", base) || target == filepath.Join(string(filepath.Separator)+"private", base)
+}
+
+// ensureNoFollowDirChain проходит каждый компонент abs-каталога сверху вниз.
+func ensureNoFollowDirChain(abs string) error {
+	root := filepath.VolumeName(abs)
+	rest := abs
+	if root != "" {
+		rest = rest[len(root):]
+	}
+	rest = strings.TrimLeft(rest, string(filepath.Separator))
+	current := root
+	if current == "" {
+		current = string(filepath.Separator)
+	}
+	for _, component := range strings.Split(rest, string(filepath.Separator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		switch {
+		case os.IsNotExist(err):
+			if mkErr := os.Mkdir(current, 0755); mkErr != nil && !os.IsExist(mkErr) {
+				return mkErr
+			}
+			if reqErr := requireDirectory(current); reqErr != nil {
+				return reqErr
+			}
+		case err != nil:
+			return err
+		default:
+			if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+				if isSystemBootstrapRedirect(current, info) {
+					resolved, rerr := filepath.EvalSymlinks(current)
+					if rerr != nil {
+						return rerr
+					}
+					current = resolved
+					continue
+				}
+				return fmt.Errorf("controller path %s должен быть каталогом без symlink", current)
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Closes **P0** findings from `audit-2026-09-05`.

- **AUD-01** (gate): gate runs checks against the exact candidate; a non-WORKTREE candidate whose blob output differs from the working tree is blocked
- **AUD-02** (safeio): `EnsureDirPath` rejects any symlink leaf, symlink redirect of a bootstrap path resolves canonically (**F-5**): only root-level system paths (`/var`, `/tmp`, `/etc`) may redirect to `/private/...`, and the resolved target must be canonical — a fake `private/...` symlink inside the workspace is rejected
- **AUD-03** (dsse): keys pinned to Config identity; run/session tested to not send outbound calls to default key
- **AUD-04** (candidate evidence): evidence per attempt/run, compare-and-swap into evidence dir, attach/reharvest + evict=remove for partial candidates

### Код-ревью findings (F-4, F-5, F-7)

- **F-4** (exact-candidate checked only tracked files): `workingTreeMatchesCommit` now blocks any non-ignored **untracked** file (`git ls-files --others --exclude-standard`) for a commit candidate — gitignored content (`.ai-team/`) stays allowed. Tests: `TestRunBlocksUntrackedContentForCommitCandidate`, `TestRunAllowGitignoredServiceDirForCommitCandidate`.
- **F-5** (fake macOS `/private` symlink redirect inside workspace): see AUD-02 above; `SystemBootstrapRedirectPaths` accepts only `/var`→`/private/var`, `/tmp`→`/private/tmp`, `/etc`→`/private/etc` at root; tests `TestEnsureDirPathRejectsFakePrivateSymlinkRedirect`, `TestSystemBootstrapRedirectOnlyRootLevel`.
- **F-7** (redact scanner missed secrets in JSON/JSONL): `likelySecretValue` now keys on letter+digit (not upper+digit), so lowercase hex/base64 tokens are detected; `scanJSON` propagates the secret field context into array elements and nested objects. Tests flipped: `password=0123456789abcdef` now redacts, benign stays; added `TestScanJSONSecretArrayContext`, `TestScanJSONDetectsLowerHexToken`.

Verified: `make verify` green; race E2E green. One commit `0ec0d20`.
