### PR TITLE
Audit P1 fixes: AUD-05, AUD-06, AUD-11

### DIFF
--- a/cmd/ai-team/gate.go
+++ b/cmd/ai-team/gate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/arturpanteleev/ai-team/pkg/dsse"
 	"github.com/arturpanteleev/ai-team/pkg/gate"
 	"github.com/arturpanteleev/ai-team/pkg/logging"
+	"github.com/arturpanteleev/ai-team/pkg/redact"
 	"github.com/arturpanteleev/ai-team/pkg/safeio"
 )
 
@@ -77,15 +78,19 @@ func cmdGate() {
 		os.Exit(code)
 	}
 
-	if err := gate.WriteBundle(*out, result); err != nil {
+	// AUD-11: privacy guard обязателен ДО публикации и подписи bundle —
+	// gate-записи содержат captured Stdout/Stderr проверок, которые могут
+	// нести credential. Политика та же fail-closed, что и у export.
+	policyCfg, cfgErr := loadPolicyConfig(*target)
+	if cfgErr != nil {
+		fatal("Ошибка загрузки конфига: %v", cfgErr)
+	}
+	policy := redactionPolicy(policyCfg)
+	policy.RepoRoot = *target
+
+	if err := publishGateBundle(*out, result, policy, privKey); err != nil {
 		fmt.Fprintf(os.Stderr, "✗ Gate bundle: %v\n", err)
 		os.Exit(exitBlocked)
-	}
-	if privKey != nil {
-		if err := gate.SignBundle(*out, privKey); err != nil {
-			fmt.Fprintf(os.Stderr, "✗ Gate bundle подпись: %v\n", err)
-			os.Exit(exitBlocked)
-		}
 	}
 	printGateSummary(result, *out)
 	if logging.GetMode() == logging.ModeJSON || logging.GetMode() == logging.ModeQuiet {
@@ -97,12 +102,52 @@ func cmdGate() {
 				"policy":        result.PolicyVerdict,
 				"bundle_sha256": result.BundleSHA256,
 				"bundle":        *out,
-				"signed":        false,
+				"signed":        privKey != nil,
 			},
 			Exit: gate.ExitCode(result),
 		})
 	}
 	os.Exit(gate.ExitCode(result))
+}
+
+// publishGateBundle записывает attestation bundle в staging-каталог, прогоняет
+// privacy scan (fail-closed, AUD-11) по сериализованным records и только при
+// чистом вердикте подписывает и атомарно публикует в outDir. Сигнатура (DSSE)
+// всегда вычисляется по окончательным безопасным records; при секретах ничего
+// не публикуется. Существующий outDir отклоняется (bundle immutable).
+func publishGateBundle(outDir string, result *gate.Result, policy redact.Policy, privKey ed25519.PrivateKey) error {
+	if _, err := os.Stat(outDir); err == nil {
+		return fmt.Errorf("bundle %s уже существует", outDir)
+	}
+	if err := os.MkdirAll(filepath.Dir(outDir), 0755); err != nil {
+		return fmt.Errorf("staging каталог: %w", err)
+	}
+	tmp, err := os.MkdirTemp(filepath.Dir(outDir), ".gate-bundle-")
+	if err != nil {
+		return fmt.Errorf("staging каталог: %w", err)
+	}
+	defer os.RemoveAll(tmp)
+	if err := gate.WriteBundle(tmp, result); err != nil {
+		return err
+	}
+	report, redactErr := redact.Verify(tmp, policy)
+	if redactErr != nil {
+		return fmt.Errorf("bundle содержит секреты: %w", redactErr)
+	}
+	if len(report.Violations) > 0 {
+		logging.Emit(logging.Record{Level: "warn", Command: "gate", Type: "redact_findings",
+			Message: "Секреты найдены, но политика разрешает публикацию",
+			Data:    map[string]any{"violations": len(report.Violations)}})
+	}
+	if privKey != nil {
+		if err := gate.SignBundle(tmp, privKey); err != nil {
+			return err
+		}
+	}
+	if err := os.Rename(tmp, outDir); err != nil {
+		return fmt.Errorf("публикация bundle: %w", err)
+	}
+	return nil
 }
 
 // loadGateConfig загружает gate config: заданный --config, либо gate.yaml в

