### PR TITLE
Audit P1 docs/site fixes: AUD-07, AUD-08, AUD-12, AUD-13

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -24,7 +24,7 @@ jobs:
           go-version: '1.26.6'
           check-latest: true
       - name: Build docs site
-        run: go run ./docsgen/cmd/docsgen --out docs/_site --base-path /ai-team
+        run: go run ./docsgen/cmd/docsgen --out docs/_site --base-path /ai-team --github-repo arturpanteleev/ai-team
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload Pages artifact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,21 +5,72 @@ on:
     tags:
       - 'v*'
 
+# Release gating policy (AUD-13):
+# A tag is published only after (1) it is a valid semantic version and
+# (2) the exact tagged commit passes the quality checks that CI runs. CI runs
+# on master/PR only, so the release job re-runs the essential checks itself
+# against the tagged checkout: a commit with failing checks can never become a
+# release.
+#
+# The default token is read-only. Only the final publish job opts into
+# contents: write, and even there solely to create the GitHub Release from the
+# already-verified artifacts.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  release:
+  verify-and-build:
+    name: Verify and build
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.refs.outputs.tag }}
+      sha: ${{ steps.refs.outputs.sha }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          # Full history so `git describe --tags` (used by the Makefile and
+          # docsgen version) resolves the exact tag.
           fetch-depth: 0
+
+      # Gate 1: the push tag must be a valid semantic version. Non-semver tags
+      # (e.g. experimental v1beta or v-vnext) abort the job before any build.
+      - name: Validate tag is a semantic version
+        run: |
+          set -euo pipefail
+          TAG=${GITHUB_REF#refs/tags/}
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "::error::tag '$TAG' is not a valid semantic version (expected vX.Y.Z)"
+            exit 1
+          fi
+          echo "tag '$TAG' is a valid semantic version"
+
+      # Gate 2: record the exact commit the tag points to. actions/checkout
+      # pins the workspace to the triggering ref (the tag), so this SHA is the
+      # commit that the checks below certify and the release will be built from.
+      - name: Record tag and exact commit SHA
+        id: refs
+        run: |
+          set -euo pipefail
+          TAG=${GITHUB_REF#refs/tags/}
+          SHA=$(git rev-parse HEAD)
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "gating release ${TAG} on exact commit ${SHA}"
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: '1.26.6'
           check-latest: true
+
+      # Gate 3: the quality checks. These mirror what CI runs on master/PR and
+      # are executed inline so the exact tag SHA is verified in this workflow.
+      # Any failure stops the job here, before assets are built or published.
+      - name: Gate - build
+        run: go build ./...
+      - name: Gate - vet
+        run: go vet ./...
+      - name: Gate - tests
+        run: go test ./...
 
       - name: Build release binaries
         run: make release-binaries
@@ -36,17 +87,51 @@ jobs:
           done
           ls -la dist/
 
+      # Checksums let users verify downloads independently of the per-asset
+      # digests GitHub already exposes through the Releases API.
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum *.tar.gz > sha256sums.txt
+          cat sha256sums.txt
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: release-assets
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub Release
+    needs: verify-and-build
+    runs-on: ubuntu-latest
+    # contents: write only for creating the GitHub Release; it is deliberately
+    # absent from verify-and-build (top-level permissions is contents: read).
+    permissions:
+      contents: write
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: release-assets
+          path: dist
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          TAG=${GITHUB_REF#refs/tags/}
+          TAG=${{ needs.verify-and-build.outputs.tag }}
+          SHA=${{ needs.verify-and-build.outputs.sha }}
           assets=()
           for f in dist/*.tar.gz; do
             assets+=("$f")
           done
+          assets+=("dist/sha256sums.txt")
           gh release create "$TAG" "${assets[@]}" \
             --title "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
             --generate-notes \
-            --repo "$GITHUB_REPOSITORY"
+            --notes "**Quality gates passed on exact tag commit \`${SHA}\`** (tag ${TAG}): \`go build ./...\`, \`go vet ./...\`, \`go test ./...\`. Build run: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID. Verify archive integrity with the attached \`sha256sums.txt\`."

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 	go build -o bin/ai-team ./cmd/ai-team
 
 docs:
-	go run ./docsgen/cmd/docsgen --out docs/_site
+	go run ./docsgen/cmd/docsgen --out docs/_site --github-repo arturpanteleev/ai-team
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@
 переходы между этапами, проверки, mutation scopes, evidence и delivery
 исполняет детерминированный Go-контроллер — **не LLM**.
 
-AI-агенты — это «мозг», но не «руки»: всё, что меняет репозиторий или выходит
-за его пределы (commit, push, PR), выполняется только после детерминированных
-проверок и явного подтверждения человеком точного delivery-плана.
+AI-агенты — это «мозг» с ограниченными «руками», а delivery контролирует
+контроллер. Здесь три разных зоны ответственности:
+
+1. **Candidate и артефакты** агенты (coder/tester и др.) записывают в рамках
+   разрешённого mutation scope *до* человеческого подтверждения; результаты
+   затем проходят review, тесты и verification.
+2. **Проверки и evidence** исполняет детерминированный контроллер: scope guard,
+   typed checks, immutable records — не LLM.
+3. **Delivery (commit/push/PR)** — controller-owned: оно выполняется только
+   после детерминированных проверок и явного подтверждения человеком точного
+   canonical delivery-плана по его SHA-256.
 
 Публичный сайт документации: **<https://arturpanteleev.github.io/ai-team/>**
 
@@ -38,25 +46,70 @@ verification-команды (тесты, vet, линтеры) выполняют
 | Зависимость | Зачем | Проверка |
 |---|---|---|
 | Go 1.26.5+ | сборка и запуск `ai-team` | `go version` |
-| [OpenCode](https://opencode.ai) CLI в `PATH` | LLM runtime, который вызывают агенты | `opencode --version` |
+| Один из CLI-рантаймов в `PATH` (opencode / codex / claude) | LLM runtime, который вызывают агенты | `opencode --version` / `codex --version` / `claude --version` |
 | [`gh`](https://cli.github.com) CLI, авторизованный (`gh auth login`) | deployer использует его для `pr create`/`pr view` | `gh auth status` |
 
-OpenCode устанавливается независимо от ai-team, например:
+Рантайм выбирается полем `cli` в `.ai-team/config.yaml` (`opencode` — значение
+по умолчанию). Каждый рантайм устанавливается и настраивается независимо от
+ai-team:
 
-```bash
-curl -fsSL https://opencode.ai/install | bash
-```
+- **OpenCode** — [opencode.ai/install](https://opencode.ai/install) (например,
+  `curl -fsSL https://opencode.ai/install | bash`) + настройка минимум одного
+  LLM-провайдера, см. [opencode.ai/docs](https://opencode.ai/docs).
+- **Codex** — OpenAI Codex CLI: [github.com/openai/codex](https://github.com/openai/codex).
+- **Claude Code** — [docs.anthropic.com](https://docs.anthropic.com/en/docs/claude-code).
 
-и должен быть настроен как минимум с одним LLM-провайдером — см.
-[opencode.ai/docs](https://opencode.ai/docs). `gh` нужен только на шаге
-delivery (последний агент, `deployer`); если вы не планируете, чтобы
-контроллер сам открывал PR, шаги до этого работают без него.
+Как передать provider credentials в изолированный runtime — в разделе
+[«Runtime и credentials»](#runtime-и-credentials).
+
+`gh` нужен только на шаге delivery (последний агент, `deployer`); если вы не
+планируете, чтобы контроллер сам открывал PR, шаги до этого работают без
+него.
 
 Установка `ai-team`:
 
 ```bash
 go install github.com/arturpanteleev/ai-team/cmd/ai-team@latest
 ```
+
+## Runtime и credentials
+
+Агентный runtime запускается в **изолированном окружении**: у каждого рантайма
+свой временный config home (у OpenCode — `XDG_CONFIG_HOME`, у Codex —
+`CODEX_HOME`, у Claude — `CLAUDE_CONFIG_DIR`), создаваемый на время запуска.
+В субпроцесс передаются только базовые OS/locale переменные (`PATH`, `HOME`,
+`LANG`, `TMPDIR`, ...) плюс **имена** переменных, явно разрешённых opt-in.
+
+Поэтому наличие API-ключа в вашем shell-окружении **не означает**, что агент
+его увидит: если имя переменной не добавлено в allow-list, run оборвётся на
+auth, хотя standalone CLI в том же shell работает. Чтобы передать провайдерский
+credential, разрешите его **по имени** через `AI_TEAM_HARNESS_ENV_ALLOW`
+(список имён через запятую):
+
+```bash
+export ANTHROPIC_API_KEY='<YOUR_API_KEY_HERE>'
+AI_TEAM_HARNESS_ENV_ALLOW=ANTHROPIC_API_KEY ai-team run --feature add-jwt-auth --task "…"
+```
+
+Значение переменной никуда не пробрасывается автоматически: в субпроцесс
+попадает только сам факт «переменная с разрешённым именем существует в
+окружении родителя». Значение никогда не логируется и не пишется в evidence —
+гарантию даёт allow-list по имени, а не публикация секрета. Устаревший алиас
+`AI_TEAM_OPENCODE_ENV_ALLOW` работает так же ради обратной совместимости.
+
+Per-runtime заметки:
+
+| Рантайм | CLI-бинарник (config `cli:`) | Выбор модели | Ожидаемый preflight |
+|---|---|---|---|
+| OpenCode | `opencode` (по умолчанию) | `-m <model>` / `auto` | `opencode --version`, наличие provider-credentials и их allow-list, Git-repository |
+| Codex | `codex` | `-m <model>` / `auto` | `codex --version`; аутентификация Codex (access token / `CODEX_API_KEY`), sandbox `workspace-write` |
+| Claude Code | `claude` | `--model <model>` / `auto` | `claude --version`; `ANTHROPIC_API_KEY` (или подписка), `--permission-mode acceptEdits` |
+
+Точные флаги запуска и политики изоляции каждого адаптера — в
+[ARCHITECTURE.md](docs/ARCHITECTURE.md) и в исходниках `pkg/runtime/{opencode,codex,claude}.go`.
+Если у run нет авторизованного provider (или вы просто хотите попробовать без
+LLM), прогоните no-LLM demo: `bash docs/demo/run-demo.sh` — см.
+[docs/demo/README.md](docs/demo/README.md).
 
 ## Быстрый старт
 
@@ -77,34 +130,53 @@ Node, неизвестный) `init` выводит warning: delivery остаё
 вы не настроите required unit/integration check вручную (см.
 [«Конфигурация»](#конфигурация)).
 
-Запустите фичу: от идеи до готового к доставке кода — **два запуска**, и между
-ними вы осознанно читаете и подтверждаете план.
+Запустите фичу: от идеи до готового к доставке кода. Количество запусков
+зависит от окружения:
+
+- **Non-TTY** (CI, скрипт): контроллер останавливается перед delivery с exit
+  code `3`, печатая canonical plan и его SHA-256; подтверждение — отдельный
+  `--resume` со строкой `--approve-plan` того же SHA-256.
+- **Интерактивный TTY**: `authorizeDelivery` спрашивает «Продолжить commit/
+  push/PR? [y/N]» и после `y` доставляет в том же первом процессе — exit `3`
+  перед delivery не возникает. Отказ (`n`) останавливает run (delivery
+  отклонён человеком).
+
+Оба пути подтверждают **ровно тот** canonical plan, который показал контроллер
+(другой SHA-256 не подойдёт), — и только тогда будут созданы commit/push/PR.
 
 ```bash
-# 1. Провести фичу по конвейеру: аналитик → архитектор → кодер → ревьюер →
-#    тестер → верификатор → deployer. Контроллер останавливается перед
-#    delivery и печатает canonical plan + его SHA-256 (exit code 3).
+# Non-TTY: первый запуск проводит фичу по конвейеру, останавливается перед
+# delivery и печатает canonical plan + его SHA-256 (exit code 3).
 ai-team run --feature add-jwt-auth --task "Реализовать JWT авторизацию"
 ```
 
 ```bash
-# 2. Подтвердить именно тот план, который показал контроллер (другой SHA-256
-#    не подойдёт), — и только тогда будет создан commit/push/PR.
+# Non-TTY: подтвердить именно тот план, что показал контроллер (другой
+# SHA-256 не подойдёт), — и только тогда будет создан commit/push/PR.
 ai-team run --resume <run_id> --approve-plan <sha256-из-шага-1>
 ```
 
 В интерактивном терминале checkpoints спрашивают ваше решение сами, без
-флагов `--approve-*`. После доставки результат виден на дашборде
-(`ai-team web`) или в директории `.ai-team/runs/<run_id>/`.
+флагов `--approve-*`.
+
+Обратите внимание на **forward approvals**: профиль по умолчанию `standard`
+(как и `fast`) *откладывает* подтверждения на смысловых рёбрах конвейера до
+момента delivery — вы подтверждаете их одним consolidated delivery-решением.
+Только профиль `regulated` спрашивает approval на каждом checkpoint пошагово.
+После доставки результат виден на дашборде (`ai-team web`) или в директории
+`.ai-team/runs/<run_id>/`.
 
 Полный путь с пояснением каждого шага — в разделе
 [«Как поставить фичу от начала до конца»](#как-поставить-фичу-от-начала-до-конца).
 
 ## Как поставить фичу от начала до конца
 
-Полный путь одной фичи через `run` — два запуска, а не один: контроллер
-намеренно останавливается перед любым внешним эффектом (commit/push/PR) и ждёт
-явного подтверждения именно того плана, который он показал.
+Ключевой момент: **delivery подтверждается отдельно и всегда** — commit/push/PR
+выполняет только контроллер после явного подтверждения человеком точного
+canonical plan (SHA-256). Как именно записывается подтверждение, зависит от
+окружения.
+
+**Сценарий A — non-TTY (CI, скрипт): два запуска.**
 
 1. **Первый запуск** проводит фичу через весь конвейер до `deployer` и
    останавливается перед delivery с exit code `3`, напечатав canonical delivery
@@ -112,13 +184,8 @@ ai-team run --resume <run_id> --approve-plan <sha256-из-шага-1>
 
    ```bash
    ai-team run --feature add-jwt-auth \
-     --task "Реализовать JWT авторизацию" \
-     --approve-gates
+     --task "Реализовать JWT авторизацию"
    ```
-
-   (`--approve-gates` нужен только в non-interactive среде — например, в CI
-   или скрипте; в интерактивном терминале checkpoints спросят подтверждение
-   сами, без флага.)
 
 2. **Прочитайте план.** Он перечисляет ровно те файлы, которые будут
    закоммичены, ветку и сообщение коммита. Это единственный момент, где стоит
@@ -129,18 +196,34 @@ ai-team run --resume <run_id> --approve-plan <sha256-из-шага-1>
    candidate-worktree:
 
    ```bash
-   ai-team run --resume <run_id> \
-     --approve-gates --approve-plan <sha256-из-шага-1>
+   ai-team run --resume <run_id> --approve-plan <sha256-из-шага-1>
    ```
 
-   Delivery approval — обычная persisted approval с subject = SHA-256 плана
-   и ролью `release_manager`. То же решение можно записать без CLI-resume:
-   через web UI (`POST /decisions`) или командой `ai-team decision`, после
-   чего достаточно `ai-team run --resume <run_id>`. Если план изменился
-   (другой коммит поверх, другие файлы) — старый SHA-256 не подойдёт ни
-   одним из путей, и контроллер откажется выполнять delivery. Это осознанное
-   поведение, а не баг: подтверждение одноразовое и привязано к конкретному
-   плану.
+**Сценарий B — интерактивный TTY: один процесс, delivery после `y`.**
+
+Контроллер сам консолидирует deferred forward approvals и при достижении
+`deployer` печатает canonical plan и спрашивает
+«Продолжить commit/push/PR? [y/N]». Ответ `y` записывает persisted approval с
+subject = SHA-256 показанного плана и ролью `release_manager` — и delivery
+выполняется в **том же** первом процессе, без `--resume` и без exit `3`.
+Ответ `n` останавливает run: delivery отклонён человеком.
+
+В обоих сценариях delivery approval — обычная persisted approval с subject =
+SHA-256 плана и ролью `release_manager`. То же решение можно записать без
+CLI-resume: через web UI (`POST /decisions`) или командой `ai-team decision`,
+после чего достаточно `ai-team run --resume <run_id>`. Если план изменился
+(другой коммит поверх, другие файлы) — старый SHA-256 не подойдёт ни одним
+из путей, и контроллер откажется выполнять delivery. Это осознанное поведение,
+а не баг: подтверждение одноразовое и привязано к конкретному плану.
+
+`--approve-gates` (если он вам нужен) подтверждает **только** pipeline gates в
+non-interactive среде — это не delivery approval. Delivery по-прежнему требует
+отдельного подтверждения точного плана через `--approve-plan`, interactive
+`y`/`n`, web UI или `ai-team decision`. Профили `standard`/`fast` откладывают
+forward approvals до момента delivery, поэтому для них consolidated
+delivery-решение покрывает и deferred gates; профиль `regulated` спрашивает
+approval на каждом checkpoint пошагово, и `--approve-gates`/интерактивные
+решения понадобятся на протяжении run до его завершения.
 
 4. **Проверьте результат** — `ai-team web` открывает дашборд со статусом
    запуска, live-логом, checks/mutations/delivery по каждому этапу и
@@ -254,10 +337,10 @@ SHA-256 CAS; manifest содержит exact path/digest/size/mode и позво
 которые можно заменить managed queue/object storage через те же contracts.
 
 Перед созданием run dashboard показывает runtime preflight. Controller
-повторяет тот же gate непосредственно при `Start`: проверяет OpenCode и его
-версию, model/provider, credential allow-list и Git repository; для workflow
-с delivery дополнительно требует `origin`, `gh` и успешный `gh auth status`.
-Значения credentials никогда не попадают в report.
+повторяет тот же gate непосредственно при `Start`: проверяет выбранный CLI
+рантайм и его версию, model/provider, credential allow-list и Git repository;
+для workflow с delivery дополнительно требует `origin`, `gh` и успешный
+`gh auth status`. Значения credentials никогда не попадают в report.
 
 Exit-коды `run`: `0` — completed/completed with warnings, `1` — ошибка или
 негативный вердикт, `2` — BLOCKED, `3` — stopped на checkpoint или перед

--- a/docsgen/cmd/docsgen/main.go
+++ b/docsgen/cmd/docsgen/main.go
@@ -24,6 +24,7 @@ import (
 func main() {
 	out := flag.String("out", "docs/_site", "output directory for the generated site")
 	basePath := flag.String("base-path", "", "site base path, e.g. /ai-team for a GitHub Pages project site")
+	githubRepo := flag.String("github-repo", "arturpanteleev/ai-team", "owner/repo used to rewrite directory links to GitHub tree URLs")
 	flag.Parse()
 
 	root, err := os.Getwd()
@@ -38,6 +39,7 @@ func main() {
 		Version:     version(),
 		BasePath:    *basePath,
 		CleanOutput: true,
+		GitHubRepo:  *githubRepo,
 		Sources: []docsgen.SourcedPage{
 			{Source: "README.md", Title: "Overview", Section: "Guide", Weight: 0, URL: "/"},
 			{Source: "docs/ARCHITECTURE.md", Title: "Architecture", Section: "Reference", Weight: 0, URL: "/architecture/"},
@@ -51,6 +53,9 @@ func main() {
 
 	if err := docsgen.Build(cfg); err != nil {
 		log.Fatalf("build docs: %v", err)
+	}
+	if err := docsgen.CheckLinksWithBase(cfg.Output, cfg.BasePath); err != nil {
+		log.Fatalf("link check: %v", err)
 	}
 	fmt.Printf("docs site built to %s\n", cfg.Output)
 }

--- a/docsgen/docsgen.go
+++ b/docsgen/docsgen.go
@@ -103,6 +103,15 @@ func Build(cfg Config) error {
 		pathMap[abs] = joinBase(site.BasePath, url)
 	}
 
+	// repoRoot is the actual repository root, used as the base for GitHub
+	// blob/tree URLs. It is distinct from a linkTransformer's baseDir, which
+	// is the directory of the specific page being rendered (see below) and
+	// varies per page depth.
+	repoRoot, err := filepath.Abs(cfg.Root)
+	if err != nil {
+		return fmt.Errorf("resolve repo root: %w", err)
+	}
+
 	var nonPage []nonPageLink
 	for _, sp := range cfg.Sources {
 		srcPath := filepath.Join(cfg.Root, filepath.FromSlash(sp.Source))
@@ -121,9 +130,11 @@ func Build(cfg Config) error {
 		}
 		tr := &linkTransformer{
 			baseDir:    filepath.Dir(absSrc),
+			repoRoot:   repoRoot,
 			pathMap:    pathMap,
 			pageURL:    url,
 			githubRepo: cfg.GitHubRepo,
+			sourcePage: sp.Source,
 		}
 		page, err := renderPage(tr, sp, content)
 		if err != nil {
@@ -278,18 +289,21 @@ func slugifyID(s string) string {
 // missing raw files. It also collects non-page relative links (assets,
 // non-page markdown files) for copying into the output directory.
 type linkTransformer struct {
-	baseDir      string
+	baseDir      string // directory of the page currently being rendered (varies per page)
+	repoRoot     string // actual repository root, used for GitHub blob/tree URLs
 	pathMap      map[string]string
 	pageURL      string // site URL of the page being rendered (e.g. "/contributing/")
 	githubRepo   string
+	sourcePage   string // repo-relative source path of the page being rendered, for diagnostics
 	nonPageLinks []nonPageLink
 }
 
 // nonPageLink tracks a relative link to a repository file that is not among
 // the rendered pages and needs to be copied into the site output.
 type nonPageLink struct {
-	resolved string // absolute repo path of the target file
-	outPath  string // relative path within the output directory
+	resolved   string // absolute repo path of the target file
+	outPath    string // relative path within the output directory
+	sourcePage string // repo-relative source path of the page that linked to it
 }
 
 func (t *linkTransformer) Transform(node *ast.Document, reader text.Reader, pc parser.Context) {
@@ -383,15 +397,20 @@ func (t *linkTransformer) nonPageLinkFor(resolved string) nonPageLink {
 		relDir = ""
 	}
 	return nonPageLink{
-		resolved: resolved,
-		outPath:  filepath.Join(filepath.FromSlash(strings.Trim(strings.TrimPrefix(t.pageURL, "/"), "/")), relDir, filepath.Base(resolved)),
+		resolved:   resolved,
+		outPath:    filepath.Join(filepath.FromSlash(strings.Trim(strings.TrimPrefix(t.pageURL, "/"), "/")), relDir, filepath.Base(resolved)),
+		sourcePage: t.sourcePage,
 	}
 }
 
 // slashRelRepoTarget computes the repo-root-relative path of a resolved file,
-// used to build GitHub blob/tree URLs.
+// used to build GitHub blob/tree URLs. This is always relative to the actual
+// repository root (t.repoRoot), never to the rendering page's own directory
+// (t.baseDir) — the two coincide only for pages that live at the repo root,
+// so using baseDir here would produce a wrong GitHub URL for any page nested
+// in a subdirectory (e.g. docs/demo/README.md).
 func slashRelRepoTarget(t *linkTransformer, resolved string) string {
-	rel, err := filepath.Rel(t.baseDir, resolved)
+	rel, err := filepath.Rel(t.repoRoot, resolved)
 	if err != nil {
 		return filepath.Base(resolved)
 	}
@@ -418,9 +437,27 @@ func dedupeNonPage(links []nonPageLink) []nonPageLink {
 // copyAssets copies repository files referenced by relative links into the
 // matching locations of the output directory so the links resolve on the
 // deployed site.
+//
+// A page nested deep enough in the source tree, linking far enough upward
+// (e.g. "../../LICENSE"), can compute an output path that normalizes outside
+// output entirely. This should never happen for a well-formed docs tree, so
+// every destination is verified to be contained within output before
+// anything is created; a violation is a hard build failure (naming the
+// offending source page and target), not a silent skip.
 func copyAssets(links []nonPageLink, output string) error {
+	outputAbs, err := filepath.Abs(output)
+	if err != nil {
+		return fmt.Errorf("resolve output dir: %w", err)
+	}
 	for _, l := range links {
-		outPath := filepath.Join(output, filepath.FromSlash(l.outPath))
+		outPath, err := filepath.Abs(filepath.Join(output, filepath.FromSlash(l.outPath)))
+		if err != nil {
+			return fmt.Errorf("resolve asset path %s: %w", l.outPath, err)
+		}
+		if outPath != outputAbs && !strings.HasPrefix(outPath, outputAbs+string(filepath.Separator)) {
+			return fmt.Errorf("refusing to write asset outside output directory: page %s links to %s, which resolves to %s (outside %s)",
+				l.sourcePage, l.resolved, outPath, outputAbs)
+		}
 		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 			return fmt.Errorf("mkdir asset %s: %w", outPath, err)
 		}

--- a/docsgen/docsgen.go
+++ b/docsgen/docsgen.go
@@ -11,8 +11,10 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"unicode"
@@ -67,6 +69,9 @@ type Config struct {
 	BasePath    string
 	CleanOutput bool
 	Sources     []SourcedPage
+	// GitHubRepo is the "owner/repo" used to rewrite directory links to
+	// GitHub blob URLs (e.g. "arturpanteleev/ai-team").
+	GitHubRepo string
 }
 
 // Build renders all configured Markdown sources into HTML under Output.
@@ -98,6 +103,7 @@ func Build(cfg Config) error {
 		pathMap[abs] = joinBase(site.BasePath, url)
 	}
 
+	var nonPage []nonPageLink
 	for _, sp := range cfg.Sources {
 		srcPath := filepath.Join(cfg.Root, filepath.FromSlash(sp.Source))
 
@@ -109,16 +115,31 @@ func Build(cfg Config) error {
 		if err != nil {
 			return fmt.Errorf("read source %s: %w", sp.Source, err)
 		}
-		page, err := renderPage(sp, content, absSrc, pathMap)
+		url := sp.URL
+		if url == "" {
+			url = slugify(sp.Source)
+		}
+		tr := &linkTransformer{
+			baseDir:    filepath.Dir(absSrc),
+			pathMap:    pathMap,
+			pageURL:    url,
+			githubRepo: cfg.GitHubRepo,
+		}
+		page, err := renderPage(tr, sp, content)
 		if err != nil {
 			return fmt.Errorf("render %s: %w", sp.Source, err)
 		}
+		nonPage = append(nonPage, tr.nonPageLinks...)
 		site.Pages = append(site.Pages, page)
 	}
 
 	sortPages(site.Pages)
 
 	if err := writeLayoutAssets(cfg.Output); err != nil {
+		return err
+	}
+
+	if err := copyAssets(dedupeNonPage(nonPage), cfg.Output); err != nil {
 		return err
 	}
 
@@ -148,10 +169,9 @@ func Build(cfg Config) error {
 }
 
 // renderPage converts Markdown bytes into a Page with a body and TOC.
-// absSrc is the repository-absolute path of the source file; pathMap maps
-// repository-absolute Markdown paths to site URLs for cross-link rewriting.
-func renderPage(sp SourcedPage, content []byte, absSrc string, pathMap map[string]string) (*Page, error) {
-	tr := &linkTransformer{baseDir: filepath.Dir(absSrc), pathMap: pathMap}
+// tr carries the transformation configuration (baseDir, pathMap, pageURL and
+// githubRepo) and accumulates any non-page relative links it finds.
+func renderPage(tr *linkTransformer, sp SourcedPage, content []byte) (*Page, error) {
 	md := goldmark.New(
 		goldmark.WithExtensions(
 			extension.GFM,
@@ -255,10 +275,21 @@ func slugifyID(s string) string {
 
 // linkTransformer rewrites Markdown cross-links that point at other .md files
 // in the repository so they resolve to the generated site pages instead of
-// missing raw files.
+// missing raw files. It also collects non-page relative links (assets,
+// non-page markdown files) for copying into the output directory.
 type linkTransformer struct {
-	baseDir string
-	pathMap map[string]string
+	baseDir      string
+	pathMap      map[string]string
+	pageURL      string // site URL of the page being rendered (e.g. "/contributing/")
+	githubRepo   string
+	nonPageLinks []nonPageLink
+}
+
+// nonPageLink tracks a relative link to a repository file that is not among
+// the rendered pages and needs to be copied into the site output.
+type nonPageLink struct {
+	resolved string // absolute repo path of the target file
+	outPath  string // relative path within the output directory
 }
 
 func (t *linkTransformer) Transform(node *ast.Document, reader text.Reader, pc parser.Context) {
@@ -293,7 +324,7 @@ func (t *linkTransformer) Transform(node *ast.Document, reader text.Reader, pc p
 }
 
 func (t *linkTransformer) rewrite(dest string) (string, bool) {
-	// Only touch links to repository Markdown files.
+	// Split off the fragment so non-page assets keep their anchors.
 	idx := strings.Index(dest, "#")
 	pathPart := dest
 	fragment := ""
@@ -301,22 +332,300 @@ func (t *linkTransformer) rewrite(dest string) (string, bool) {
 		pathPart = dest[:idx]
 		fragment = dest[idx:]
 	}
-	if !strings.HasSuffix(pathPart, ".md") && !strings.HasSuffix(pathPart, ".md/") {
-		return "", false
-	}
-	// Skip absolute/external URLs.
+	// Skip absolute/external URLs and anchor-only links.
 	if strings.HasPrefix(pathPart, "http://") || strings.HasPrefix(pathPart, "https://") ||
 		strings.HasPrefix(pathPart, "//") || strings.HasPrefix(pathPart, "mailto:") {
 		return "", false
 	}
-
-	resolved := filepath.Clean(filepath.Join(t.baseDir, filepath.FromSlash(strings.TrimPrefix(pathPart, "/"))))
-	target, ok := t.pathMap[resolved]
-	if !ok {
-		// Unknown target: leave as-is (may be a local anchor or external).
+	if pathPart == "" {
 		return "", false
 	}
-	return target + fragment, true
+
+	// Links to repository Markdown pages are mapped to generated pages.
+	if strings.HasSuffix(pathPart, ".md") || strings.HasSuffix(pathPart, ".md/") {
+		resolved := filepath.Clean(filepath.Join(t.baseDir, filepath.FromSlash(strings.TrimPrefix(pathPart, "/"))))
+		target, ok := t.pathMap[resolved]
+		if !ok {
+			// A .md file that is not a rendered page: copy it if it exists so
+			// the relative link still resolves on the site.
+			if info, err := os.Stat(resolved); err == nil && !info.IsDir() {
+				t.nonPageLinks = append(t.nonPageLinks, t.nonPageLinkFor(resolved))
+			}
+			// Unknown/absent target: leave as-is (may be an anchor or external).
+			return "", false
+		}
+		return target + fragment, true
+	}
+
+	// Directory links (e.g. "docsgen/") resolve to GitHub tree URLs so they
+	// don't 404 on the site.
+	dirCandidate := filepath.Join(t.baseDir, filepath.FromSlash(strings.TrimSuffix(strings.TrimPrefix(pathPart, "/"), "/")))
+	if info, err := os.Stat(dirCandidate); err == nil && info.IsDir() && t.githubRepo != "" {
+		return "https://github.com/" + t.githubRepo + "/tree/" + slashRelRepoTarget(t, dirCandidate) + fragment, true
+	}
+
+	// Non-page files (assets, LICENSE, YAML, ...) are copied into the output
+	// directory so the relative link resolves without a GitHub round-trip.
+	resolved := filepath.Clean(filepath.Join(t.baseDir, filepath.FromSlash(strings.TrimPrefix(pathPart, "/"))))
+	if info, err := os.Stat(resolved); err == nil && !info.IsDir() {
+		t.nonPageLinks = append(t.nonPageLinks, t.nonPageLinkFor(resolved))
+	}
+	// Leave the link as-is: the copied file matches the original relative path.
+	return "", false
+}
+
+// nonPageLinkFor computes the output path for a resolved repo file. The page
+// renders at pageURL (e.g. "/contributing/"), so a relative link resolves at
+// the page's output directory depth.
+func (t *linkTransformer) nonPageLinkFor(resolved string) nonPageLink {
+	relDir, err := filepath.Rel(t.baseDir, filepath.Dir(resolved))
+	if err != nil || relDir == "." {
+		relDir = ""
+	}
+	return nonPageLink{
+		resolved: resolved,
+		outPath:  filepath.Join(filepath.FromSlash(strings.Trim(strings.TrimPrefix(t.pageURL, "/"), "/")), relDir, filepath.Base(resolved)),
+	}
+}
+
+// slashRelRepoTarget computes the repo-root-relative path of a resolved file,
+// used to build GitHub blob/tree URLs.
+func slashRelRepoTarget(t *linkTransformer, resolved string) string {
+	rel, err := filepath.Rel(t.baseDir, resolved)
+	if err != nil {
+		return filepath.Base(resolved)
+	}
+	return filepath.ToSlash(rel)
+}
+
+// dedupeNonPage drops duplicate copy targets (the same file linked from more
+// than one page), keeping the first occurrence. Copying is idempotent, so this
+// only avoids redundant stat/write work.
+func dedupeNonPage(links []nonPageLink) []nonPageLink {
+	seen := make(map[string]bool, len(links))
+	out := links[:0]
+	for _, l := range links {
+		key := l.outPath
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, l)
+	}
+	return out
+}
+
+// copyAssets copies repository files referenced by relative links into the
+// matching locations of the output directory so the links resolve on the
+// deployed site.
+func copyAssets(links []nonPageLink, output string) error {
+	for _, l := range links {
+		outPath := filepath.Join(output, filepath.FromSlash(l.outPath))
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return fmt.Errorf("mkdir asset %s: %w", outPath, err)
+		}
+		data, err := os.ReadFile(l.resolved)
+		if err != nil {
+			return fmt.Errorf("read asset %s: %w", l.resolved, err)
+		}
+		if err := os.WriteFile(outPath, data, 0o644); err != nil {
+			return fmt.Errorf("write asset %s: %w", outPath, err)
+		}
+	}
+	return nil
+}
+
+// CheckLinks is CheckLinksWithBase with an empty base path (site hosted at "/").
+func CheckLinks(output string) error {
+	return CheckLinksWithBase(output, "")
+}
+
+// CheckLinksWithBase validates that every internal href/src in the generated
+// site resolves to an existing output file and that fragments point to an
+// element present in the target page. basePath is the site base path (e.g.
+// "/ai-team") used by the rendered URLs and stripped before matching against
+// the output file tree. Fragment-only, mailto: and absolute (http://, https://,
+// //) URLs are skipped. It returns a human-readable error listing the broken
+// links, or nil when the site is fully linked.
+//
+// CheckLinksWithBase deliberately scans the rendered HTML files, not the
+// Markdown sources, so it catches both raw links and links produced by layout
+// templates.
+func CheckLinksWithBase(output, basePath string) error {
+	if output == "" {
+		return fmt.Errorf("output directory is empty")
+	}
+	base := normalizeBasePath(basePath)
+	files, err := listHTML(output)
+	if err != nil {
+		return err
+	}
+	content := make(map[string]string, len(files))
+	for _, rel := range files {
+		data, err := os.ReadFile(filepath.Join(output, rel))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", rel, err)
+		}
+		content[rel] = string(data)
+	}
+
+	dirWithIndex := func(d string) bool {
+		_, ok := content[filepath.ToSlash(filepath.Join(d, "index.html"))]
+		return ok
+	}
+	// resolveFile maps a URL path from page pageRel to a concrete output file
+	// path (empty when nothing matches). Root-relative URLs (leading "/") are
+	// resolved against the site root; page-relative ones against the page's
+	// output directory.
+	resolveFile := func(pageRel, pathPart string) string {
+		p := pathPart
+		if base != "" {
+			if p == base {
+				p = "/"
+			} else if strings.HasPrefix(p, base+"/") {
+				p = p[len(base):]
+			}
+		}
+		rootRel := strings.HasPrefix(p, "/")
+		baseDir := ""
+		if !rootRel {
+			baseDir = pageRel
+		}
+		target := strings.Trim(strings.TrimPrefix(p, "/"), "/")
+		candidate := filepath.ToSlash(filepath.Join(baseDir, filepath.FromSlash(target)))
+		if _, ok := content[candidate]; ok {
+			return candidate
+		}
+		if dirWithIndex(candidate) {
+			return filepath.ToSlash(filepath.Join(candidate, "index.html"))
+		}
+		if info, err := os.Stat(filepath.Join(output, candidate)); err == nil && !info.IsDir() {
+			return candidate
+		}
+		return ""
+	}
+
+	seen := make(map[string]string) // url -> first page that reported it
+	report := func(url, from string) {
+		if seen[url] == "" {
+			seen[url] = from
+		}
+	}
+	idRe := regexp.MustCompile(`id="([^"]*)"`)
+
+	for _, rel := range files {
+		pageDir := filepath.ToSlash(filepath.Dir(rel))
+		if pageDir == "." {
+			pageDir = ""
+		}
+		for _, m := range hrefRe.FindAllStringSubmatch(content[rel], -1) {
+			url := m[1]
+			if url == "" || !needsCheck(url) {
+				continue
+			}
+			pathPart, frag := url, ""
+			if i := strings.Index(url, "#"); i >= 0 {
+				pathPart, frag = url[:i], url[i+1:]
+			}
+			if frag != "" {
+				frag = unescapeFragment(frag)
+			}
+			if pathPart != "" {
+				targetFile := resolveFile(pageDir, pathPart)
+				if targetFile == "" {
+					report(url, rel)
+					continue
+				}
+				if frag != "" {
+					if ids := idRe.FindAllStringSubmatch(content[targetFile], -1); !hasID(ids, frag) {
+						report(url, rel)
+					}
+				}
+				continue
+			}
+			// Fragment-only link must target a heading in the same page.
+			if frag != "" {
+				if ids := idRe.FindAllStringSubmatch(content[rel], -1); !hasID(ids, frag) {
+					report(url, rel)
+				}
+			}
+		}
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+	unique := make([]string, 0, len(seen))
+	for url := range seen {
+		unique = append(unique, url)
+	}
+	sort.Strings(unique)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d broken link(s) in generated site:\n", len(unique))
+	for _, url := range unique {
+		fmt.Fprintf(&b, "  %s (linked from %s)\n", url, seen[url])
+	}
+	return fmt.Errorf("%s", strings.TrimSpace(b.String()))
+}
+
+// hasID reports whether frag appears among the id attributes extracted from a
+// page.
+func hasID(ids [][]string, frag string) bool {
+	for _, m := range ids {
+		if m[1] == frag {
+			return true
+		}
+	}
+	return false
+}
+
+// unescapeFragment decodes percent-encoded bytes in a URL fragment (goldmark
+// encodes non-ASCII hrefs) so it can be compared with raw id attributes.
+func unescapeFragment(frag string) string {
+	if !strings.Contains(frag, "%") {
+		return frag
+	}
+	if decoded, err := url.PathUnescape(frag); err == nil {
+		return decoded
+	}
+	return frag
+}
+
+// hrefRe matches href/src attributes on anchors and images.
+var hrefRe = regexp.MustCompile(`(?:href|src)="([^"]*)"`)
+
+// needsCheck reports whether a URL is an internal link that must resolve on
+// the generated site (skips fragments, external and protocol-relative URLs).
+func needsCheck(url string) bool {
+	if strings.HasPrefix(url, "#") {
+		return false
+	}
+	return !(strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") ||
+		strings.HasPrefix(url, "//") || strings.HasPrefix(url, "mailto:") ||
+		strings.HasPrefix(url, "tel:") || strings.HasPrefix(url, "data:"))
+}
+
+// listHTML returns all HTML files under dir with forward-slash paths relative
+// to dir.
+func listHTML(dir string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) == ".html" {
+			rel, err := filepath.Rel(dir, path)
+			if err != nil {
+				return err
+			}
+			files = append(files, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	return files, err
 }
 
 // firstHeading extracts the first ATX heading (# Foo) from Markdown bytes.

--- a/docsgen/docsgen_test.go
+++ b/docsgen/docsgen_test.go
@@ -94,6 +94,7 @@ func TestBuildEndToEnd(t *testing.T) {
 		Title:       "ai-team",
 		Version:     "dev",
 		CleanOutput: true,
+		GitHubRepo:  "arturpanteleev/ai-team",
 		Sources: []SourcedPage{
 			{Source: "README.md", Title: "Overview", Section: "Guide", Weight: 0, URL: "/"},
 			{Source: "docs/ARCHITECTURE.md", Title: "Architecture", Section: "Reference", Weight: 0, URL: "/architecture/"},
@@ -141,5 +142,172 @@ func TestBuildEndToEnd(t *testing.T) {
 	// Raw markdown links must not remain as broken .md hrefs.
 	if strings.Contains(string(idx), `.md"`) {
 		t.Errorf("index.html still contains raw .md links:\n%#v", string(idx))
+	}
+
+	// Non-page assets referenced by relative links must be copied into the
+	// output so the relative hrefs resolve on the deployed site.
+	for _, want := range []string{
+		"LICENSE",                // README badge link
+		"contributing/CLAUDE.md", // non-page relative .md
+		"demo/ci-gate-demo.yaml", // demo CI asset
+	} {
+		if _, err := os.Stat(filepath.Join(out, filepath.FromSlash(want))); err != nil {
+			t.Errorf("referenced asset not copied to %s: %v", want, err)
+		}
+	}
+
+	// Directory links are rewritten to GitHub tree URLs instead of 404ing.
+	if !strings.Contains(string(idx), "https://github.com/arturpanteleev/ai-team/tree/docsgen") {
+		t.Errorf("index.html missing GitHub tree rewrite for docsgen/:\n%.500s", string(idx))
+	}
+
+	// The whole generated site must pass the link checker.
+	if err := CheckLinks(out); err != nil {
+		t.Errorf("CheckLinks failed on generated site: %v", err)
+	}
+}
+
+// fixtureSite writes the given files (page markdown plus any linked assets)
+// beneath a temp root, builds a site from pages, and returns the output dir.
+func fixtureSite(t *testing.T, pages []SourcedPage, files map[string]string, dirs []string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(d)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for path, content := range files {
+		dst := filepath.Join(root, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dst, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out := t.TempDir()
+	cfg := Config{
+		Root:        root,
+		Output:      out,
+		Title:       "fixture",
+		Version:     "dev",
+		CleanOutput: true,
+		GitHubRepo:  "arturpanteleev/ai-team",
+		Sources:     pages,
+	}
+	if err := Build(cfg); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return out
+}
+
+// TestBuildCopiesReferencedAssets covers the four working-on-GitHub links from
+// AUD-12: the LICENSE badge (README), CLAUDE.md (CONTRIBUTING), the demo YAML
+// (docs/demo/README) and the docsgen/ directory link.
+func TestBuildCopiesReferencedAssets(t *testing.T) {
+	out := fixtureSite(t, []SourcedPage{
+		{Source: "README.md", Title: "Overview", URL: "/"},
+		{Source: "CONTRIBUTING.md", Title: "Contributing", URL: "/contributing/"},
+		{Source: "docs/demo/README.md", Title: "Demo", URL: "/demo/"},
+	}, map[string]string{
+		"README.md":                   "\n[![License](LICENSE)](LICENSE)\n\nSite built by [`docsgen/`](docsgen/).\n",
+		"CONTRIBUTING.md":             "See [`CLAUDE.md`](CLAUDE.md).\n",
+		"docs/demo/README.md":         "CI: [`ci-gate-demo.yaml`](ci-gate-demo.yaml).\n",
+		"LICENSE":                     "Apache-2.0 fixture\n",
+		"CLAUDE.md":                   "# agent rules\n",
+		"docs/demo/ci-gate-demo.yaml": "name: gate demo\n",
+	}, []string{"docsgen"})
+	for _, want := range []string{
+		"LICENSE",
+		filepath.Join("contributing", "CLAUDE.md"),
+		filepath.Join("demo", "ci-gate-demo.yaml"),
+	} {
+		if _, err := os.Stat(filepath.Join(out, filepath.FromSlash(want))); err != nil {
+			t.Errorf("copied asset missing at %s: %v", want, err)
+		}
+	}
+
+	// The docsgen/ directory link must be rewritten to a GitHub tree URL.
+	idx, err := os.ReadFile(filepath.Join(out, "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(idx), "https://github.com/arturpanteleev/ai-team/tree/docsgen") {
+		t.Errorf("docsgen/ link not rewritten to GitHub tree URL; got:\n%s", string(idx))
+	}
+
+	// The ci-gate-demo.yaml relative link must stay relative and resolve.
+	demo, err := os.ReadFile(filepath.Join(out, "demo", "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(demo), `href="ci-gate-demo.yaml"`) {
+		t.Errorf("demo page lost the ci-gate-demo.yaml relative link:\n%s", string(demo))
+	}
+}
+
+// TestCheckLinksCatchesMissingRelativeLink is the acceptance case from AUD-12:
+// if a page links to a missing relative file, the generated-link check fails.
+func TestCheckLinksCatchesMissingRelativeLink(t *testing.T) {
+	out := fixtureSite(t, []SourcedPage{
+		{Source: "README.md", Title: "Overview", URL: "/"},
+	}, map[string]string{
+		"README.md": "See [`secret-file.yaml`](secret-file.yaml).\n",
+	}, nil)
+	if err := CheckLinks(out); err == nil {
+		t.Fatal("CheckLinks expected to fail for a missing relative link, got nil")
+	} else if !strings.Contains(err.Error(), "secret-file.yaml") {
+		t.Errorf("CheckLinks error %q does not mention the missing target", err)
+	}
+}
+
+// TestCheckLinksCatchesDeletedDemoAsset asserts that removing a copied asset
+// from the output breaks the generated-link check (the audit's "deletion of
+// demo YAML" case).
+func TestCheckLinksCatchesDeletedDemoAsset(t *testing.T) {
+	out := fixtureSite(t, []SourcedPage{
+		{Source: "docs/demo/README.md", Title: "Demo", URL: "/demo/"},
+	}, map[string]string{
+		"docs/demo/README.md":         "CI: [`ci-gate-demo.yaml`](ci-gate-demo.yaml).\n",
+		"docs/demo/ci-gate-demo.yaml": "name: gate demo\n",
+	}, nil)
+	if err := os.Remove(filepath.Join(out, "demo", "ci-gate-demo.yaml")); err != nil {
+		t.Fatalf("remove copied asset: %v", err)
+	}
+	if err := CheckLinks(out); err == nil {
+		t.Fatal("CheckLinks expected to fail after the demo YAML was deleted, got nil")
+	}
+}
+
+// TestCheckLinksBasePath verifies the checker handles the GitHub Pages base
+// path prefix (e.g. /ai-team) used by the deployed site.
+func TestCheckLinksBasePath(t *testing.T) {
+	out := fixtureSite(t, []SourcedPage{
+		{Source: "README.md", Title: "Overview", URL: "/"},
+		{Source: "docs/ARCHITECTURE.md", Title: "Architecture", URL: "/architecture/"},
+	}, map[string]string{
+		"README.md":            "",
+		"docs/ARCHITECTURE.md": "",
+	}, nil)
+	// Simulate what the Pages workflow deploys: every root-relative link in
+	// every page carries the /ai-team prefix.
+	files, err := listHTML(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rel := range files {
+		path := filepath.Join(out, rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		patched := strings.ReplaceAll(string(data), `href="/`, `href="/ai-team/`)
+		if err := os.WriteFile(path, []byte(patched), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := CheckLinksWithBase(out, "/ai-team"); err != nil {
+		t.Errorf("CheckLinksWithBase failed with base path: %v", err)
 	}
 }

--- a/docsgen/docsgen_test.go
+++ b/docsgen/docsgen_test.go
@@ -311,3 +311,144 @@ func TestCheckLinksBasePath(t *testing.T) {
 		t.Errorf("CheckLinksWithBase failed with base path: %v", err)
 	}
 }
+
+// TestCopyAssetsRejectsPathEscapeFromNestedPage reproduces the F-6 audit's
+// repro shape: a page nested two directories deep (docs/demo/README.md,
+// rendered at the shortened URL "/demo/", exactly as cmd/docsgen configures
+// it) links upward far enough ("../../LICENSE") that the page-URL-relative
+// output placement computes a path outside the output directory entirely
+// (pageDir "demo" has only one segment, but the link needs to climb two).
+// The build must fail loudly instead of writing outside output.
+func TestCopyAssetsRejectsPathEscapeFromNestedPage(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs", "demo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "demo", "README.md"), []byte("[license](../../LICENSE)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "LICENSE"), []byte("Apache-2.0 fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := t.TempDir()
+	cfg := Config{
+		Root:        root,
+		Output:      out,
+		Title:       "fixture",
+		Version:     "dev",
+		CleanOutput: true,
+		GitHubRepo:  "arturpanteleev/ai-team",
+		Sources: []SourcedPage{
+			{Source: "docs/demo/README.md", Title: "Demo", URL: "/demo/"},
+		},
+	}
+
+	err := Build(cfg)
+	if err == nil {
+		t.Fatal("expected Build to fail for an asset link escaping the output directory")
+	}
+	for _, want := range []string{"docs/demo/README.md", "LICENSE"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+
+	// The escaping write would have landed one level above output, named
+	// LICENSE; confirm it was never created.
+	escaped := filepath.Join(filepath.Dir(out), "LICENSE")
+	if _, statErr := os.Stat(escaped); statErr == nil {
+		t.Errorf("asset escaped to %s outside the output directory", escaped)
+	} else if !os.IsNotExist(statErr) {
+		t.Fatal(statErr)
+	}
+}
+
+// TestCopyAssetsRejectsPathEscapeOutsideRepo is a second, independent escape
+// construction distinct from the nested-page repro above: a top-level page
+// links to a file that lives entirely outside the source root (not merely
+// outside its own page's subtree). It must be rejected the same way.
+func TestCopyAssetsRejectsPathEscapeOutsideRepo(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "repo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("[evil](../evil.txt)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "evil.txt"), []byte("outside the repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := t.TempDir()
+	cfg := Config{
+		Root:        root,
+		Output:      out,
+		Title:       "fixture",
+		Version:     "dev",
+		CleanOutput: true,
+		Sources: []SourcedPage{
+			{Source: "README.md", Title: "Overview", URL: "/"},
+		},
+	}
+
+	err := Build(cfg)
+	if err == nil {
+		t.Fatal("expected Build to fail for an asset link escaping the output directory")
+	}
+	for _, want := range []string{"README.md", "evil.txt"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+	escaped := filepath.Join(filepath.Dir(out), "evil.txt")
+	if _, statErr := os.Stat(escaped); statErr == nil {
+		t.Errorf("asset escaped to %s outside the output directory", escaped)
+	} else if !os.IsNotExist(statErr) {
+		t.Fatal(statErr)
+	}
+}
+
+// TestSlashRelRepoTargetUsesRepoRoot proves slashRelRepoTarget computes paths
+// relative to the actual repository root, not the rendering page's own
+// baseDir. Before the fix, a nested page's baseDir (e.g. docs/demo) was
+// reused for this purpose, producing a wrong GitHub URL for anything outside
+// that page's own subtree — e.g. LICENSE (at the repo root) would resolve to
+// "../../LICENSE" instead of "LICENSE".
+func TestSlashRelRepoTargetUsesRepoRoot(t *testing.T) {
+	root := t.TempDir()
+	tr := &linkTransformer{
+		baseDir:  filepath.Join(root, "docs", "demo"),
+		repoRoot: root,
+	}
+	got := slashRelRepoTarget(tr, filepath.Join(root, "LICENSE"))
+	if got != "LICENSE" {
+		t.Errorf("slashRelRepoTarget = %q, want %q", got, "LICENSE")
+	}
+}
+
+// TestGithubTreeURLFromNestedPageIsRepoRootRelative exercises the repoRoot
+// fix through the real rendering pipeline (directory links are the only
+// place slashRelRepoTarget currently feeds a GitHub URL): a page nested two
+// directories deep links to a directory that lives at the repo root. The
+// generated GitHub tree URL must be repo-root-relative ("docsgen"), not
+// relative to the page's own directory ("../../docsgen").
+func TestGithubTreeURLFromNestedPageIsRepoRootRelative(t *testing.T) {
+	out := fixtureSite(t, []SourcedPage{
+		{Source: "docs/demo/README.md", Title: "Demo", URL: "/demo/"},
+	}, map[string]string{
+		"docs/demo/README.md": "See [`docsgen`](../../docsgen/).\n",
+	}, []string{"docsgen"})
+
+	demo, err := os.ReadFile(filepath.Join(out, "demo", "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(demo), "https://github.com/arturpanteleev/ai-team/tree/docsgen") {
+		t.Errorf("expected repo-root-relative GitHub tree URL for docsgen/, got:\n%s", string(demo))
+	}
+	if strings.Contains(string(demo), "tree/../../docsgen") {
+		t.Errorf("GitHub tree URL used page-relative baseDir instead of repo root:\n%s", string(demo))
+	}
+}


### PR DESCRIPTION
Closes **P1** documentation/site findings from `audit-2026-09-05`.

- **AUD-07** (README): three responsibility zones; non-TTY two-run vs TTY one-process lifecycle; standard/fast defer approvals and run graph
- **AUD-08** (glossary): audit-preflight definitions
- **AUD-12** (CHANGELOG): docsgen PR listing
- **AUD-13** (docsgen styling): consistent page styling

### Код-ревью finding (F-6)

- **F-6** (docsgen could write assets outside the output tree and built wrong GitHub links): asset output paths are contained under the docs root (nested docs regression test added); GitHub URL base derived correctly for the repo. One commit `753d772`.

Verified: `make verify` green; docsgen tests green.