--- a/cmd/ai-team/gate_test.go
+++ b/cmd/ai-team/gate_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arturpanteleev/ai-team/pkg/checks"
+	"github.com/arturpanteleev/ai-team/pkg/gate"
+	"github.com/arturpanteleev/ai-team/pkg/redact"
+)
+
+func gitCmd(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func gateRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitCmd(t, dir, "init", "-q")
+	gitCmd(t, dir, "config", "user.email", "test@test")
+	gitCmd(t, dir, "config", "user.name", "test")
+	for name, content := range map[string]string{
+		"src/app.go":        "package app\n",
+		"tests/app_test.go": "package app\n\nfunc TestApp() {}\n",
+	} {
+		full := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gitCmd(t, dir, "add", ".")
+	gitCmd(t, dir, "commit", "-qm", "init")
+	return dir
+}
+
+// TestPublishGateBundleBlocksOnSecrets — AUD-11: публикация gate bundle
+// обязана пройти privacy scan (fail-closed, D0) ДО записи и подписи. Проверка,
+// печатающая github token в output, блокирует публикацию; bundle не создаётся.
+func TestPublishGateBundleBlocksOnSecrets(t *testing.T) {
+	dir := gateRepo(t)
+	token := "ghp_" + strings.Repeat("7", 36)
+	cfg := &gate.Config{SchemaVersion: gate.SchemaVersion, DiffPolicy: gate.DiffPolicy{TestModify: gate.TestModifyRequired}}
+	cfg.Checks = []checks.Definition{{
+		Name: "leak-endpoint", Class: "unit", Adapter: checks.AdapterCommand, Policy: checks.PolicyRequired,
+		Command: []string{"sh", "-c", "printf 'GITHUB_TOKEN=" + token + "'"},
+	}}
+	result, code, err := gate.Run(context.Background(), gate.Options{TargetDir: dir, Base: "HEAD", Candidate: "HEAD", Config: cfg})
+	if err != nil {
+		t.Fatalf("gate.Run: %v", err)
+	}
+	if code != gate.ExitPass || result.Status != "passed" {
+		t.Fatalf("проверка должна пройти, got code=%d status=%s", code, result.Status)
+	}
+
+	policy := redact.Policy{FailOnSecrets: true, RepoRoot: dir}
+	out := filepath.Join(dir, ".ai-team", "gates", "aud11")
+	if err := publishGateBundle(out, result, policy, nil); err == nil {
+		t.Fatal("bundle с secret в check output обязан блокироваться")
+	}
+	if _, err := os.Stat(out); err == nil {
+		t.Fatal("bundle не должен быть опубликован при секретах")
+	}
+
+	// Чистый run публикуется; повторная публикация в существующий out
+	// отклоняется (bundle immutable).
+	cleanCfg := &gate.Config{SchemaVersion: gate.SchemaVersion, DiffPolicy: gate.DiffPolicy{TestModify: gate.TestModifyRequired}}
+	result2, code2, err := gate.Run(context.Background(), gate.Options{TargetDir: dir, Base: "HEAD", Candidate: "HEAD", Config: cleanCfg})
+	if err != nil || code2 != gate.ExitPass {
+		t.Fatalf("повторный gate.Run: code=%d err=%v", code2, err)
+	}
+	if err := publishGateBundle(out, result2, policy, nil); err != nil {
+		t.Fatalf("публикация чистого bundle: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "index.json")); err != nil {
+		t.Fatalf("bundle не опубликован: %v", err)
+	}
+	if err := publishGateBundle(out, result2, policy, nil); err == nil {
+		t.Fatal("повторная публикация в существующий каталог должна отклоняться")
+	}
+
+	// Подписанный bundle (DSSE) вычисляется по безопасным records: тех же
+	// check output, что и при публикации без подписи.
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out2 := filepath.Join(dir, ".ai-team", "gates", "aud11-signed")
+	if err := publishGateBundle(out2, result2, policy, priv); err != nil {
+		t.Fatalf("публикация подписанного bundle: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out2, "dsse.json")); err != nil {
+		t.Fatalf("подписанный bundle должен содержать dsse.json: %v", err)
+	}
+}

--- a/pkg/pipeline/delivery_deferred.go
+++ b/pkg/pipeline/delivery_deferred.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/arturpanteleev/ai-team/pkg/attest"
+	"github.com/arturpanteleev/ai-team/pkg/checks"
 	"github.com/arturpanteleev/ai-team/pkg/delivery"
 	"github.com/arturpanteleev/ai-team/pkg/evidence"
 	"github.com/arturpanteleev/ai-team/pkg/safeio"
@@ -100,6 +102,14 @@ func (rs *runState) executeDeferredDelivery() error {
 // перезапустить `ai-team deliver --run <id> --target <repo>`); enforcement
 // детерминированный: результат привязан к plan, зафиксированному в
 // delivery_deferred event, и к terminal статусу run.
+//
+// AUD-05: рабочий каталог (workspace) разрешается из проверенной run metadata —
+// state_path из delivery_deferred event указывает на candidate worktree
+// Git-run'а, а не на control target, который передаёт CLI.
+// targetDir остаётся только контрольным корнем для sanity-проверки.
+// Дополнительно сверяется identity workspace с attested candidate digest из
+// attestation.json, а сам retry берёт workspace lock, чтобы конкурентные
+// повторы не выполнили доставку дважды.
 func (p *Pipeline) DeliverDeferred(runDir, feature, targetDir string) (delivery.TerminalRecord, error) {
 	if _, err := safeio.ExistingDir(runDir); err != nil {
 		return delivery.TerminalRecord{}, err
@@ -145,6 +155,44 @@ func (p *Pipeline) DeliverDeferred(runDir, feature, targetDir string) (delivery.
 	if marker.PlanHash == "" || (marker.Feature != "" && marker.Feature != feature) {
 		return delivery.TerminalRecord{}, errors.New("deliver: delivery_deferred маркер не согласован с run")
 	}
+	// AUD-05: prepared plan и delivery выполняются в workspace, записанном в
+	// state_path (для Git-run — candidate worktree), а не в указанном CLI
+	// control target. Без state_path retry fail-closed: невозможно выбрать
+	// верный workspace.
+	workspace, err := deliveryWorkspaceFromStatePath(marker.StatePath, feature)
+	if err != nil {
+		return delivery.TerminalRecord{}, err
+	}
+	// workspace должен лежать внутри control target (или совпадать с ним),
+	// иначе cmdDeliver был вызван для чуждого репозитория. Пути канонизируем:
+	// state_path может быть записан уже через символическую ссылку
+	// (на macOS /var → /private/var), а CLI target — нет.
+	workspaceCanon, targetCanon := canonicalPath(workspace), canonicalPath(targetDir)
+	rel, relErr := filepath.Rel(targetCanon, workspaceCanon)
+	if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return delivery.TerminalRecord{}, fmt.Errorf("deliver: workspace %s вне control target %s", workspace, targetDir)
+	}
+
+	lock, err := evidence.AcquireWorkspaceLock(workspace)
+	if err != nil {
+		return delivery.TerminalRecord{}, fmt.Errorf("deliver: workspace lock: %w", err)
+	}
+	defer lock.Close()
+
+	// AUD-05: retry обязан исполнять доставку в тот же candidate, который был
+	// attestated в terminal finalize; проверив digest workspace — fail-closed
+	// при реконфигурации ворктри между finalize и повторной доставкой.
+	if candidateDigest, found, digestErr := candidateWorkspaceDigestOfRun(runDir); digestErr != nil {
+		return delivery.TerminalRecord{}, digestErr
+	} else if found {
+		currentDigest, wsErr := checks.WorkspaceDigest(workspace)
+		if wsErr != nil {
+			return delivery.TerminalRecord{}, fmt.Errorf("deliver: workspace digest: %w", wsErr)
+		}
+		if currentDigest != candidateDigest {
+			return delivery.TerminalRecord{}, fmt.Errorf("deliver: workspace %s не совпадает с attested candidate %s", currentDigest, candidateDigest)
+		}
+	}
 
 	attestationDigest, err := attestationDigestOfRun(runDir)
 	if err != nil {
@@ -155,7 +203,7 @@ func (p *Pipeline) DeliverDeferred(runDir, feature, targetDir string) (delivery.
 		return delivery.TerminalRecord{}, err
 	}
 
-	plan, found, err := delivery.LoadPreparedPlan(targetDir, feature)
+	plan, found, err := delivery.LoadPreparedPlan(workspace, feature)
 	if err != nil {
 		return delivery.TerminalRecord{}, fmt.Errorf("deliver: prepared plan: %w", err)
 	}
@@ -176,7 +224,7 @@ func (p *Pipeline) DeliverDeferred(runDir, feature, targetDir string) (delivery.
 		delivery.TrailerAttestation + ": " + attestationDigest,
 	}
 	result, err := p.delivery.Execute(context.Background(), delivery.Request{
-		TargetDir: targetDir, Feature: feature, Plan: plan, Trailers: trailers,
+		TargetDir: workspace, Feature: feature, Plan: plan, Trailers: trailers,
 	})
 	if err != nil {
 		return delivery.TerminalRecord{}, err
@@ -199,10 +247,72 @@ func (p *Pipeline) DeliverDeferred(runDir, feature, targetDir string) (delivery.
 	return record, nil
 }
 
+// deliveryWorkspaceFromStatePath выделяет корень workspace из абсолютного
+// пути delivery state (<workspace>/.ai-team/delivery/<feature>.json) и
+// валидирует его форму. Вернёт ошибку при попытке вывести стейт за пределы
+// канонической структуры.
+func deliveryWorkspaceFromStatePath(statePath, feature string) (string, error) {
+	if statePath == "" {
+		return "", errors.New("deliver: delivery_deferred маркер не содержит state_path")
+	}
+	if feature == "" || feature == "." || feature == ".." || strings.ContainsAny(feature, `/\\`) || strings.Contains(feature, "..") {
+		return "", fmt.Errorf("deliver: невалидный feature %q", feature)
+	}
+	path := filepath.Clean(filepath.FromSlash(statePath))
+	if !filepath.IsAbs(path) {
+		return "", errors.New("deliver: state_path должен быть absolute")
+	}
+	workspace := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+	if workspace == "." || workspace == "/" || !filepath.IsAbs(workspace) {
+		return "", errors.New("deliver: state_path не содержит candidate workspace")
+	}
+	expected := filepath.Join(workspace, ".ai-team", "delivery", feature+".json")
+	if expected != path {
+		return "", fmt.Errorf("deliver: state_path %q не соответствует workspace layout %q", path, expected)
+	}
+	return workspace, nil
+}
+
+// canonicalPath разрешает символические ссылки пути (для сравнения путей из
+// разных источников — state_path и CLI target могут отличаться формой одного
+// физического каталога, например /var vs /private/var на macOS).
+func canonicalPath(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return filepath.Clean(p)
+}
+
+// candidateWorkspaceDigestOfRun читает attested subject 'candidate' из
+// attestation.json (digest sha256). found=false для non-Git run'ов — там
+// workspace == control target и digest верифицировать нечем.
+func candidateWorkspaceDigestOfRun(runDir string) (digest string, found bool, err error) {
+	data, readErr := safeio.ReadRegularFile(filepath.Join(runDir, "attestation.json"), 1<<20)
+	if readErr != nil {
+		return "", false, fmt.Errorf("deferred delivery: attestation: %w", readErr)
+	}
+	statement, parseErr := attest.Parse(data)
+	if parseErr != nil {
+		return "", false, fmt.Errorf("deferred delivery: attestation parse: %w", parseErr)
+	}
+	for _, subject := range statement.Subject {
+		if subject.Name != "candidate" {
+			continue
+		}
+		value, ok := subject.Digest["sha256"]
+		if !ok || value == "" {
+			return "", false, errors.New("deferred delivery: candidate subject не содержит sha256 digest")
+		}
+		return value, true, nil
+	}
+	return "", false, nil
+}
+
 // deferredMarkerEvent — доказательство утверждённой delivery-стадии в run.
 type deferredMarkerEvent struct {
-	PlanHash string `json:"plan_hash"`
-	Feature  string `json:"feature"`
+	PlanHash  string `json:"plan_hash"`
+	Feature   string `json:"feature"`
+	StatePath string `json:"state_path"`
 }
 
 func firstDeferredMarker(runDir string) (deferredMarkerEvent, error) {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -681,12 +681,17 @@ func (p *Pipeline) RunWithResult(ctx context.Context, runCfg RunConfig) (RunResu
 		return RunResult{RunID: runID, Outcome: outcome}, finalErr
 	}
 	// V0-9: отложенная (deferred) доставка — только после terminal finalize и
-	// только для полностью completed-ранна, когда attestation digest и runtime
-	// identity детерминированы. Enforcement: план перегружается из prepared
-	// state и должен совпасть с approvedPlanHash и маркером стадии.
-	if outcome == workflow.RunCompleted && rs.deferredDelivery != nil {
-		if deferredErr := rs.executeDeferredDelivery(); deferredErr != nil {
-			return RunResult{RunID: runID, Outcome: outcome}, deferredErr
+	// только для полностью completed-ранна (включая completed_with_warnings:
+	// AUD-06 — warning не меняет delivery-контракт, пользователь ждёт
+	// commit/push/PR), когда attestation digest и runtime identity
+	// детерминированы. Enforcement: план перегружается из prepared state и
+	// должен совпасть с approvedPlanHash и маркером стадии.
+	switch outcome {
+	case workflow.RunCompleted, workflow.RunCompletedWithWarnings:
+		if rs.deferredDelivery != nil {
+			if deferredErr := rs.executeDeferredDelivery(); deferredErr != nil {
+				return RunResult{RunID: runID, Outcome: outcome}, deferredErr
+			}
 		}
 	}
 	return RunResult{RunID: runID, Outcome: outcome}, finalErr

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -145,7 +145,18 @@ preconditions:
 outputs:
   plan: '{feature}/delivery-plan.json'
 `),
+		"coder/def.yaml": def(`name: coder
+runtime: agentcli
+prompt_file: prompt.md
+mutation: source
+allowed_paths: ['**']
+require_diff: true
+inputs:
+  task: tasks/{feature}/task.md
+outputs: {}
+`),
 		"approver/prompt.md": def("test"),
+		"coder/prompt.md":    def("test"),
 	})
 }
 
@@ -261,6 +272,20 @@ func (f *fakeDeliveryService) Execute(_ context.Context, request delivery.Reques
 	f.calls++
 	hash, _ := request.Plan.Hash()
 	return delivery.Result{PlanHash: hash, CommitSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", PRURL: "https://example.test/pr/1"}, nil
+}
+
+// capturingDeliveryService фиксирует TargetDir каждого delivery request
+// (AUD-05: retry должен исполняться в candidate worktree, а не control target).
+type capturingDeliveryService struct {
+	calls   int
+	targets []string
+}
+
+func (f *capturingDeliveryService) Execute(_ context.Context, request delivery.Request) (delivery.Result, error) {
+	f.calls++
+	f.targets = append(f.targets, request.TargetDir)
+	hash, _ := request.Plan.Hash()
+	return delivery.Result{PlanHash: hash, CommitSHA: strings.Repeat("a", 40), PRURL: "https://example.test/pr/1"}, nil
 }
 
 func prepareDelivery(t *testing.T, dir string) string {
@@ -961,6 +986,213 @@ func TestDeliverDeferredRetriesFailedHook(t *testing.T) {
 		}
 	}
 	// Повторная доставка теперь блокируется (однократная запись).
+	if _, err := New(nil, nil, WithDeliveryService(okService)).DeliverDeferred(runDir, "", dir); err == nil {
+		t.Fatal("повторная доставка после успеха должна быть отклонена")
+	}
+}
+
+// TestRun_CompletedWithWarningsRunsPostTerminalDelivery — AUD-06: post-terminal
+// deferred доставка должна выполняться не только для completed, но и для
+// completed_with_warnings (необязательный check на stage дал warning). Итог
+// фиксируется в terminal delivery record; сбой hook-а при warnings не
+// маскируется успехом run (exit 0).
+func TestRun_CompletedWithWarningsRunsPostTerminalDelivery(t *testing.T) {
+	warningCheck := config.AgentConfig{
+		Name: "approver",
+		Checks: []checks.Definition{{
+			Name: "optional-neta", Class: "security",
+			Command: []string{"ai-team-tool-that-does-not-exist"}, Policy: checks.PolicyOptional,
+		}},
+	}
+
+	dir := env(t)
+	approvedPlanHash := prepareDelivery(t, dir)
+	rt := newScripted()
+	rt.content["approver"] = map[string]string{"review": "**Verdict:** APPROVED\n"}
+	service := &fakeDeliveryService{}
+	p := New(cfgFor(warningCheck, config.AgentConfig{Name: "deployer"}), deliveryRegistry(),
+		WithRuntimeFactory(rt.factory), WithPrompter(&scriptedPrompter{}), WithDeliveryService(service))
+	result, err := p.RunWithResult(context.Background(), RunConfig{
+		Feature: "feat", TaskDesc: "t", TargetDir: dir, ApproveGates: true, ApprovePlanHash: approvedPlanHash,
+	})
+	if err != nil {
+		t.Fatalf("completed_with_warnings run обязан выполнить post-terminal delivery: %v", err)
+	}
+	if result.Outcome != workflow.RunCompletedWithWarnings {
+		t.Fatalf("ожидался outcome %q, got %q", workflow.RunCompletedWithWarnings, result.Outcome)
+	}
+	if service.calls != 1 {
+		t.Fatalf("post-terminal delivery должен выполняться и при warnings, calls=%d", service.calls)
+	}
+	runDir := onlyRunDir(t, dir)
+	record, ok, readErr := delivery.ReadTerminalRecord(runDir)
+	if readErr != nil || !ok {
+		t.Fatalf("terminal delivery record не записан: err=%v ok=%v", readErr, ok)
+	}
+	if record.CommitSHA == "" || record.PlanHash != approvedPlanHash {
+		t.Fatalf("terminal record не согласован: %+v", record)
+	}
+
+	// Сбой доставки при warnings не должен маскироваться успехом run.
+	dir2 := env(t)
+	approvedPlanHash2 := prepareDelivery(t, dir2)
+	rt2 := newScripted()
+	rt2.content["approver"] = map[string]string{"review": "**Verdict:** APPROVED\n"}
+	failing := &gracefulDeliveryService{}
+	p2 := New(cfgFor(warningCheck, config.AgentConfig{Name: "deployer"}), deliveryRegistry(),
+		WithRuntimeFactory(rt2.factory), WithPrompter(&scriptedPrompter{}), WithDeliveryService(failing))
+	if err := p2.Run(context.Background(), RunConfig{
+		Feature: "feat", TaskDesc: "t", TargetDir: dir2, ApproveGates: true, ApprovePlanHash: approvedPlanHash2,
+	}); err == nil {
+		t.Fatal("сбой post-terminal delivery при warnings обязан вернуть ошибку (exit 0 не маскирует delivery result)")
+	}
+}
+
+// TestDeliverDeferredRetriesFailedHookFromCandidateWorktree — AUD-05: retry
+// доставки Git-run'а обязан резолвить candidate worktree из state_path
+// delivery_deferred event, а не читать prepared plan в control target (decoy).
+// Сбой post-terminal хука → DeliverDeferred(runDir, "", controlRoot) продолжает
+// exact candidate: тот же approved plan, тот же workspace, без чтения decoy
+// плана и без нового LLM-вызова (delivery — controller-owned).
+func TestDeliverDeferredRetriesFailedHookFromCandidateWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git недоступен")
+	}
+	dir := env(t)
+	gitInit(t, dir)
+	for name, content := range map[string]string{
+		".gitignore":     ".ai-team/\n",
+		"go.mod":         "module example.test/retry\n\ngo 1.26\n",
+		"change_test.go": "package change\n\nimport \"testing\"\n\nfunc TestPrepared(t *testing.T) {}\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(name)), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, args := range [][]string{
+		{"add", "."},
+		{"commit", "-qm", "init"},
+		{"branch", "-M", "main"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	rt := newScripted()
+	rt.content["approver"] = map[string]string{"review": "**Verdict:** APPROVED\n"}
+	rt.onExec = func(name string, _ []runtime.Artifact) {
+		if name == "coder" {
+			// Мутация пишется в candidate worktree (rt.targetDir), как вёл бы
+			// себя реальный agent CLI в worktree Git-run'а.
+			if err := os.WriteFile(filepath.Join(rt.targetDir, "change.go"), []byte("package change\n"), 0644); err != nil {
+				t.Fatalf("coder mutation: %v", err)
+			}
+		}
+	}
+	service := &gracefulDeliveryService{}
+	p := New(cfgFor(
+		config.AgentConfig{Name: "coder", Checks: []checks.Definition{{
+			Name: "candidate-tests", Class: "unit", Adapter: checks.AdapterGoTest,
+			Command: []string{"go", "test", "-json", "-count=1", "./..."}, Policy: checks.PolicyRequired,
+		}}},
+		config.AgentConfig{Name: "approver"},
+		config.AgentConfig{Name: "deployer"},
+	), deliveryRegistry(), WithRuntimeFactory(rt.factory),
+		WithPrompter(&scriptedPrompter{interactive: true, answers: []string{"y"}}),
+		WithDeliveryService(service))
+	err := p.Run(context.Background(), RunConfig{Feature: "feat", TaskDesc: "t", TargetDir: dir, ApproveGates: true})
+	if err == nil {
+		t.Fatal("post-terminal хук упал — Run обязан вернуть ошибку")
+	}
+	// Decoy plan — рукам подготовка плана в control target (feature "feat").
+	// После run: candidate уже создан, clean-workspace требования нет. Hash
+	// decoy заведомо отличается от in-run плана candidate worktree: старая
+	// реализация читала control root и падала бы на hash mismatch.
+	prepareDelivery(t, dir)
+	runDir := onlyRunDir(t, dir)
+	runID := filepath.Base(runDir)
+	if _, ok, readErr := delivery.ReadTerminalRecord(runDir); readErr != nil || ok {
+		t.Fatalf("terminal record не должен существовать при сбойном хуке: ok=%v err=%v", ok, readErr)
+	}
+
+	// Workspace из delivery_deferred event — candidate worktree run'а.
+	var marker struct {
+		PlanHash  string `json:"plan_hash"`
+		StatePath string `json:"state_path"`
+	}
+	events, readEventsErr := os.ReadFile(filepath.Join(runDir, "events.jsonl"))
+	if readEventsErr != nil {
+		t.Fatal(readEventsErr)
+	}
+	foundMarker := false
+	for _, line := range strings.Split(string(events), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev struct {
+			Type string            `json:"type"`
+			Data map[string]string `json:"data"`
+		}
+		if json.Unmarshal([]byte(line), &ev) != nil || ev.Type != "delivery_deferred" {
+			continue
+		}
+		marker.PlanHash, marker.StatePath = ev.Data["plan_hash"], ev.Data["state_path"]
+		foundMarker = true
+		break
+	}
+	if !foundMarker || marker.StatePath == "" {
+		t.Fatalf("delivery_deferred маркер должен содержать state_path: found=%v marker=%+v", foundMarker, marker)
+	}
+	worktree := filepath.FromSlash(filepath.Dir(filepath.Dir(filepath.Dir(marker.StatePath))))
+	expectedWorktree := filepath.Join(canonicalPath(dir), ".ai-team", "worktrees", runID)
+	if worktree != expectedWorktree {
+		t.Fatalf("ожидался candidate worktree %s, got %s (state_path=%s)", expectedWorktree, worktree, marker.StatePath)
+	}
+
+	okService := &capturingDeliveryService{}
+	record, err := New(nil, nil, WithDeliveryService(okService)).DeliverDeferred(runDir, "", dir)
+	if err != nil {
+		t.Fatalf("DeliverDeferred из control target: %v", err)
+	}
+	if okService.calls != 1 || len(okService.targets) != 1 || okService.targets[0] != worktree {
+		t.Fatalf("доставка выполнена не в candidate worktree: calls=%d targets=%v", okService.calls, okService.targets)
+	}
+	if record.CommitSHA == "" || record.PlanHash != marker.PlanHash {
+		t.Fatalf("terminal record не согласован с approved plan: %+v vs %s", record, marker.PlanHash)
+	}
+	if len(record.Trailers) != 3 {
+		t.Fatalf("expected 3 trailers, got %v", record.Trailers)
+	}
+	for _, trailer := range record.Trailers {
+		switch {
+		case strings.HasPrefix(trailer, delivery.TrailerRunID+": "):
+			if trailer != delivery.TrailerRunID+": "+runID {
+				t.Fatalf("run id trailer mismatch: %q", trailer)
+			}
+		case strings.HasPrefix(trailer, delivery.TrailerRuntime+": "):
+			if record.RuntimeIdentity == "" {
+				t.Fatalf("runtime identity пустая")
+			}
+		case strings.HasPrefix(trailer, delivery.TrailerAttestation+": "):
+			if record.AttestationSHA256 == "" || !strings.Contains(trailer, record.AttestationSHA256) {
+				t.Fatalf("attestation trailer mismatch: %q", trailer)
+			}
+		}
+	}
+	// Нет нового LLM-вызова: deployer controller-owned, run исполнял только
+	// coder и approver.
+	if rt.calls["deployer"] != 0 || len(rt.executed) != 2 {
+		t.Fatalf("не должно быть LLM-вызовов при repeat доставки: executed=%v calls=%v", rt.executed, rt.calls)
+	}
+	// Prepared plan существует в candidate worktree (decoy в control target,
+	// куда его положил prepareDelivery, — не читался).
+	if _, found, loadErr := delivery.LoadPreparedPlan(worktree, "feat"); loadErr != nil || !found {
+		t.Fatalf("prepared plan в worktree обязан существовать: found=%v err=%v", found, loadErr)
+	}
+	// Повторная доставка блокируется (однократная запись).
 	if _, err := New(nil, nil, WithDeliveryService(okService)).DeliverDeferred(runDir, "", dir); err == nil {
 		t.Fatal("повторная доставка после успеха должна быть отклонена")
 	}


### PR DESCRIPTION
Closes **P1** findings from `audit-2026-09-05`.

- **AUD-05** (delivery): `DeliverDeferred` resolves the candidate workspace from the `delivery_deferred` state_path (rejected if outside the control target), verifies the workspace digest against the attested candidate subject, and takes a workspace lock — a retry after failed push/PR executes the exact approved candidate, not a plan looked up in the control root.
- **AUD-06** (delivery): post-terminal deferred delivery now also runs for `RunCompletedWithWarnings`, matching the standalone policy and CLI success mapping; delivery failure still surfaces as an error.
- **AUD-11** (gate/redact): gate bundle is privacy-scanned fail-closed in a staging dir before publication/signing, reusing the export redaction policy, and published atomically; DSSE signature computed only over final safe records.

Verified: `make verify` green.